### PR TITLE
feat: chunk protocol, storage handler, and cross-node e2e tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ saorsa-core = "0.10.2"
 saorsa-pqc = "0.4.0"
 
 # Payment verification - autonomi network lookup + EVM payment
-autonomi = "0.9"
 ant-evm = "0.1.19"
 evmlib = "0.4.7"
 xor_name = "5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ hex = "0.4"
 # Utilities
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
+rand = "0.8"
 tempfile = "3"
 
 # Archive extraction for auto-upgrade
@@ -86,7 +87,6 @@ bincode = "1"
 tokio-test = "0.4"
 proptest = "1"
 serde_json = "1"
-rand = "0.8"
 
 # E2E test infrastructure
 [[test]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,12 +79,14 @@ tempfile = "3"
 flate2 = "1"
 tar = "0.4"
 
+# Protocol serialization
+bincode = "1"
+
 [dev-dependencies]
 tokio-test = "0.4"
 proptest = "1"
 serde_json = "1"
 rand = "0.8"
-bincode = "1"
 
 # E2E test infrastructure
 [[test]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/bin/keygen.rs"
 
 [dependencies]
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
-saorsa-core = { version = "0.10.0", default-features = false }
+saorsa-core = "0.10.2"
 saorsa-pqc = "0.4.0"
 
 # Payment verification - autonomi network lookup + EVM payment

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,6 @@ hex = "0.4"
 # Utilities
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
-rand = "0.8"
 tempfile = "3"
 
 # Archive extraction for auto-upgrade
@@ -87,6 +86,7 @@ bincode = "1"
 tokio-test = "0.4"
 proptest = "1"
 serde_json = "1"
+rand = "0.8"
 
 # E2E test infrastructure
 [[test]]

--- a/src/ant_protocol/chunk.rs
+++ b/src/ant_protocol/chunk.rs
@@ -261,7 +261,7 @@ impl std::fmt::Display for ProtocolError {
 impl std::error::Error for ProtocolError {}
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
 

--- a/src/ant_protocol/chunk.rs
+++ b/src/ant_protocol/chunk.rs
@@ -6,6 +6,7 @@
 //! This module defines the wire protocol messages for chunk operations
 //! using bincode serialization for compact, fast encoding.
 
+use bincode::Options;
 use serde::{Deserialize, Serialize};
 
 /// Protocol identifier for chunk operations.
@@ -16,6 +17,14 @@ pub const PROTOCOL_VERSION: u16 = 1;
 
 /// Maximum chunk size in bytes (4MB).
 pub const MAX_CHUNK_SIZE: usize = 4 * 1024 * 1024;
+
+/// Maximum wire message size for deserialization.
+///
+/// Set to `MAX_CHUNK_SIZE` + 1 MB headroom for the envelope (`request_id`,
+/// enum discriminants, address, payment proof, etc.).  This prevents a
+/// malicious peer from sending a length-prefixed `Vec` that causes an
+/// unbounded allocation.
+const MAX_WIRE_MESSAGE_SIZE: u64 = (MAX_CHUNK_SIZE + 1024 * 1024) as u64;
 
 /// Data type identifier for chunks.
 pub const DATA_TYPE_CHUNK: u32 = 0;
@@ -63,7 +72,11 @@ impl ChunkMessage {
     ///
     /// Returns an error if serialization fails.
     pub fn encode(&self) -> Result<Vec<u8>, ProtocolError> {
-        bincode::serialize(self).map_err(|e| ProtocolError::SerializationFailed(e.to_string()))
+        bincode::DefaultOptions::new()
+            .with_limit(MAX_WIRE_MESSAGE_SIZE)
+            .allow_trailing_bytes()
+            .serialize(self)
+            .map_err(|e| ProtocolError::SerializationFailed(e.to_string()))
     }
 
     /// Decode a message from bytes using bincode.
@@ -72,7 +85,11 @@ impl ChunkMessage {
     ///
     /// Returns an error if deserialization fails.
     pub fn decode(data: &[u8]) -> Result<Self, ProtocolError> {
-        bincode::deserialize(data).map_err(|e| ProtocolError::DeserializationFailed(e.to_string()))
+        bincode::DefaultOptions::new()
+            .with_limit(MAX_WIRE_MESSAGE_SIZE)
+            .allow_trailing_bytes()
+            .deserialize(data)
+            .map_err(|e| ProtocolError::DeserializationFailed(e.to_string()))
     }
 }
 

--- a/src/ant_protocol/chunk.rs
+++ b/src/ant_protocol/chunk.rs
@@ -1,0 +1,396 @@
+//! Chunk message types for the ANT protocol.
+//!
+//! Chunks are immutable, content-addressed data blocks where the address
+//! is the SHA256 hash of the content. Maximum size is 4MB.
+//!
+//! This module defines the wire protocol messages for chunk operations
+//! using bincode serialization for compact, fast encoding.
+
+use serde::{Deserialize, Serialize};
+
+/// Protocol identifier for chunk operations.
+pub const CHUNK_PROTOCOL_ID: &str = "saorsa/ant/chunk/v1";
+
+/// Current protocol version.
+pub const PROTOCOL_VERSION: u16 = 1;
+
+/// Maximum chunk size in bytes (4MB).
+pub const MAX_CHUNK_SIZE: usize = 4 * 1024 * 1024;
+
+/// Data type identifier for chunks.
+pub const DATA_TYPE_CHUNK: u32 = 0;
+
+/// Content-addressed identifier (32 bytes).
+pub type XorName = [u8; 32];
+
+/// Wrapper enum for all chunk protocol messages.
+///
+/// Uses a single-byte discriminant for efficient wire encoding.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ChunkMessage {
+    /// Request to store a chunk.
+    PutRequest(ChunkPutRequest),
+    /// Response to a PUT request.
+    PutResponse(ChunkPutResponse),
+    /// Request to retrieve a chunk.
+    GetRequest(ChunkGetRequest),
+    /// Response to a GET request.
+    GetResponse(ChunkGetResponse),
+    /// Request a storage quote.
+    QuoteRequest(ChunkQuoteRequest),
+    /// Response with a storage quote.
+    QuoteResponse(ChunkQuoteResponse),
+}
+
+impl ChunkMessage {
+    /// Encode the message to bytes using bincode.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if serialization fails.
+    pub fn encode(&self) -> Result<Vec<u8>, ProtocolError> {
+        bincode::serialize(self).map_err(|e| ProtocolError::SerializationFailed(e.to_string()))
+    }
+
+    /// Decode a message from bytes using bincode.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if deserialization fails.
+    pub fn decode(data: &[u8]) -> Result<Self, ProtocolError> {
+        bincode::deserialize(data).map_err(|e| ProtocolError::DeserializationFailed(e.to_string()))
+    }
+}
+
+// =============================================================================
+// PUT Request/Response
+// =============================================================================
+
+/// Request to store a chunk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChunkPutRequest {
+    /// The content-addressed identifier (SHA256 of content).
+    pub address: XorName,
+    /// The chunk data.
+    pub content: Vec<u8>,
+    /// Optional payment proof (serialized `ProofOfPayment`).
+    /// Required for new chunks unless already verified.
+    pub payment_proof: Option<Vec<u8>>,
+}
+
+impl ChunkPutRequest {
+    /// Create a new PUT request.
+    #[must_use]
+    pub fn new(address: XorName, content: Vec<u8>) -> Self {
+        Self {
+            address,
+            content,
+            payment_proof: None,
+        }
+    }
+
+    /// Create a new PUT request with payment proof.
+    #[must_use]
+    pub fn with_payment(address: XorName, content: Vec<u8>, payment_proof: Vec<u8>) -> Self {
+        Self {
+            address,
+            content,
+            payment_proof: Some(payment_proof),
+        }
+    }
+}
+
+/// Response to a PUT request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ChunkPutResponse {
+    /// Chunk stored successfully.
+    Success {
+        /// The address where the chunk was stored.
+        address: XorName,
+    },
+    /// Chunk already exists (idempotent success).
+    AlreadyExists {
+        /// The existing chunk address.
+        address: XorName,
+    },
+    /// Payment is required to store this chunk.
+    PaymentRequired {
+        /// Error message.
+        message: String,
+    },
+    /// An error occurred.
+    Error(ProtocolError),
+}
+
+// =============================================================================
+// GET Request/Response
+// =============================================================================
+
+/// Request to retrieve a chunk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChunkGetRequest {
+    /// The content-addressed identifier to retrieve.
+    pub address: XorName,
+}
+
+impl ChunkGetRequest {
+    /// Create a new GET request.
+    #[must_use]
+    pub fn new(address: XorName) -> Self {
+        Self { address }
+    }
+}
+
+/// Response to a GET request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ChunkGetResponse {
+    /// Chunk found and returned.
+    Success {
+        /// The chunk address.
+        address: XorName,
+        /// The chunk data.
+        content: Vec<u8>,
+    },
+    /// Chunk not found.
+    NotFound {
+        /// The requested address.
+        address: XorName,
+    },
+    /// An error occurred.
+    Error(ProtocolError),
+}
+
+// =============================================================================
+// Quote Request/Response
+// =============================================================================
+
+/// Request a storage quote for a chunk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChunkQuoteRequest {
+    /// The content address of the data to store.
+    pub address: XorName,
+    /// Size of the data in bytes.
+    pub data_size: u64,
+    /// Data type identifier (0 for chunks).
+    pub data_type: u32,
+}
+
+impl ChunkQuoteRequest {
+    /// Create a new quote request.
+    #[must_use]
+    pub fn new(address: XorName, data_size: u64) -> Self {
+        Self {
+            address,
+            data_size,
+            data_type: DATA_TYPE_CHUNK,
+        }
+    }
+}
+
+/// Response with a storage quote.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ChunkQuoteResponse {
+    /// Quote generated successfully.
+    Success {
+        /// Serialized `PaymentQuote`.
+        quote: Vec<u8>,
+    },
+    /// Quote generation failed.
+    Error(ProtocolError),
+}
+
+// =============================================================================
+// Protocol Errors
+// =============================================================================
+
+/// Errors that can occur during protocol operations.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ProtocolError {
+    /// Message serialization failed.
+    SerializationFailed(String),
+    /// Message deserialization failed.
+    DeserializationFailed(String),
+    /// Chunk exceeds maximum size.
+    ChunkTooLarge {
+        /// Size of the chunk in bytes.
+        size: usize,
+        /// Maximum allowed size.
+        max_size: usize,
+    },
+    /// Content address mismatch (hash(content) != address).
+    AddressMismatch {
+        /// Expected address.
+        expected: XorName,
+        /// Actual address computed from content.
+        actual: XorName,
+    },
+    /// Storage operation failed.
+    StorageFailed(String),
+    /// Payment verification failed.
+    PaymentFailed(String),
+    /// Quote generation failed.
+    QuoteFailed(String),
+    /// Internal error.
+    Internal(String),
+}
+
+impl std::fmt::Display for ProtocolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SerializationFailed(msg) => write!(f, "serialization failed: {msg}"),
+            Self::DeserializationFailed(msg) => write!(f, "deserialization failed: {msg}"),
+            Self::ChunkTooLarge { size, max_size } => {
+                write!(f, "chunk size {size} exceeds maximum {max_size}")
+            }
+            Self::AddressMismatch { expected, actual } => {
+                write!(
+                    f,
+                    "address mismatch: expected {}, got {}",
+                    hex::encode(expected),
+                    hex::encode(actual)
+                )
+            }
+            Self::StorageFailed(msg) => write!(f, "storage failed: {msg}"),
+            Self::PaymentFailed(msg) => write!(f, "payment failed: {msg}"),
+            Self::QuoteFailed(msg) => write!(f, "quote failed: {msg}"),
+            Self::Internal(msg) => write!(f, "internal error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for ProtocolError {}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_put_request_encode_decode() {
+        let address = [0xAB; 32];
+        let content = vec![1, 2, 3, 4, 5];
+        let request = ChunkPutRequest::new(address, content.clone());
+        let msg = ChunkMessage::PutRequest(request);
+
+        let encoded = msg.encode().expect("encode should succeed");
+        let decoded = ChunkMessage::decode(&encoded).expect("decode should succeed");
+
+        if let ChunkMessage::PutRequest(req) = decoded {
+            assert_eq!(req.address, address);
+            assert_eq!(req.content, content);
+            assert!(req.payment_proof.is_none());
+        } else {
+            panic!("expected PutRequest");
+        }
+    }
+
+    #[test]
+    fn test_put_request_with_payment() {
+        let address = [0xAB; 32];
+        let content = vec![1, 2, 3, 4, 5];
+        let payment = vec![10, 20, 30];
+        let request = ChunkPutRequest::with_payment(address, content.clone(), payment.clone());
+
+        assert_eq!(request.address, address);
+        assert_eq!(request.content, content);
+        assert_eq!(request.payment_proof, Some(payment));
+    }
+
+    #[test]
+    fn test_get_request_encode_decode() {
+        let address = [0xCD; 32];
+        let request = ChunkGetRequest::new(address);
+        let msg = ChunkMessage::GetRequest(request);
+
+        let encoded = msg.encode().expect("encode should succeed");
+        let decoded = ChunkMessage::decode(&encoded).expect("decode should succeed");
+
+        if let ChunkMessage::GetRequest(req) = decoded {
+            assert_eq!(req.address, address);
+        } else {
+            panic!("expected GetRequest");
+        }
+    }
+
+    #[test]
+    fn test_put_response_success() {
+        let address = [0xEF; 32];
+        let response = ChunkPutResponse::Success { address };
+        let msg = ChunkMessage::PutResponse(response);
+
+        let encoded = msg.encode().expect("encode should succeed");
+        let decoded = ChunkMessage::decode(&encoded).expect("decode should succeed");
+
+        if let ChunkMessage::PutResponse(ChunkPutResponse::Success { address: addr }) = decoded {
+            assert_eq!(addr, address);
+        } else {
+            panic!("expected PutResponse::Success");
+        }
+    }
+
+    #[test]
+    fn test_get_response_not_found() {
+        let address = [0x12; 32];
+        let response = ChunkGetResponse::NotFound { address };
+        let msg = ChunkMessage::GetResponse(response);
+
+        let encoded = msg.encode().expect("encode should succeed");
+        let decoded = ChunkMessage::decode(&encoded).expect("decode should succeed");
+
+        if let ChunkMessage::GetResponse(ChunkGetResponse::NotFound { address: addr }) = decoded {
+            assert_eq!(addr, address);
+        } else {
+            panic!("expected GetResponse::NotFound");
+        }
+    }
+
+    #[test]
+    fn test_quote_request_encode_decode() {
+        let address = [0x34; 32];
+        let request = ChunkQuoteRequest::new(address, 1024);
+        let msg = ChunkMessage::QuoteRequest(request);
+
+        let encoded = msg.encode().expect("encode should succeed");
+        let decoded = ChunkMessage::decode(&encoded).expect("decode should succeed");
+
+        if let ChunkMessage::QuoteRequest(req) = decoded {
+            assert_eq!(req.address, address);
+            assert_eq!(req.data_size, 1024);
+            assert_eq!(req.data_type, DATA_TYPE_CHUNK);
+        } else {
+            panic!("expected QuoteRequest");
+        }
+    }
+
+    #[test]
+    fn test_protocol_error_display() {
+        let err = ProtocolError::ChunkTooLarge {
+            size: 5_000_000,
+            max_size: MAX_CHUNK_SIZE,
+        };
+        assert!(err.to_string().contains("5000000"));
+        assert!(err.to_string().contains(&MAX_CHUNK_SIZE.to_string()));
+
+        let err = ProtocolError::AddressMismatch {
+            expected: [0xAA; 32],
+            actual: [0xBB; 32],
+        };
+        let display = err.to_string();
+        assert!(display.contains("address mismatch"));
+    }
+
+    #[test]
+    fn test_invalid_decode() {
+        let invalid_data = vec![0xFF, 0xFF, 0xFF];
+        let result = ChunkMessage::decode(&invalid_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_constants() {
+        assert_eq!(CHUNK_PROTOCOL_ID, "saorsa/ant/chunk/v1");
+        assert_eq!(PROTOCOL_VERSION, 1);
+        assert_eq!(MAX_CHUNK_SIZE, 4 * 1024 * 1024);
+        assert_eq!(DATA_TYPE_CHUNK, 0);
+    }
+}

--- a/src/ant_protocol/mod.rs
+++ b/src/ant_protocol/mod.rs
@@ -50,7 +50,7 @@ pub mod chunk;
 
 // Re-export chunk types for convenience
 pub use chunk::{
-    ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkPutRequest, ChunkPutResponse,
-    ChunkQuoteRequest, ChunkQuoteResponse, ProtocolError, XorName, CHUNK_PROTOCOL_ID,
-    DATA_TYPE_CHUNK, MAX_CHUNK_SIZE, PROTOCOL_VERSION,
+    ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkMessageBody, ChunkPutRequest,
+    ChunkPutResponse, ChunkQuoteRequest, ChunkQuoteResponse, ProtocolError, XorName,
+    CHUNK_PROTOCOL_ID, DATA_TYPE_CHUNK, MAX_CHUNK_SIZE, PROTOCOL_VERSION,
 };

--- a/src/ant_protocol/mod.rs
+++ b/src/ant_protocol/mod.rs
@@ -1,0 +1,56 @@
+//! ANT protocol implementation for the saorsa network.
+//!
+//! This module implements the wire protocol for storing and retrieving
+//! data on the saorsa network, compatible with the autonomi network protocol.
+//!
+//! # Data Types
+//!
+//! The ANT protocol supports multiple data types:
+//!
+//! - **Chunk**: Immutable, content-addressed data (hash == address)
+//! - *Scratchpad*: Mutable, owner-indexed data (planned)
+//! - *Pointer*: Lightweight mutable references (planned)
+//! - *`GraphEntry`*: DAG entries with parent links (planned)
+//!
+//! # Protocol Overview
+//!
+//! The protocol uses bincode serialization for compact, fast encoding.
+//! Each data type has its own message types for PUT/GET operations.
+//!
+//! ## Chunk Messages
+//!
+//! - `ChunkPutRequest` / `ChunkPutResponse` - Store chunks
+//! - `ChunkGetRequest` / `ChunkGetResponse` - Retrieve chunks
+//! - `ChunkQuoteRequest` / `ChunkQuoteResponse` - Request storage quotes
+//!
+//! ## Payment Flow
+//!
+//! 1. Client requests a quote via `ChunkQuoteRequest`
+//! 2. Node returns signed `PaymentQuote` in `ChunkQuoteResponse`
+//! 3. Client pays on Arbitrum via `PaymentVault.payForQuotes()`
+//! 4. Client sends `ChunkPutRequest` with `payment_proof`
+//! 5. Node verifies payment and stores chunk
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use saorsa_node::ant_protocol::{ChunkMessage, ChunkPutRequest, ChunkGetRequest};
+//!
+//! // Create a PUT request
+//! let address = compute_address(&data);
+//! let request = ChunkPutRequest::with_payment(address, data, payment_proof);
+//! let message = ChunkMessage::PutRequest(request);
+//! let bytes = message.encode()?;
+//!
+//! // Decode a response
+//! let response = ChunkMessage::decode(&response_bytes)?;
+//! ```
+
+pub mod chunk;
+
+// Re-export chunk types for convenience
+pub use chunk::{
+    ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkPutRequest, ChunkPutResponse,
+    ChunkQuoteRequest, ChunkQuoteResponse, ProtocolError, XorName, CHUNK_PROTOCOL_ID,
+    DATA_TYPE_CHUNK, MAX_CHUNK_SIZE, PROTOCOL_VERSION,
+};

--- a/src/client/chunk_protocol.rs
+++ b/src/client/chunk_protocol.rs
@@ -1,0 +1,78 @@
+//! Shared helper for the chunk protocol request/response pattern.
+//!
+//! Extracts the duplicated "subscribe → send → poll event loop" into a single
+//! generic function used by both [`super::QuantumClient`] and E2E test helpers.
+
+use crate::ant_protocol::{ChunkMessage, ChunkMessageBody, CHUNK_PROTOCOL_ID};
+use saorsa_core::{P2PEvent, P2PNode};
+use std::time::Duration;
+use tokio::time::Instant;
+use tracing::warn;
+
+/// Send a chunk-protocol message to `target_peer` and await a matching response.
+///
+/// The event loop filters by topic (`CHUNK_PROTOCOL_ID`), source peer, decode
+/// errors (warn + skip), and `request_id` mismatch (skip).
+///
+/// * `response_handler` — inspects the decoded [`ChunkMessageBody`] and returns:
+///   - `Some(Ok(T))` to resolve successfully,
+///   - `Some(Err(E))` to resolve with an error,
+///   - `None` to keep waiting (wrong variant / not our response).
+/// * `send_error` — produces the caller's error type when `send_message` fails.
+/// * `timeout_error` — produces the caller's error type on deadline expiry.
+///
+/// # Errors
+///
+/// Returns `Err(E)` if sending fails (via `send_error`), the `response_handler`
+/// returns a protocol-level error, or the deadline expires (via `timeout_error`).
+#[allow(clippy::too_many_arguments)]
+pub async fn send_and_await_chunk_response<T, E>(
+    node: &P2PNode,
+    target_peer: &str,
+    message_bytes: Vec<u8>,
+    request_id: u64,
+    timeout: Duration,
+    response_handler: impl Fn(ChunkMessageBody) -> Option<Result<T, E>>,
+    send_error: impl FnOnce(String) -> E,
+    timeout_error: impl FnOnce() -> E,
+) -> Result<T, E> {
+    // Subscribe before sending so we don't miss the response
+    let mut events = node.subscribe_events();
+
+    let target_peer_id = target_peer.to_string();
+
+    node.send_message(&target_peer_id, CHUNK_PROTOCOL_ID, message_bytes)
+        .await
+        .map_err(|e| send_error(e.to_string()))?;
+
+    let deadline = Instant::now() + timeout;
+
+    while Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match tokio::time::timeout(remaining, events.recv()).await {
+            Ok(Ok(P2PEvent::Message {
+                topic,
+                source,
+                data,
+            })) if topic == CHUNK_PROTOCOL_ID && source == target_peer_id => {
+                let response = match ChunkMessage::decode(&data) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        warn!("Failed to decode chunk message, skipping: {e}");
+                        continue;
+                    }
+                };
+                if response.request_id != request_id {
+                    continue;
+                }
+                if let Some(result) = response_handler(response.body) {
+                    return result;
+                }
+            }
+            Ok(Ok(_)) => {}
+            Ok(Err(_)) | Err(_) => break,
+        }
+    }
+
+    Err(timeout_error())
+}

--- a/src/client/data_types.rs
+++ b/src/client/data_types.rs
@@ -5,6 +5,18 @@
 //! the address is the SHA256 hash of the content.
 
 use bytes::Bytes;
+use sha2::{Digest, Sha256};
+
+/// Compute the content address (SHA256 hash) for the given data.
+#[must_use]
+pub fn compute_address(content: &[u8]) -> XorName {
+    let mut hasher = Sha256::new();
+    hasher.update(content);
+    let result = hasher.finalize();
+    let mut address = [0u8; 32];
+    address.copy_from_slice(&result);
+    address
+}
 
 /// A content-addressed identifier (32 bytes).
 ///
@@ -39,12 +51,7 @@ impl DataChunk {
     /// Create a chunk from content, computing the address automatically.
     #[must_use]
     pub fn from_content(content: Bytes) -> Self {
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(&content);
-        let result = hasher.finalize();
-        let mut address = [0u8; 32];
-        address.copy_from_slice(&result);
+        let address = compute_address(&content);
         Self { address, content }
     }
 
@@ -57,11 +64,7 @@ impl DataChunk {
     /// Verify that the address matches SHA256(content).
     #[must_use]
     pub fn verify(&self) -> bool {
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(&self.content);
-        let result = hasher.finalize();
-        self.address == result.as_slice()
+        self.address == compute_address(&self.content)
     }
 }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -53,8 +53,10 @@
 //! - **ML-DSA-65** (NIST FIPS 204): Digital signatures for authentication
 //! - **ChaCha20-Poly1305**: Symmetric encryption for data at rest
 
+mod chunk_protocol;
 mod data_types;
 mod quantum;
 
+pub use chunk_protocol::send_and_await_chunk_response;
 pub use data_types::{compute_address, ChunkStats, DataChunk, XorName};
 pub use quantum::{QuantumClient, QuantumConfig};

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -56,5 +56,5 @@
 mod data_types;
 mod quantum;
 
-pub use data_types::{ChunkStats, DataChunk, XorName};
+pub use data_types::{compute_address, ChunkStats, DataChunk, XorName};
 pub use quantum::{QuantumClient, QuantumConfig};

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 //! Configuration for saorsa-node.
 
 use serde::{Deserialize, Serialize};
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::path::PathBuf;
 
 /// IP version configuration.
@@ -580,8 +580,6 @@ const fn default_storage_verify_on_read() -> bool {
 /// - saorsa-bootstrap-1 (NYC): 165.22.4.178:12000
 /// - saorsa-bootstrap-2 (SFO): 164.92.111.156:12000
 fn default_testnet_bootstrap() -> Vec<SocketAddr> {
-    use std::net::{Ipv4Addr, SocketAddrV4};
-
     vec![
         // saorsa-bootstrap-1 (Digital Ocean NYC1)
         SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(165, 22, 4, 178), 12000)),

--- a/src/config.rs
+++ b/src/config.rs
@@ -130,6 +130,10 @@ pub struct NodeConfig {
     #[serde(default)]
     pub bootstrap_cache: BootstrapCacheConfig,
 
+    /// Storage configuration for chunk persistence.
+    #[serde(default)]
+    pub storage: StorageConfig,
+
     /// Log level.
     #[serde(default = "default_log_level")]
     pub log_level: String,
@@ -364,6 +368,7 @@ impl Default for NodeConfig {
             payment: PaymentConfig::default(),
             attestation: AttestationNodeConfig::default(),
             bootstrap_cache: BootstrapCacheConfig::default(),
+            storage: StorageConfig::default(),
             log_level: default_log_level(),
         }
     }
@@ -521,6 +526,52 @@ const fn default_bootstrap_max_contacts() -> usize {
 
 const fn default_bootstrap_stale_days() -> u64 {
     7
+}
+
+// ============================================================================
+// Storage Configuration
+// ============================================================================
+
+/// Storage configuration for chunk persistence.
+///
+/// Controls how chunks are stored on disk, including:
+/// - Whether storage is enabled
+/// - Maximum chunks to store (for capacity management)
+/// - Content verification on read
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageConfig {
+    /// Enable chunk storage.
+    /// Default: true
+    #[serde(default = "default_storage_enabled")]
+    pub enabled: bool,
+
+    /// Maximum number of chunks to store (0 = unlimited).
+    /// Default: 0 (unlimited)
+    #[serde(default)]
+    pub max_chunks: usize,
+
+    /// Verify content hash matches address on read.
+    /// Default: true
+    #[serde(default = "default_storage_verify_on_read")]
+    pub verify_on_read: bool,
+}
+
+impl Default for StorageConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_storage_enabled(),
+            max_chunks: 0,
+            verify_on_read: default_storage_verify_on_read(),
+        }
+    }
+}
+
+const fn default_storage_enabled() -> bool {
+    true
+}
+
+const fn default_storage_verify_on_read() -> bool {
+    true
 }
 
 /// Default testnet bootstrap nodes.

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,6 +44,14 @@ pub enum Error {
     #[error("serialization error: {0}")]
     Serialization(String),
 
+    /// Protocol error.
+    #[error("protocol error: {0}")]
+    Protocol(String),
+
+    /// Invalid chunk error.
+    #[error("invalid chunk: {0}")]
+    InvalidChunk(String),
+
     /// Node is shutting down.
     #[error("node is shutting down")]
     ShuttingDown,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,8 @@ pub mod storage;
 pub mod upgrade;
 
 pub use ant_protocol::{
-    ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkPutRequest, ChunkPutResponse,
-    ChunkQuoteRequest, ChunkQuoteResponse, CHUNK_PROTOCOL_ID, MAX_CHUNK_SIZE,
+    ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkMessageBody, ChunkPutRequest,
+    ChunkPutResponse, ChunkQuoteRequest, ChunkQuoteResponse, CHUNK_PROTOCOL_ID, MAX_CHUNK_SIZE,
 };
 pub use client::{compute_address, DataChunk, QuantumClient, QuantumConfig, XorName};
 pub use config::{BootstrapCacheConfig, NodeConfig, StorageConfig};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 
+pub mod ant_protocol;
 pub mod attestation;
 pub mod client;
 pub mod config;
@@ -48,18 +49,17 @@ pub mod node;
 pub mod payment;
 #[cfg(test)]
 mod probe;
-pub mod ant_protocol;
 pub mod storage;
 pub mod upgrade;
 
-pub use client::{DataChunk, QuantumClient, QuantumConfig, XorName};
+pub use ant_protocol::{
+    ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkPutRequest, ChunkPutResponse,
+    ChunkQuoteRequest, ChunkQuoteResponse, CHUNK_PROTOCOL_ID, MAX_CHUNK_SIZE,
+};
+pub use client::{compute_address, DataChunk, QuantumClient, QuantumConfig, XorName};
 pub use config::{BootstrapCacheConfig, NodeConfig, StorageConfig};
 pub use error::{Error, Result};
 pub use event::{NodeEvent, NodeEventsChannel};
 pub use node::{NodeBuilder, RunningNode};
 pub use payment::{PaymentStatus, PaymentVerifier, PaymentVerifierConfig};
-pub use ant_protocol::{
-    ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkPutRequest, ChunkPutResponse,
-    ChunkQuoteRequest, ChunkQuoteResponse, CHUNK_PROTOCOL_ID, MAX_CHUNK_SIZE,
-};
 pub use storage::{AntProtocol, DiskStorage, DiskStorageConfig};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,11 +48,18 @@ pub mod node;
 pub mod payment;
 #[cfg(test)]
 mod probe;
+pub mod ant_protocol;
+pub mod storage;
 pub mod upgrade;
 
 pub use client::{DataChunk, QuantumClient, QuantumConfig, XorName};
-pub use config::{BootstrapCacheConfig, NodeConfig};
+pub use config::{BootstrapCacheConfig, NodeConfig, StorageConfig};
 pub use error::{Error, Result};
 pub use event::{NodeEvent, NodeEventsChannel};
 pub use node::{NodeBuilder, RunningNode};
 pub use payment::{PaymentStatus, PaymentVerifier, PaymentVerifierConfig};
+pub use ant_protocol::{
+    ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkPutRequest, ChunkPutResponse,
+    ChunkQuoteRequest, ChunkQuoteResponse, CHUNK_PROTOCOL_ID, MAX_CHUNK_SIZE,
+};
+pub use storage::{AntProtocol, DiskStorage, DiskStorageConfig};

--- a/src/node.rs
+++ b/src/node.rs
@@ -5,9 +5,9 @@ use crate::attestation::VerificationLevel;
 use crate::config::{AttestationMode, AttestationNodeConfig, IpVersion, NetworkMode, NodeConfig};
 use crate::error::{Error, Result};
 use crate::event::{create_event_channel, NodeEvent, NodeEventsChannel, NodeEventsSender};
-use crate::payment::{PaymentVerifier, PaymentVerifierConfig, QuoteGenerator};
 use crate::payment::metrics::QuotingMetricsTracker;
 use crate::payment::wallet::parse_rewards_address;
+use crate::payment::{PaymentVerifier, PaymentVerifierConfig, QuoteGenerator};
 use crate::storage::{AntProtocol, DiskStorage, DiskStorageConfig};
 use crate::upgrade::{AutoApplyUpgrader, UpgradeMonitor, UpgradeResult};
 use ant_evm::RewardsAddress;
@@ -617,11 +617,7 @@ impl RunningNode {
                             match protocol.handle_message(&data).await {
                                 Ok(response) => {
                                     if let Err(e) = p2p
-                                        .send_message(
-                                            &source,
-                                            CHUNK_PROTOCOL_ID,
-                                            response.to_vec(),
-                                        )
+                                        .send_message(&source, CHUNK_PROTOCOL_ID, response.to_vec())
                                         .await
                                     {
                                         warn!(

--- a/src/payment/mod.rs
+++ b/src/payment/mod.rs
@@ -37,8 +37,8 @@ pub mod quote;
 mod verifier;
 pub mod wallet;
 
-pub use cache::VerifiedCache;
+pub use cache::{CacheStats, VerifiedCache};
 pub use metrics::QuotingMetricsTracker;
 pub use quote::{verify_quote_content, QuoteGenerator, XorName};
-pub use verifier::{PaymentStatus, PaymentVerifier, PaymentVerifierConfig};
+pub use verifier::{EvmVerifierConfig, PaymentStatus, PaymentVerifier, PaymentVerifierConfig};
 pub use wallet::{is_valid_address, parse_rewards_address, WalletConfig};

--- a/src/storage/disk.rs
+++ b/src/storage/disk.rs
@@ -9,15 +9,12 @@
 //!
 //! Where `xx` and `yy` are the first two bytes of the address in hex.
 
+use crate::ant_protocol::XorName;
 use crate::error::{Error, Result};
-use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 use tracing::{debug, trace, warn};
-
-/// Content address type (32 bytes).
-pub type XorName = [u8; 32];
 
 /// Configuration for disk storage.
 #[derive(Debug, Clone)]
@@ -282,12 +279,7 @@ impl DiskStorage {
     /// Compute content address (SHA256 hash).
     #[must_use]
     pub fn compute_address(content: &[u8]) -> XorName {
-        let mut hasher = Sha256::new();
-        hasher.update(content);
-        let result = hasher.finalize();
-        let mut address = [0u8; 32];
-        address.copy_from_slice(&result);
-        address
+        crate::client::compute_address(content)
     }
 
     /// Get the root directory.

--- a/src/storage/disk.rs
+++ b/src/storage/disk.rs
@@ -1,0 +1,463 @@
+//! Content-addressed disk storage with sharded directories.
+//!
+//! Provides persistent storage for chunks using a two-level directory structure
+//! to avoid large directory listings:
+//!
+//! ```text
+//! {root}/chunks/{xx}/{yy}/{address}.chunk
+//! ```
+//!
+//! Where `xx` and `yy` are the first two bytes of the address in hex.
+
+use crate::error::{Error, Result};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+use tracing::{debug, trace, warn};
+
+/// Content address type (32 bytes).
+pub type XorName = [u8; 32];
+
+/// Configuration for disk storage.
+#[derive(Debug, Clone)]
+pub struct DiskStorageConfig {
+    /// Root directory for chunk storage.
+    pub root_dir: PathBuf,
+    /// Whether to verify content on read (compares hash to address).
+    pub verify_on_read: bool,
+    /// Maximum number of chunks to store (0 = unlimited).
+    pub max_chunks: usize,
+}
+
+impl Default for DiskStorageConfig {
+    fn default() -> Self {
+        Self {
+            root_dir: PathBuf::from(".saorsa/chunks"),
+            verify_on_read: true,
+            max_chunks: 0,
+        }
+    }
+}
+
+/// Statistics about storage operations.
+#[derive(Debug, Clone, Default)]
+pub struct StorageStats {
+    /// Total number of chunks stored.
+    pub chunks_stored: u64,
+    /// Total number of chunks retrieved.
+    pub chunks_retrieved: u64,
+    /// Total bytes stored.
+    pub bytes_stored: u64,
+    /// Total bytes retrieved.
+    pub bytes_retrieved: u64,
+    /// Number of duplicate writes (already exists).
+    pub duplicates: u64,
+    /// Number of verification failures on read.
+    pub verification_failures: u64,
+}
+
+/// Content-addressed disk storage.
+///
+/// Uses a sharded directory structure for efficient storage:
+/// ```text
+/// {root}/chunks/{xx}/{yy}/{address}.chunk
+/// ```
+pub struct DiskStorage {
+    /// Storage configuration.
+    config: DiskStorageConfig,
+    /// Operation statistics.
+    stats: parking_lot::RwLock<StorageStats>,
+}
+
+impl DiskStorage {
+    /// Create a new disk storage instance.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the root directory cannot be created.
+    pub async fn new(config: DiskStorageConfig) -> Result<Self> {
+        // Ensure root directory exists
+        let chunks_dir = config.root_dir.join("chunks");
+        fs::create_dir_all(&chunks_dir)
+            .await
+            .map_err(|e| Error::Storage(format!("Failed to create chunks directory: {e}")))?;
+
+        debug!("Initialized disk storage at {:?}", config.root_dir);
+
+        Ok(Self {
+            config,
+            stats: parking_lot::RwLock::new(StorageStats::default()),
+        })
+    }
+
+    /// Store a chunk.
+    ///
+    /// Uses atomic write (temp file + rename) for crash safety.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - Content address (should be SHA256 of content)
+    /// * `content` - Chunk data
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if the chunk was newly stored, `false` if it already existed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the write fails or content doesn't match address.
+    pub async fn put(&self, address: &XorName, content: &[u8]) -> Result<bool> {
+        // Verify content address
+        let computed = Self::compute_address(content);
+        if computed != *address {
+            return Err(Error::Storage(format!(
+                "Content address mismatch: expected {}, computed {}",
+                hex::encode(address),
+                hex::encode(computed)
+            )));
+        }
+
+        let chunk_path = self.chunk_path(address);
+
+        // Check if already exists
+        if chunk_path.exists() {
+            trace!("Chunk {} already exists", hex::encode(address));
+            {
+                let mut stats = self.stats.write();
+                stats.duplicates += 1;
+            }
+            return Ok(false);
+        }
+
+        // Ensure parent directories exist
+        if let Some(parent) = chunk_path.parent() {
+            fs::create_dir_all(parent)
+                .await
+                .map_err(|e| Error::Storage(format!("Failed to create shard directory: {e}")))?;
+        }
+
+        // Atomic write: temp file + rename
+        let temp_path = chunk_path.with_extension("tmp");
+        let mut file = fs::File::create(&temp_path)
+            .await
+            .map_err(|e| Error::Storage(format!("Failed to create temp file: {e}")))?;
+
+        file.write_all(content)
+            .await
+            .map_err(|e| Error::Storage(format!("Failed to write chunk: {e}")))?;
+
+        file.flush()
+            .await
+            .map_err(|e| Error::Storage(format!("Failed to flush chunk: {e}")))?;
+
+        // Rename for atomic commit
+        fs::rename(&temp_path, &chunk_path)
+            .await
+            .map_err(|e| Error::Storage(format!("Failed to rename temp file: {e}")))?;
+
+        {
+            let mut stats = self.stats.write();
+            stats.chunks_stored += 1;
+            stats.bytes_stored += content.len() as u64;
+        }
+
+        debug!(
+            "Stored chunk {} ({} bytes)",
+            hex::encode(address),
+            content.len()
+        );
+
+        Ok(true)
+    }
+
+    /// Retrieve a chunk.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - Content address to retrieve
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(content)` if found, `None` if not found.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if read fails or verification fails.
+    pub async fn get(&self, address: &XorName) -> Result<Option<Vec<u8>>> {
+        let chunk_path = self.chunk_path(address);
+
+        if !chunk_path.exists() {
+            trace!("Chunk {} not found", hex::encode(address));
+            return Ok(None);
+        }
+
+        let content = fs::read(&chunk_path)
+            .await
+            .map_err(|e| Error::Storage(format!("Failed to read chunk: {e}")))?;
+
+        // Verify content if configured
+        if self.config.verify_on_read {
+            let computed = Self::compute_address(&content);
+            if computed != *address {
+                {
+                    let mut stats = self.stats.write();
+                    stats.verification_failures += 1;
+                }
+                warn!(
+                    "Chunk verification failed: expected {}, computed {}",
+                    hex::encode(address),
+                    hex::encode(computed)
+                );
+                return Err(Error::Storage(format!(
+                    "Chunk verification failed for {}",
+                    hex::encode(address)
+                )));
+            }
+        }
+
+        {
+            let mut stats = self.stats.write();
+            stats.chunks_retrieved += 1;
+            stats.bytes_retrieved += content.len() as u64;
+        }
+
+        debug!(
+            "Retrieved chunk {} ({} bytes)",
+            hex::encode(address),
+            content.len()
+        );
+
+        Ok(Some(content))
+    }
+
+    /// Check if a chunk exists.
+    #[must_use]
+    pub fn exists(&self, address: &XorName) -> bool {
+        self.chunk_path(address).exists()
+    }
+
+    /// Delete a chunk.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if deletion fails.
+    pub async fn delete(&self, address: &XorName) -> Result<bool> {
+        let chunk_path = self.chunk_path(address);
+
+        if !chunk_path.exists() {
+            return Ok(false);
+        }
+
+        fs::remove_file(&chunk_path)
+            .await
+            .map_err(|e| Error::Storage(format!("Failed to delete chunk: {e}")))?;
+
+        debug!("Deleted chunk {}", hex::encode(address));
+
+        Ok(true)
+    }
+
+    /// Get storage statistics.
+    #[must_use]
+    pub fn stats(&self) -> StorageStats {
+        self.stats.read().clone()
+    }
+
+    /// Get the path for a chunk.
+    fn chunk_path(&self, address: &XorName) -> PathBuf {
+        // Two-level sharding using first two bytes
+        let shard1 = format!("{:02x}", address[0]);
+        let shard2 = format!("{:02x}", address[1]);
+        let filename = format!("{}.chunk", hex::encode(address));
+
+        self.config
+            .root_dir
+            .join("chunks")
+            .join(shard1)
+            .join(shard2)
+            .join(filename)
+    }
+
+    /// Compute content address (SHA256 hash).
+    #[must_use]
+    pub fn compute_address(content: &[u8]) -> XorName {
+        let mut hasher = Sha256::new();
+        hasher.update(content);
+        let result = hasher.finalize();
+        let mut address = [0u8; 32];
+        address.copy_from_slice(&result);
+        address
+    }
+
+    /// Get the root directory.
+    #[must_use]
+    pub fn root_dir(&self) -> &Path {
+        &self.config.root_dir
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    async fn create_test_storage() -> (DiskStorage, TempDir) {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let config = DiskStorageConfig {
+            root_dir: temp_dir.path().to_path_buf(),
+            verify_on_read: true,
+            max_chunks: 0,
+        };
+        let storage = DiskStorage::new(config).await.expect("create storage");
+        (storage, temp_dir)
+    }
+
+    #[tokio::test]
+    async fn test_put_and_get() {
+        let (storage, _temp) = create_test_storage().await;
+
+        let content = b"hello world";
+        let address = DiskStorage::compute_address(content);
+
+        // Store chunk
+        let is_new = storage.put(&address, content).await.expect("put");
+        assert!(is_new);
+
+        // Retrieve chunk
+        let retrieved = storage.get(&address).await.expect("get");
+        assert_eq!(retrieved, Some(content.to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_put_duplicate() {
+        let (storage, _temp) = create_test_storage().await;
+
+        let content = b"test data";
+        let address = DiskStorage::compute_address(content);
+
+        // First store
+        let is_new1 = storage.put(&address, content).await.expect("put 1");
+        assert!(is_new1);
+
+        // Duplicate store
+        let is_new2 = storage.put(&address, content).await.expect("put 2");
+        assert!(!is_new2);
+
+        // Check stats
+        let stats = storage.stats();
+        assert_eq!(stats.chunks_stored, 1);
+        assert_eq!(stats.duplicates, 1);
+    }
+
+    #[tokio::test]
+    async fn test_get_not_found() {
+        let (storage, _temp) = create_test_storage().await;
+
+        let address = [0xAB; 32];
+        let result = storage.get(&address).await.expect("get");
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_exists() {
+        let (storage, _temp) = create_test_storage().await;
+
+        let content = b"exists test";
+        let address = DiskStorage::compute_address(content);
+
+        assert!(!storage.exists(&address));
+
+        storage.put(&address, content).await.expect("put");
+
+        assert!(storage.exists(&address));
+    }
+
+    #[tokio::test]
+    async fn test_delete() {
+        let (storage, _temp) = create_test_storage().await;
+
+        let content = b"delete test";
+        let address = DiskStorage::compute_address(content);
+
+        // Store
+        storage.put(&address, content).await.expect("put");
+        assert!(storage.exists(&address));
+
+        // Delete
+        let deleted = storage.delete(&address).await.expect("delete");
+        assert!(deleted);
+        assert!(!storage.exists(&address));
+
+        // Delete again (already deleted)
+        let deleted2 = storage.delete(&address).await.expect("delete 2");
+        assert!(!deleted2);
+    }
+
+    #[tokio::test]
+    async fn test_address_mismatch() {
+        let (storage, _temp) = create_test_storage().await;
+
+        let content = b"some content";
+        let wrong_address = [0xFF; 32]; // Wrong address
+
+        let result = storage.put(&wrong_address, content).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("mismatch"));
+    }
+
+    #[tokio::test]
+    async fn test_chunk_path_sharding() {
+        let (storage, _temp) = create_test_storage().await;
+
+        // Address starting with 0xAB, 0xCD...
+        let mut address = [0u8; 32];
+        address[0] = 0xAB;
+        address[1] = 0xCD;
+
+        let path = storage.chunk_path(&address);
+        let path_str = path.to_string_lossy();
+
+        // Should contain sharded directories
+        assert!(path_str.contains("ab"));
+        assert!(path_str.contains("cd"));
+        assert!(path_str.ends_with(".chunk"));
+    }
+
+    #[test]
+    fn test_compute_address() {
+        // Known SHA256 hash of "hello world"
+        let content = b"hello world";
+        let address = DiskStorage::compute_address(content);
+
+        let expected_hex = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+        assert_eq!(hex::encode(address), expected_hex);
+    }
+
+    #[tokio::test]
+    async fn test_stats() {
+        let (storage, _temp) = create_test_storage().await;
+
+        let content1 = b"content 1";
+        let content2 = b"content 2";
+        let address1 = DiskStorage::compute_address(content1);
+        let address2 = DiskStorage::compute_address(content2);
+
+        // Store two chunks
+        storage.put(&address1, content1).await.expect("put 1");
+        storage.put(&address2, content2).await.expect("put 2");
+
+        // Retrieve one
+        storage.get(&address1).await.expect("get");
+
+        let stats = storage.stats();
+        assert_eq!(stats.chunks_stored, 2);
+        assert_eq!(stats.chunks_retrieved, 1);
+        assert_eq!(
+            stats.bytes_stored,
+            content1.len() as u64 + content2.len() as u64
+        );
+        assert_eq!(stats.bytes_retrieved, content1.len() as u64);
+    }
+}

--- a/src/storage/handler.rs
+++ b/src/storage/handler.rs
@@ -65,11 +65,6 @@ impl AntProtocol {
         payment_verifier: Arc<PaymentVerifier>,
         quote_generator: Arc<QuoteGenerator>,
     ) -> Self {
-        info!(
-            "ANT protocol handler initialized (protocol={})",
-            CHUNK_PROTOCOL_ID
-        );
-
         Self {
             storage,
             payment_verifier,

--- a/src/storage/handler.rs
+++ b/src/storage/handler.rs
@@ -1,0 +1,544 @@
+//! ANT protocol handler for autonomi protocol messages.
+//!
+//! This handler processes chunk PUT/GET requests with optional payment verification,
+//! storing chunks to disk and using the DHT for network-wide retrieval.
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────┐
+//! │                    AntProtocol                        │
+//! ├─────────────────────────────────────────────────────────┤
+//! │  protocol_id() = "saorsa/autonomi/chunk/v1"            │
+//! │                                                         │
+//! │  handle_message(data) ──▶ decode ChunkMessage  │
+//! │                                   │                     │
+//! │         ┌─────────────────────────┼─────────────────┐  │
+//! │         ▼                         ▼                 ▼  │
+//! │   ChunkQuoteRequest           ChunkPutRequest    ChunkGetRequest
+//! │         │                         │                 │  │
+//! │         ▼                         ▼                 ▼  │
+//! │   QuoteGenerator          PaymentVerifier    DiskStorage│
+//! │         │                         │                 │  │
+//! │         └─────────────────────────┴─────────────────┘  │
+//! │                           │                             │
+//! │                 return Ok(response_bytes)               │
+//! └─────────────────────────────────────────────────────────┘
+//! ```
+
+use crate::ant_protocol::{
+    ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkPutRequest, ChunkPutResponse,
+    ChunkQuoteRequest, ChunkQuoteResponse, ProtocolError, CHUNK_PROTOCOL_ID, DATA_TYPE_CHUNK,
+    MAX_CHUNK_SIZE,
+};
+use crate::error::Result;
+use crate::payment::{PaymentVerifier, QuoteGenerator};
+use crate::storage::disk::DiskStorage;
+use bytes::Bytes;
+use std::sync::Arc;
+use tracing::{debug, info, warn};
+
+/// ANT protocol handler.
+///
+/// Handles chunk PUT/GET/Quote requests using disk storage for persistence
+/// and optional payment verification.
+pub struct AntProtocol {
+    /// Disk storage for chunk persistence.
+    storage: Arc<DiskStorage>,
+    /// Payment verifier for checking payments.
+    payment_verifier: Arc<PaymentVerifier>,
+    /// Quote generator for creating storage quotes.
+    quote_generator: Arc<QuoteGenerator>,
+}
+
+impl AntProtocol {
+    /// Create a new ANT protocol handler.
+    ///
+    /// # Arguments
+    ///
+    /// * `storage` - Disk storage for chunk persistence
+    /// * `payment_verifier` - Payment verifier for validating payments
+    /// * `quote_generator` - Quote generator for creating storage quotes
+    #[must_use]
+    pub fn new(
+        storage: Arc<DiskStorage>,
+        payment_verifier: Arc<PaymentVerifier>,
+        quote_generator: Arc<QuoteGenerator>,
+    ) -> Self {
+        info!(
+            "ANT protocol handler initialized (protocol={})",
+            CHUNK_PROTOCOL_ID
+        );
+
+        Self {
+            storage,
+            payment_verifier,
+            quote_generator,
+        }
+    }
+
+    /// Get the protocol identifier.
+    #[must_use]
+    pub fn protocol_id(&self) -> &'static str {
+        CHUNK_PROTOCOL_ID
+    }
+
+    /// Handle an incoming protocol message.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - Raw message bytes
+    ///
+    /// # Returns
+    ///
+    /// Response bytes, or an error if handling fails.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if message decoding or handling fails.
+    pub async fn handle_message(&self, data: &[u8]) -> Result<Bytes> {
+        let message = ChunkMessage::decode(data)
+            .map_err(|e| crate::error::Error::Protocol(format!("Failed to decode message: {e}")))?;
+
+        let response = match message {
+            ChunkMessage::PutRequest(req) => {
+                ChunkMessage::PutResponse(self.handle_put(req).await)
+            }
+            ChunkMessage::GetRequest(req) => {
+                ChunkMessage::GetResponse(self.handle_get(req).await)
+            }
+            ChunkMessage::QuoteRequest(ref req) => {
+                ChunkMessage::QuoteResponse(self.handle_quote(req))
+            }
+            // Response messages shouldn't be received as requests
+            ChunkMessage::PutResponse(_)
+            | ChunkMessage::GetResponse(_)
+            | ChunkMessage::QuoteResponse(_) => {
+                let error = ProtocolError::Internal("Unexpected response message".to_string());
+                ChunkMessage::PutResponse(ChunkPutResponse::Error(error))
+            }
+        };
+
+        response
+            .encode()
+            .map(Bytes::from)
+            .map_err(|e| crate::error::Error::Protocol(format!("Failed to encode response: {e}")))
+    }
+
+    /// Handle a PUT request.
+    async fn handle_put(&self, request: ChunkPutRequest) -> ChunkPutResponse {
+        let address = request.address;
+        debug!("Handling PUT request for {}", hex::encode(address));
+
+        // 1. Validate chunk size
+        if request.content.len() > MAX_CHUNK_SIZE {
+            return ChunkPutResponse::Error(ProtocolError::ChunkTooLarge {
+                size: request.content.len(),
+                max_size: MAX_CHUNK_SIZE,
+            });
+        }
+
+        // 2. Verify content address matches SHA256(content)
+        let computed = DiskStorage::compute_address(&request.content);
+        if computed != address {
+            return ChunkPutResponse::Error(ProtocolError::AddressMismatch {
+                expected: address,
+                actual: computed,
+            });
+        }
+
+        // 3. Check if already exists (idempotent success)
+        if self.storage.exists(&address) {
+            debug!("Chunk {} already exists", hex::encode(address));
+            return ChunkPutResponse::AlreadyExists { address };
+        }
+
+        // 4. Verify payment
+        let payment_result = self
+            .payment_verifier
+            .verify_payment(&address, request.payment_proof.as_deref())
+            .await;
+
+        match payment_result {
+            Ok(status) if status.can_store() => {
+                // Payment verified or cached
+            }
+            Ok(_) => {
+                return ChunkPutResponse::PaymentRequired {
+                    message: "Payment required for new chunk".to_string(),
+                };
+            }
+            Err(e) => {
+                return ChunkPutResponse::Error(ProtocolError::PaymentFailed(e.to_string()));
+            }
+        }
+
+        // 5. Store to disk
+        match self.storage.put(&address, &request.content).await {
+            Ok(_) => {
+                info!(
+                    "Stored chunk {} ({} bytes)",
+                    hex::encode(address),
+                    request.content.len()
+                );
+                // Record the store in metrics
+                self.quote_generator.record_store(DATA_TYPE_CHUNK);
+                ChunkPutResponse::Success { address }
+            }
+            Err(e) => {
+                warn!("Failed to store chunk {}: {}", hex::encode(address), e);
+                ChunkPutResponse::Error(ProtocolError::StorageFailed(e.to_string()))
+            }
+        }
+    }
+
+    /// Handle a GET request.
+    async fn handle_get(&self, request: ChunkGetRequest) -> ChunkGetResponse {
+        let address = request.address;
+        debug!("Handling GET request for {}", hex::encode(address));
+
+        match self.storage.get(&address).await {
+            Ok(Some(content)) => {
+                debug!(
+                    "Retrieved chunk {} ({} bytes)",
+                    hex::encode(address),
+                    content.len()
+                );
+                ChunkGetResponse::Success { address, content }
+            }
+            Ok(None) => {
+                debug!("Chunk {} not found", hex::encode(address));
+                ChunkGetResponse::NotFound { address }
+            }
+            Err(e) => {
+                warn!("Failed to retrieve chunk {}: {}", hex::encode(address), e);
+                ChunkGetResponse::Error(ProtocolError::StorageFailed(e.to_string()))
+            }
+        }
+    }
+
+    /// Handle a quote request.
+    fn handle_quote(&self, request: &ChunkQuoteRequest) -> ChunkQuoteResponse {
+        debug!(
+            "Handling quote request for {} (size: {})",
+            hex::encode(request.address),
+            request.data_size
+        );
+
+        // Validate data size - data_size is u64, cast carefully
+        let data_size_usize = usize::try_from(request.data_size).unwrap_or(usize::MAX);
+        if data_size_usize > MAX_CHUNK_SIZE {
+            return ChunkQuoteResponse::Error(ProtocolError::ChunkTooLarge {
+                size: data_size_usize,
+                max_size: MAX_CHUNK_SIZE,
+            });
+        }
+
+        match self
+            .quote_generator
+            .create_quote(request.address, data_size_usize, request.data_type)
+        {
+            Ok(quote) => {
+                // Serialize the quote
+                match rmp_serde::to_vec(&quote) {
+                    Ok(quote_bytes) => ChunkQuoteResponse::Success { quote: quote_bytes },
+                    Err(e) => ChunkQuoteResponse::Error(ProtocolError::QuoteFailed(format!(
+                        "Failed to serialize quote: {e}"
+                    ))),
+                }
+            }
+            Err(e) => ChunkQuoteResponse::Error(ProtocolError::QuoteFailed(e.to_string())),
+        }
+    }
+
+    /// Get storage statistics.
+    #[must_use]
+    pub fn storage_stats(&self) -> crate::storage::StorageStats {
+        self.storage.stats()
+    }
+
+    /// Get payment cache statistics.
+    #[must_use]
+    pub fn payment_cache_stats(&self) -> crate::payment::CacheStats {
+        self.payment_verifier.cache_stats()
+    }
+
+    /// Check if a chunk exists locally.
+    #[must_use]
+    pub fn exists(&self, address: &[u8; 32]) -> bool {
+        self.storage.exists(address)
+    }
+
+    /// Get a chunk directly from local storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if storage access fails.
+    pub async fn get_local(&self, address: &[u8; 32]) -> Result<Option<Vec<u8>>> {
+        self.storage.get(address).await
+    }
+
+    /// Store a chunk directly to local storage (bypasses payment verification).
+    ///
+    /// This is useful for testing or when payment has been verified elsewhere.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if storage fails or content doesn't match address.
+    pub async fn put_local(&self, address: &[u8; 32], content: &[u8]) -> Result<bool> {
+        self.storage.put(address, content).await
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::payment::metrics::QuotingMetricsTracker;
+    use crate::payment::{EvmVerifierConfig, PaymentVerifierConfig};
+    use crate::storage::DiskStorageConfig;
+    use ant_evm::RewardsAddress;
+    use tempfile::TempDir;
+
+    async fn create_test_protocol() -> (AntProtocol, TempDir) {
+        let temp_dir = TempDir::new().expect("create temp dir");
+
+        let storage_config = DiskStorageConfig {
+            root_dir: temp_dir.path().to_path_buf(),
+            verify_on_read: true,
+            max_chunks: 0,
+        };
+        let storage = Arc::new(
+            DiskStorage::new(storage_config)
+                .await
+                .expect("create storage"),
+        );
+
+        let payment_config = PaymentVerifierConfig {
+            evm: EvmVerifierConfig {
+                enabled: false, // Disable EVM for tests
+                ..Default::default()
+            },
+            cache_capacity: 100,
+        };
+        let payment_verifier = Arc::new(PaymentVerifier::new(payment_config));
+
+        let rewards_address = RewardsAddress::new([1u8; 20]);
+        let metrics_tracker = QuotingMetricsTracker::new(1000, 100);
+        let quote_generator = Arc::new(QuoteGenerator::new(rewards_address, metrics_tracker));
+
+        let protocol = AntProtocol::new(storage, payment_verifier, quote_generator);
+        (protocol, temp_dir)
+    }
+
+    #[tokio::test]
+    async fn test_put_and_get_chunk() {
+        let (protocol, _temp) = create_test_protocol().await;
+
+        let content = b"hello world";
+        let address = DiskStorage::compute_address(content);
+
+        // Create PUT request - with empty payment proof (EVM disabled)
+        let put_request = ChunkPutRequest::with_payment(
+            address,
+            content.to_vec(),
+            rmp_serde::to_vec(&ant_evm::ProofOfPayment {
+                peer_quotes: vec![],
+            })
+            .unwrap(),
+        );
+        let put_msg = ChunkMessage::PutRequest(put_request);
+        let put_bytes = put_msg.encode().expect("encode put");
+
+        // Handle PUT
+        let response_bytes = protocol
+            .handle_message(&put_bytes)
+            .await
+            .expect("handle put");
+        let response = ChunkMessage::decode(&response_bytes).expect("decode response");
+
+        if let ChunkMessage::PutResponse(ChunkPutResponse::Success { address: addr }) =
+            response
+        {
+            assert_eq!(addr, address);
+        } else {
+            panic!("expected PutResponse::Success, got: {response:?}");
+        }
+
+        // Create GET request
+        let get_request = ChunkGetRequest::new(address);
+        let get_msg = ChunkMessage::GetRequest(get_request);
+        let get_bytes = get_msg.encode().expect("encode get");
+
+        // Handle GET
+        let response_bytes = protocol
+            .handle_message(&get_bytes)
+            .await
+            .expect("handle get");
+        let response = ChunkMessage::decode(&response_bytes).expect("decode response");
+
+        if let ChunkMessage::GetResponse(ChunkGetResponse::Success {
+            address: addr,
+            content: data,
+        }) = response
+        {
+            assert_eq!(addr, address);
+            assert_eq!(data, content.to_vec());
+        } else {
+            panic!("expected GetResponse::Success");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_not_found() {
+        let (protocol, _temp) = create_test_protocol().await;
+
+        let address = [0xAB; 32];
+        let get_request = ChunkGetRequest::new(address);
+        let get_msg = ChunkMessage::GetRequest(get_request);
+        let get_bytes = get_msg.encode().expect("encode get");
+
+        let response_bytes = protocol
+            .handle_message(&get_bytes)
+            .await
+            .expect("handle get");
+        let response = ChunkMessage::decode(&response_bytes).expect("decode response");
+
+        if let ChunkMessage::GetResponse(ChunkGetResponse::NotFound { address: addr }) =
+            response
+        {
+            assert_eq!(addr, address);
+        } else {
+            panic!("expected GetResponse::NotFound");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_put_address_mismatch() {
+        let (protocol, _temp) = create_test_protocol().await;
+
+        let content = b"test content";
+        let wrong_address = [0xFF; 32]; // Wrong address
+
+        let put_request = ChunkPutRequest::with_payment(
+            wrong_address,
+            content.to_vec(),
+            rmp_serde::to_vec(&ant_evm::ProofOfPayment {
+                peer_quotes: vec![],
+            })
+            .unwrap(),
+        );
+        let put_msg = ChunkMessage::PutRequest(put_request);
+        let put_bytes = put_msg.encode().expect("encode put");
+
+        let response_bytes = protocol
+            .handle_message(&put_bytes)
+            .await
+            .expect("handle put");
+        let response = ChunkMessage::decode(&response_bytes).expect("decode response");
+
+        if let ChunkMessage::PutResponse(ChunkPutResponse::Error(
+            ProtocolError::AddressMismatch { .. },
+        )) = response
+        {
+            // Expected
+        } else {
+            panic!("expected AddressMismatch error, got: {response:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_put_chunk_too_large() {
+        let (protocol, _temp) = create_test_protocol().await;
+
+        // Create oversized content
+        let content = vec![0u8; MAX_CHUNK_SIZE + 1];
+        let address = DiskStorage::compute_address(&content);
+
+        let put_request = ChunkPutRequest::new(address, content);
+        let put_msg = ChunkMessage::PutRequest(put_request);
+        let put_bytes = put_msg.encode().expect("encode put");
+
+        let response_bytes = protocol
+            .handle_message(&put_bytes)
+            .await
+            .expect("handle put");
+        let response = ChunkMessage::decode(&response_bytes).expect("decode response");
+
+        if let ChunkMessage::PutResponse(ChunkPutResponse::Error(
+            ProtocolError::ChunkTooLarge { .. },
+        )) = response
+        {
+            // Expected
+        } else {
+            panic!("expected ChunkTooLarge error");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_put_already_exists() {
+        let (protocol, _temp) = create_test_protocol().await;
+
+        let content = b"duplicate content";
+        let address = DiskStorage::compute_address(content);
+
+        // Store first time
+        let put_request = ChunkPutRequest::with_payment(
+            address,
+            content.to_vec(),
+            rmp_serde::to_vec(&ant_evm::ProofOfPayment {
+                peer_quotes: vec![],
+            })
+            .unwrap(),
+        );
+        let put_msg = ChunkMessage::PutRequest(put_request);
+        let put_bytes = put_msg.encode().expect("encode put");
+
+        let _ = protocol
+            .handle_message(&put_bytes)
+            .await
+            .expect("handle put");
+
+        // Store again - should return AlreadyExists
+        let response_bytes = protocol
+            .handle_message(&put_bytes)
+            .await
+            .expect("handle put 2");
+        let response = ChunkMessage::decode(&response_bytes).expect("decode response");
+
+        if let ChunkMessage::PutResponse(ChunkPutResponse::AlreadyExists {
+            address: addr,
+        }) = response
+        {
+            assert_eq!(addr, address);
+        } else {
+            panic!("expected AlreadyExists");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_protocol_id() {
+        let (protocol, _temp) = create_test_protocol().await;
+        assert_eq!(protocol.protocol_id(), CHUNK_PROTOCOL_ID);
+    }
+
+    #[tokio::test]
+    async fn test_exists_and_local_access() {
+        let (protocol, _temp) = create_test_protocol().await;
+
+        let content = b"local access test";
+        let address = DiskStorage::compute_address(content);
+
+        assert!(!protocol.exists(&address));
+
+        protocol
+            .put_local(&address, content)
+            .await
+            .expect("put local");
+
+        assert!(protocol.exists(&address));
+
+        let retrieved = protocol.get_local(&address).await.expect("get local");
+        assert_eq!(retrieved, Some(content.to_vec()));
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -10,7 +10,7 @@
 //! ┌─────────────────────────────────────────────────────────┐
 //! │        AntProtocol (implements Protocol trait)        │
 //! ├─────────────────────────────────────────────────────────┤
-//! │  protocol_id() = "saorsa/autonomi/chunk/v1"            │
+//! │  protocol_id() = "saorsa/ant/chunk/v1"                  │
 //! │                                                         │
 //! │  handle(peer_id, data) ──▶ decode AntProtocolMessage │
 //! │                                   │                     │
@@ -46,5 +46,6 @@
 mod disk;
 mod handler;
 
-pub use disk::{DiskStorage, DiskStorageConfig, StorageStats, XorName};
+pub use crate::ant_protocol::XorName;
+pub use disk::{DiskStorage, DiskStorageConfig, StorageStats};
 pub use handler::AntProtocol;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,0 +1,50 @@
+//! Storage subsystem for chunk persistence.
+//!
+//! This module provides content-addressed disk storage for chunks,
+//! along with a protocol handler that integrates with saorsa-core's
+//! `Protocol` trait for automatic message routing.
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────┐
+//! │        AntProtocol (implements Protocol trait)        │
+//! ├─────────────────────────────────────────────────────────┤
+//! │  protocol_id() = "saorsa/autonomi/chunk/v1"            │
+//! │                                                         │
+//! │  handle(peer_id, data) ──▶ decode AntProtocolMessage │
+//! │                                   │                     │
+//! │         ┌─────────────────────────┼─────────────────┐  │
+//! │         ▼                         ▼                 ▼  │
+//! │   QuoteRequest           ChunkPutRequest    ChunkGetRequest
+//! │         │                         │                 │  │
+//! │         ▼                         ▼                 ▼  │
+//! │   QuoteGenerator          PaymentVerifier    DiskStorage│
+//! │         │                         │                 │  │
+//! │         └─────────────────────────┴─────────────────┘  │
+//! │                           │                             │
+//! │                 return Ok(Some(response_bytes))         │
+//! └─────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use saorsa_node::storage::{AntProtocol, DiskStorage, DiskStorageConfig};
+//!
+//! // Create storage
+//! let config = DiskStorageConfig::default();
+//! let storage = DiskStorage::new(config).await?;
+//!
+//! // Create protocol handler
+//! let protocol = AntProtocol::new(storage, payment_verifier, quote_generator);
+//!
+//! // Register with saorsa-core
+//! listener.register_protocol(protocol).await?;
+//! ```
+
+mod disk;
+mod handler;
+
+pub use disk::{DiskStorage, DiskStorageConfig, StorageStats, XorName};
+pub use handler::AntProtocol;

--- a/tests/e2e/live_testnet.rs
+++ b/tests/e2e/live_testnet.rs
@@ -13,7 +13,6 @@
 )]
 
 use saorsa_core::{NodeConfig as CoreNodeConfig, P2PNode};
-use sha2::{Digest, Sha256};
 use std::env;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
@@ -67,12 +66,7 @@ async fn create_testnet_client() -> P2PNode {
 
 /// Compute content address (SHA256 hash).
 fn compute_address(data: &[u8]) -> XorName {
-    let mut hasher = Sha256::new();
-    hasher.update(data);
-    let hash = hasher.finalize();
-    let mut address = [0u8; 32];
-    address.copy_from_slice(&hash);
-    address
+    saorsa_node::compute_address(data)
 }
 
 /// Generate random chunk data.

--- a/tests/e2e/testnet.rs
+++ b/tests/e2e/testnet.rs
@@ -2,12 +2,31 @@
 //!
 //! This module provides the core infrastructure for creating a local testnet
 //! of 25 saorsa nodes for E2E testing.
+//!
+//! ## Protocol-Based Testing
+//!
+//! Each test node includes a `AntProtocol` handler that processes chunk
+//! PUT/GET requests using the autonomi protocol messages. This allows E2E
+//! tests to validate the complete protocol flow including:
+//! - Message encoding/decoding (bincode serialization)
+//! - Content address verification
+//! - Payment verification (when enabled)
+//! - Disk storage persistence
 
+use ant_evm::RewardsAddress;
 use bytes::Bytes;
 use rand::Rng;
-use saorsa_core::{NodeConfig as CoreNodeConfig, P2PNode};
+use saorsa_core::{NodeConfig as CoreNodeConfig, P2PEvent, P2PNode};
 use saorsa_node::client::{DataChunk, XorName};
-use sha2::{Digest, Sha256};
+use saorsa_node::payment::{
+    EvmVerifierConfig, PaymentVerifier, PaymentVerifierConfig, QuoteGenerator,
+    QuotingMetricsTracker,
+};
+use saorsa_node::ant_protocol::{
+    ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkPutRequest, ChunkPutResponse,
+    CHUNK_PROTOCOL_ID,
+};
+use saorsa_node::storage::{AntProtocol, DiskStorage, DiskStorageConfig};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -63,6 +82,22 @@ const SMALL_STABILIZATION_TIMEOUT_SECS: u64 = 60;
 
 /// Default timeout for chunk operations (seconds).
 const DEFAULT_CHUNK_OPERATION_TIMEOUT_SECS: u64 = 30;
+
+// =============================================================================
+// AntProtocol Test Configuration
+// =============================================================================
+
+/// Payment cache capacity for test nodes.
+const TEST_PAYMENT_CACHE_CAPACITY: usize = 1000;
+
+/// Test rewards address (20 bytes, all 0x01).
+const TEST_REWARDS_ADDRESS: [u8; 20] = [0x01; 20];
+
+/// Max records for quoting metrics (test value).
+const TEST_MAX_RECORDS: usize = 100_000;
+
+/// Initial records for quoting metrics (test value).
+const TEST_INITIAL_RECORDS: usize = 1000;
 
 // =============================================================================
 // Default Node Counts
@@ -279,6 +314,9 @@ pub struct TestNode {
     /// Reference to the running P2P node.
     pub p2p_node: Option<Arc<P2PNode>>,
 
+    /// ANT protocol handler for processing chunk PUT/GET requests.
+    pub ant_protocol: Option<Arc<AntProtocol>>,
+
     /// Is this a bootstrap node?
     pub is_bootstrap: bool,
 
@@ -287,6 +325,9 @@ pub struct TestNode {
 
     /// Bootstrap addresses this node connects to.
     pub bootstrap_addrs: Vec<SocketAddr>,
+
+    /// Protocol handler background task.
+    protocol_task: Option<JoinHandle<()>>,
 }
 
 impl TestNode {
@@ -308,90 +349,364 @@ impl TestNode {
     }
 
     // =========================================================================
-    // Chunk Operations (immutable, content-addressed)
+    // Chunk Operations (via autonomi protocol messages)
     // =========================================================================
 
-    /// Store a chunk on the network.
+    /// Store a chunk using the autonomi protocol.
+    ///
+    /// Creates a `ChunkPutRequest` message, sends it to the local `AntProtocol`
+    /// handler, and parses the `ChunkPutResponse`.
     ///
     /// Returns the content-addressed `XorName` where the chunk is stored.
     ///
     /// # Errors
     ///
     /// Returns an error if the node is not running, chunk exceeds max size,
-    /// storage fails, or operation times out.
+    /// protocol handling fails, or the response indicates an error.
     pub async fn store_chunk(&self, data: &[u8]) -> Result<XorName> {
-        // Validate chunk size (max 4MB)
-        const MAX_CHUNK_SIZE: usize = 4 * 1024 * 1024;
-        if data.len() > MAX_CHUNK_SIZE {
-            return Err(TestnetError::Storage(format!(
-                "Chunk size {} exceeds maximum {} bytes",
-                data.len(),
-                MAX_CHUNK_SIZE
-            )));
-        }
+        let protocol = self
+            .ant_protocol
+            .as_ref()
+            .ok_or(TestnetError::NodeNotRunning)?;
 
-        let node = self.p2p_node.as_ref().ok_or(TestnetError::NodeNotRunning)?;
-
-        // Compute content address (SHA256 hash)
+        // Compute content address
         let address = Self::compute_chunk_address(data);
 
-        // Store in DHT with timeout
+        // Create PUT request with empty payment proof (EVM disabled in tests)
+        let empty_payment = rmp_serde::to_vec(&ant_evm::ProofOfPayment {
+            peer_quotes: vec![],
+        })
+        .map_err(|e| {
+            TestnetError::Serialization(format!("Failed to serialize payment proof: {e}"))
+        })?;
+
+        let request = ChunkPutRequest::with_payment(address, data.to_vec(), empty_payment);
+        let message = ChunkMessage::PutRequest(request);
+        let message_bytes = message.encode().map_err(|e| {
+            TestnetError::Serialization(format!("Failed to encode PUT request: {e}"))
+        })?;
+
+        // Handle the protocol message
         let timeout = Duration::from_secs(DEFAULT_CHUNK_OPERATION_TIMEOUT_SECS);
-        tokio::time::timeout(timeout, node.dht_put(address, data.to_vec()))
+        let response_bytes = tokio::time::timeout(timeout, protocol.handle_message(&message_bytes))
             .await
             .map_err(|_| {
                 TestnetError::Storage(format!(
                     "Timeout storing chunk after {DEFAULT_CHUNK_OPERATION_TIMEOUT_SECS}s"
                 ))
             })?
-            .map_err(|e| TestnetError::Storage(format!("Failed to store chunk: {e}")))?;
+            .map_err(|e| TestnetError::Storage(format!("Protocol error: {e}")))?;
 
-        debug!(
-            "Node {} stored chunk at {}",
-            self.index,
-            hex::encode(address)
-        );
-        Ok(address)
+        // Parse response
+        let response = ChunkMessage::decode(&response_bytes)
+            .map_err(|e| TestnetError::Storage(format!("Failed to decode response: {e}")))?;
+
+        match response {
+            ChunkMessage::PutResponse(ChunkPutResponse::Success { address: addr }) => {
+                debug!("Node {} stored chunk at {}", self.index, hex::encode(addr));
+                Ok(addr)
+            }
+            ChunkMessage::PutResponse(ChunkPutResponse::AlreadyExists {
+                address: addr,
+            }) => {
+                debug!(
+                    "Node {} chunk already exists at {}",
+                    self.index,
+                    hex::encode(addr)
+                );
+                Ok(addr)
+            }
+            ChunkMessage::PutResponse(ChunkPutResponse::PaymentRequired { message }) => {
+                Err(TestnetError::Storage(format!(
+                    "Payment required: {message}"
+                )))
+            }
+            ChunkMessage::PutResponse(ChunkPutResponse::Error(e)) => {
+                Err(TestnetError::Storage(format!("Protocol error: {e}")))
+            }
+            _ => Err(TestnetError::Storage(
+                "Unexpected response type".to_string(),
+            )),
+        }
     }
 
-    /// Retrieve a chunk from the network.
+    /// Retrieve a chunk using the autonomi protocol.
+    ///
+    /// Creates a `ChunkGetRequest` message, sends it to the local `AntProtocol`
+    /// handler, and parses the `ChunkGetResponse`.
     ///
     /// # Errors
     ///
-    /// Returns an error if the node is not running, retrieval fails, or operation times out.
+    /// Returns an error if the node is not running, protocol handling fails,
+    /// or the response indicates an error.
     pub async fn get_chunk(&self, address: &XorName) -> Result<Option<DataChunk>> {
-        let node = self.p2p_node.as_ref().ok_or(TestnetError::NodeNotRunning)?;
+        let protocol = self
+            .ant_protocol
+            .as_ref()
+            .ok_or(TestnetError::NodeNotRunning)?;
 
+        // Create GET request
+        let request = ChunkGetRequest::new(*address);
+        let message = ChunkMessage::GetRequest(request);
+        let message_bytes = message.encode().map_err(|e| {
+            TestnetError::Serialization(format!("Failed to encode GET request: {e}"))
+        })?;
+
+        // Handle the protocol message
         let timeout = Duration::from_secs(DEFAULT_CHUNK_OPERATION_TIMEOUT_SECS);
-        let result = tokio::time::timeout(timeout, node.dht_get(*address))
+        let response_bytes = tokio::time::timeout(timeout, protocol.handle_message(&message_bytes))
             .await
             .map_err(|_| {
                 TestnetError::Retrieval(format!(
                     "Timeout retrieving chunk after {DEFAULT_CHUNK_OPERATION_TIMEOUT_SECS}s"
                 ))
-            })?;
+            })?
+            .map_err(|e| TestnetError::Retrieval(format!("Protocol error: {e}")))?;
 
-        match result {
-            Ok(Some(data)) => {
-                let chunk = DataChunk::new(*address, Bytes::from(data));
-                Ok(Some(chunk))
+        // Parse response
+        let response = ChunkMessage::decode(&response_bytes)
+            .map_err(|e| TestnetError::Retrieval(format!("Failed to decode response: {e}")))?;
+
+        match response {
+            ChunkMessage::GetResponse(ChunkGetResponse::Success { address, content }) => {
+                debug!(
+                    "Node {} retrieved chunk {} ({} bytes)",
+                    self.index,
+                    hex::encode(address),
+                    content.len()
+                );
+                Ok(Some(DataChunk::new(address, Bytes::from(content))))
             }
-            Ok(None) => Ok(None),
-            Err(e) => Err(TestnetError::Retrieval(format!(
-                "Failed to retrieve chunk: {e}"
-            ))),
+            ChunkMessage::GetResponse(ChunkGetResponse::NotFound { address }) => {
+                debug!(
+                    "Node {} chunk not found: {}",
+                    self.index,
+                    hex::encode(address)
+                );
+                Ok(None)
+            }
+            ChunkMessage::GetResponse(ChunkGetResponse::Error(e)) => {
+                Err(TestnetError::Retrieval(format!("Protocol error: {e}")))
+            }
+            _ => Err(TestnetError::Retrieval(
+                "Unexpected response type".to_string(),
+            )),
         }
     }
 
-    /// Compute content address for chunk data.
+    // =========================================================================
+    // Remote Chunk Operations (via P2P network)
+    // =========================================================================
+
+    /// Store a chunk on a remote node via P2P.
+    ///
+    /// Sends a `ChunkPutRequest` to the target node over the P2P network
+    /// and waits for the `ChunkPutResponse`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either node is not running, the message cannot be
+    /// sent, the response times out, or the remote node reports an error.
+    pub async fn store_chunk_on(&self, target: &Self, data: &[u8]) -> Result<XorName> {
+        let p2p = self
+            .p2p_node
+            .as_ref()
+            .ok_or(TestnetError::NodeNotRunning)?;
+        let target_p2p = target
+            .p2p_node
+            .as_ref()
+            .ok_or(TestnetError::NodeNotRunning)?;
+        let target_peer_id = target_p2p.peer_id().clone();
+
+        // Subscribe before sending so we don't miss the response
+        let mut events = p2p.subscribe_events();
+
+        // Create PUT request
+        let address = Self::compute_chunk_address(data);
+        let empty_payment = rmp_serde::to_vec(&ant_evm::ProofOfPayment {
+            peer_quotes: vec![],
+        })
+        .map_err(|e| {
+            TestnetError::Serialization(format!("Failed to serialize payment proof: {e}"))
+        })?;
+
+        let request = ChunkPutRequest::with_payment(address, data.to_vec(), empty_payment);
+        let message = ChunkMessage::PutRequest(request);
+        let message_bytes = message.encode().map_err(|e| {
+            TestnetError::Serialization(format!("Failed to encode PUT request: {e}"))
+        })?;
+
+        // Send to target node
+        p2p.send_message(&target_peer_id, CHUNK_PROTOCOL_ID, message_bytes)
+            .await
+            .map_err(|e| TestnetError::Storage(format!("Failed to send PUT to remote node: {e}")))?;
+
+        // Wait for response from the target
+        let timeout = Duration::from_secs(DEFAULT_CHUNK_OPERATION_TIMEOUT_SECS);
+        let deadline = Instant::now() + timeout;
+
+        while Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            match tokio::time::timeout(remaining, events.recv()).await {
+                Ok(Ok(P2PEvent::Message {
+                    topic,
+                    source,
+                    data: resp_data,
+                })) if topic == CHUNK_PROTOCOL_ID && source == target_peer_id => {
+                    let response = ChunkMessage::decode(&resp_data).map_err(|e| {
+                        TestnetError::Storage(format!("Failed to decode PUT response: {e}"))
+                    })?;
+                    match response {
+                        ChunkMessage::PutResponse(ChunkPutResponse::Success {
+                            address: addr,
+                        }) => {
+                            debug!(
+                                "Node {} stored chunk on node {}: {}",
+                                self.index,
+                                target.index,
+                                hex::encode(addr)
+                            );
+                            return Ok(addr);
+                        }
+                        ChunkMessage::PutResponse(ChunkPutResponse::AlreadyExists {
+                            address: addr,
+                        }) => {
+                            debug!(
+                                "Node {} chunk already exists on node {}: {}",
+                                self.index,
+                                target.index,
+                                hex::encode(addr)
+                            );
+                            return Ok(addr);
+                        }
+                        ChunkMessage::PutResponse(ChunkPutResponse::PaymentRequired {
+                            message,
+                        }) => {
+                            return Err(TestnetError::Storage(format!(
+                                "Payment required: {message}"
+                            )));
+                        }
+                        ChunkMessage::PutResponse(ChunkPutResponse::Error(e)) => {
+                            return Err(TestnetError::Storage(format!(
+                                "Remote protocol error: {e}"
+                            )));
+                        }
+                        _ => {} // Not a PUT response, keep waiting
+                    }
+                }
+                Ok(Ok(_)) => {} // Different topic/source, keep waiting
+                Ok(Err(_)) | Err(_) => break,
+            }
+        }
+
+        Err(TestnetError::Storage(format!(
+            "Timeout waiting for remote store response after {DEFAULT_CHUNK_OPERATION_TIMEOUT_SECS}s"
+        )))
+    }
+
+    /// Retrieve a chunk from a remote node via P2P.
+    ///
+    /// Sends a `ChunkGetRequest` to the target node over the P2P network
+    /// and waits for the `ChunkGetResponse`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either node is not running, the message cannot be
+    /// sent, the response times out, or the remote node reports an error.
+    pub async fn get_chunk_from(
+        &self,
+        target: &Self,
+        address: &XorName,
+    ) -> Result<Option<DataChunk>> {
+        let p2p = self
+            .p2p_node
+            .as_ref()
+            .ok_or(TestnetError::NodeNotRunning)?;
+        let target_p2p = target
+            .p2p_node
+            .as_ref()
+            .ok_or(TestnetError::NodeNotRunning)?;
+        let target_peer_id = target_p2p.peer_id().clone();
+
+        // Subscribe before sending
+        let mut events = p2p.subscribe_events();
+
+        // Create GET request
+        let request = ChunkGetRequest::new(*address);
+        let message = ChunkMessage::GetRequest(request);
+        let message_bytes = message.encode().map_err(|e| {
+            TestnetError::Serialization(format!("Failed to encode GET request: {e}"))
+        })?;
+
+        // Send to target node
+        p2p.send_message(&target_peer_id, CHUNK_PROTOCOL_ID, message_bytes)
+            .await
+            .map_err(|e| {
+                TestnetError::Retrieval(format!("Failed to send GET to remote node: {e}"))
+            })?;
+
+        // Wait for response from the target
+        let timeout = Duration::from_secs(DEFAULT_CHUNK_OPERATION_TIMEOUT_SECS);
+        let deadline = Instant::now() + timeout;
+
+        while Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            match tokio::time::timeout(remaining, events.recv()).await {
+                Ok(Ok(P2PEvent::Message {
+                    topic,
+                    source,
+                    data: resp_data,
+                })) if topic == CHUNK_PROTOCOL_ID && source == target_peer_id => {
+                    let response = ChunkMessage::decode(&resp_data).map_err(|e| {
+                        TestnetError::Retrieval(format!("Failed to decode GET response: {e}"))
+                    })?;
+                    match response {
+                        ChunkMessage::GetResponse(ChunkGetResponse::Success {
+                            address: addr,
+                            content,
+                        }) => {
+                            debug!(
+                                "Node {} retrieved chunk from node {}: {} ({} bytes)",
+                                self.index,
+                                target.index,
+                                hex::encode(addr),
+                                content.len()
+                            );
+                            return Ok(Some(DataChunk::new(addr, Bytes::from(content))));
+                        }
+                        ChunkMessage::GetResponse(ChunkGetResponse::NotFound {
+                            address: addr,
+                        }) => {
+                            debug!(
+                                "Node {} chunk not found on node {}: {}",
+                                self.index,
+                                target.index,
+                                hex::encode(addr)
+                            );
+                            return Ok(None);
+                        }
+                        ChunkMessage::GetResponse(ChunkGetResponse::Error(e)) => {
+                            return Err(TestnetError::Retrieval(format!(
+                                "Remote protocol error: {e}"
+                            )));
+                        }
+                        _ => {} // Not a GET response, keep waiting
+                    }
+                }
+                Ok(Ok(_)) => {} // Different topic/source, keep waiting
+                Ok(Err(_)) | Err(_) => break,
+            }
+        }
+
+        Err(TestnetError::Retrieval(format!(
+            "Timeout waiting for remote get response after {DEFAULT_CHUNK_OPERATION_TIMEOUT_SECS}s"
+        )))
+    }
+
+    /// Compute content address for chunk data (SHA256 hash).
     #[must_use]
     pub fn compute_chunk_address(data: &[u8]) -> XorName {
-        let mut hasher = Sha256::new();
-        hasher.update(data);
-        let hash = hasher.finalize();
-        let mut address = [0u8; 32];
-        address.copy_from_slice(&hash);
-        address
+        DiskStorage::compute_address(data)
     }
 }
 
@@ -576,6 +891,11 @@ impl TestNetwork {
     }
 
     /// Create a test node (but don't start it yet).
+    ///
+    /// Initializes the `AntProtocol` handler with:
+    /// - Disk storage in the node's data directory
+    /// - Payment verification disabled (for testing)
+    /// - Quote generation with a test rewards address
     async fn create_node(
         &self,
         index: usize,
@@ -592,6 +912,9 @@ impl TestNetwork {
 
         tokio::fs::create_dir_all(&data_dir).await?;
 
+        // Initialize AntProtocol for this node
+        let ant_protocol = Self::create_ant_protocol(&data_dir).await?;
+
         Ok(TestNode {
             index,
             node_id,
@@ -599,10 +922,51 @@ impl TestNetwork {
             address,
             data_dir,
             p2p_node: None,
+            ant_protocol: Some(Arc::new(ant_protocol)),
             is_bootstrap,
             state: Arc::new(RwLock::new(NodeState::Pending)),
             bootstrap_addrs,
+            protocol_task: None,
         })
+    }
+
+    /// Create an `AntProtocol` handler for a test node.
+    ///
+    /// Configures:
+    /// - Disk storage with verification enabled
+    /// - Payment verification disabled (for testing without Anvil)
+    /// - Quote generator with a test rewards address
+    async fn create_ant_protocol(data_dir: &std::path::Path) -> Result<AntProtocol> {
+        // Create disk storage
+        let storage_config = DiskStorageConfig {
+            root_dir: data_dir.to_path_buf(),
+            verify_on_read: true,
+            max_chunks: 0, // Unlimited for tests
+        };
+        let storage = DiskStorage::new(storage_config)
+            .await
+            .map_err(|e| TestnetError::Core(format!("Failed to create disk storage: {e}")))?;
+
+        // Create payment verifier with EVM disabled
+        let payment_config = PaymentVerifierConfig {
+            evm: EvmVerifierConfig {
+                enabled: false, // Disable EVM verification for tests
+                ..Default::default()
+            },
+            cache_capacity: TEST_PAYMENT_CACHE_CAPACITY,
+        };
+        let payment_verifier = PaymentVerifier::new(payment_config);
+
+        // Create quote generator with test rewards address
+        let rewards_address = RewardsAddress::new(TEST_REWARDS_ADDRESS);
+        let metrics_tracker = QuotingMetricsTracker::new(TEST_MAX_RECORDS, TEST_INITIAL_RECORDS);
+        let quote_generator = QuoteGenerator::new(rewards_address, metrics_tracker);
+
+        Ok(AntProtocol::new(
+            Arc::new(storage),
+            Arc::new(payment_verifier),
+            Arc::new(quote_generator),
+        ))
     }
 
     /// Start a single node.
@@ -632,6 +996,58 @@ impl TestNetwork {
 
         node.p2p_node = Some(Arc::new(p2p_node));
         *node.state.write().await = NodeState::Running;
+
+        // Start protocol handler that routes incoming P2P messages to AntProtocol
+        if let (Some(ref p2p), Some(ref protocol)) = (&node.p2p_node, &node.ant_protocol) {
+            let mut events = p2p.subscribe_events();
+            let p2p_clone = Arc::clone(p2p);
+            let protocol_clone = Arc::clone(protocol);
+            let node_index = node.index;
+            node.protocol_task = Some(tokio::spawn(async move {
+                while let Ok(event) = events.recv().await {
+                    if let P2PEvent::Message {
+                        topic,
+                        source,
+                        data,
+                    } = event
+                    {
+                        if topic == CHUNK_PROTOCOL_ID {
+                            debug!(
+                                "Node {} received chunk protocol message from {}",
+                                node_index, source
+                            );
+                            let protocol = Arc::clone(&protocol_clone);
+                            let p2p = Arc::clone(&p2p_clone);
+                            tokio::spawn(async move {
+                                match protocol.handle_message(&data).await {
+                                    Ok(response) => {
+                                        if let Err(e) = p2p
+                                            .send_message(
+                                                &source,
+                                                CHUNK_PROTOCOL_ID,
+                                                response.to_vec(),
+                                            )
+                                            .await
+                                        {
+                                            warn!(
+                                                "Node {} failed to send response to {}: {}",
+                                                node_index, source, e
+                                            );
+                                        }
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            "Node {} protocol handler error: {}",
+                                            node_index, e
+                                        );
+                                    }
+                                }
+                            });
+                        }
+                    }
+                }
+            }));
+        }
 
         debug!("Node {} started successfully", node.index);
         self.nodes.push(node);
@@ -749,6 +1165,9 @@ impl TestNetwork {
         // Stop all nodes in reverse order
         for node in self.nodes.iter_mut().rev() {
             debug!("Stopping node {}", node.index);
+            if let Some(handle) = node.protocol_task.take() {
+                handle.abort();
+            }
             if let Some(ref p2p) = node.p2p_node {
                 if let Err(e) = p2p.shutdown().await {
                     warn!("Error shutting down node {}: {}", node.index, e);

--- a/tests/e2e/testnet.rs
+++ b/tests/e2e/testnet.rs
@@ -570,7 +570,7 @@ impl TestNode {
                 TestnetError::Storage(format!("Failed to send PUT to remote node: {e}"))
             })?;
 
-        // Wait for response matching our request_id
+        // Wait for response matching our request_id from the target peer
         let timeout = Duration::from_secs(DEFAULT_CHUNK_OPERATION_TIMEOUT_SECS);
         let deadline = Instant::now() + timeout;
 
@@ -579,9 +579,9 @@ impl TestNode {
             match tokio::time::timeout(remaining, events.recv()).await {
                 Ok(Ok(P2PEvent::Message {
                     topic,
+                    source,
                     data: resp_data,
-                    ..
-                })) if topic == CHUNK_PROTOCOL_ID => {
+                })) if topic == CHUNK_PROTOCOL_ID && source == target_peer_id => {
                     let response = match ChunkMessage::decode(&resp_data) {
                         Ok(r) => r,
                         Err(e) => {
@@ -630,7 +630,7 @@ impl TestNode {
                         _ => {} // Not a PUT response, keep waiting
                     }
                 }
-                Ok(Ok(_)) => {} // Different topic, keep waiting
+                Ok(Ok(_)) => {} // Different topic/source, keep waiting
                 Ok(Err(_)) | Err(_) => break,
             }
         }
@@ -699,7 +699,7 @@ impl TestNode {
                 TestnetError::Retrieval(format!("Failed to send GET to remote node: {e}"))
             })?;
 
-        // Wait for response matching our request_id
+        // Wait for response matching our request_id from the target peer
         let timeout = Duration::from_secs(DEFAULT_CHUNK_OPERATION_TIMEOUT_SECS);
         let deadline = Instant::now() + timeout;
 
@@ -708,9 +708,9 @@ impl TestNode {
             match tokio::time::timeout(remaining, events.recv()).await {
                 Ok(Ok(P2PEvent::Message {
                     topic,
+                    source,
                     data: resp_data,
-                    ..
-                })) if topic == CHUNK_PROTOCOL_ID => {
+                })) if topic == CHUNK_PROTOCOL_ID && source == target_peer_id => {
                     let response = match ChunkMessage::decode(&resp_data) {
                         Ok(r) => r,
                         Err(e) => {
@@ -754,7 +754,7 @@ impl TestNode {
                         _ => {} // Not a GET response, keep waiting
                     }
                 }
-                Ok(Ok(_)) => {} // Different topic, keep waiting
+                Ok(Ok(_)) => {} // Different topic/source, keep waiting
                 Ok(Err(_)) | Err(_) => break,
             }
         }

--- a/tests/e2e/testnet.rs
+++ b/tests/e2e/testnet.rs
@@ -582,9 +582,13 @@ impl TestNode {
                     data: resp_data,
                     ..
                 })) if topic == CHUNK_PROTOCOL_ID => {
-                    let response = ChunkMessage::decode(&resp_data).map_err(|e| {
-                        TestnetError::Storage(format!("Failed to decode PUT response: {e}"))
-                    })?;
+                    let response = match ChunkMessage::decode(&resp_data) {
+                        Ok(r) => r,
+                        Err(e) => {
+                            warn!("Failed to decode chunk message, skipping: {e}");
+                            continue;
+                        }
+                    };
                     if response.request_id != request_id {
                         continue; // Not our response, keep waiting
                     }
@@ -707,9 +711,13 @@ impl TestNode {
                     data: resp_data,
                     ..
                 })) if topic == CHUNK_PROTOCOL_ID => {
-                    let response = ChunkMessage::decode(&resp_data).map_err(|e| {
-                        TestnetError::Retrieval(format!("Failed to decode GET response: {e}"))
-                    })?;
+                    let response = match ChunkMessage::decode(&resp_data) {
+                        Ok(r) => r,
+                        Err(e) => {
+                            warn!("Failed to decode chunk message, skipping: {e}");
+                            continue;
+                        }
+                    };
                     if response.request_id != request_id {
                         continue; // Not our response, keep waiting
                     }

--- a/tests/e2e/testnet.rs
+++ b/tests/e2e/testnet.rs
@@ -517,7 +517,9 @@ impl TestNode {
             .p2p_node
             .as_ref()
             .ok_or(TestnetError::NodeNotRunning)?;
-        let target_peer_id = target_p2p.peer_id().clone();
+        let target_peer_id = target_p2p
+            .transport_peer_id()
+            .ok_or_else(|| TestnetError::Core("No transport peer ID available".to_string()))?;
         self.store_chunk_on_peer(&target_peer_id, data).await
     }
 
@@ -635,7 +637,9 @@ impl TestNode {
             .p2p_node
             .as_ref()
             .ok_or(TestnetError::NodeNotRunning)?;
-        let target_peer_id = target_p2p.peer_id().clone();
+        let target_peer_id = target_p2p
+            .transport_peer_id()
+            .ok_or_else(|| TestnetError::Core("No transport peer ID available".to_string()))?;
         self.get_chunk_from_peer(&target_peer_id, address).await
     }
 


### PR DESCRIPTION
## Summary

- **Chunk protocol** (`ant_protocol::chunk`): bincode-serialized wire protocol for PUT/GET/Quote operations with content-addressed chunks (SHA256, max 4MB)
- **Disk storage** (`storage::disk`): content-addressed persistence with two-level sharded directories and atomic writes
- **Protocol handler** (`storage::handler`): `AntProtocol` handler that routes incoming chunk messages through payment verification and disk storage
- **Protocol routing** in `RunningNode`: subscribes to P2P events and dispatches chunk protocol messages to `AntProtocol`, sending responses back over P2P
- **Cross-node e2e test**: node 3 sends `ChunkPutRequest`/`ChunkGetRequest` to a random connected peer and verifies the round-trip
- **Node-to-node messaging e2e test**: validates the fundamental `send_message`/`subscribe_events` layer with proper timeout handling and clean teardown
- **Code quality**: clippy, fmt, DRY fixes, deduplicated `XorName`, stale doc corrections

## Dependencies

> **Requires [saorsa-labs/saorsa-core#11](https://github.com/saorsa-labs/saorsa-core/pull/11) to be merged first** and the `saorsa-core` dependency version bumped in `Cargo.toml` before this PR can land. That PR adds `DualStackNetworkNode::shutdown_endpoints()` and fixes `P2PNode::stop()` to call it, which is needed for clean test teardown. It also includes a fix in ant-quic where `P2pEndpoint::recv()` now respects the cancellation token via `tokio::select!`.

## Test plan

- [x] `cargo test` — 174 tests pass (132 lib + 41 e2e + 1 doctest), 0 failures
- [x] `cargo test test_node_to_node_messaging -- --ignored` — passes in ~26s with clean teardown
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)