### PR TITLE
feat: add devnet runner and client CLI binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,14 @@ path = "src/bin/saorsa-node/main.rs"
 name = "saorsa-keygen"
 path = "src/bin/keygen.rs"
 
+[[bin]]
+name = "saorsa-devnet"
+path = "src/bin/saorsa-devnet/main.rs"
+
+[[bin]]
+name = "saorsa-client"
+path = "src/bin/saorsa-client/main.rs"
+
 [dependencies]
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
 saorsa-core = "0.10.2"
@@ -73,6 +81,8 @@ hex = "0.4"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3"
+rand = "0.8"
+serde_json = "1"
 
 # Archive extraction for auto-upgrade
 flate2 = "1"
@@ -84,8 +94,6 @@ bincode = "1"
 [dev-dependencies]
 tokio-test = "0.4"
 proptest = "1"
-serde_json = "1"
-rand = "0.8"
 
 # E2E test infrastructure
 [[test]]

--- a/src/bin/saorsa-client/cli.rs
+++ b/src/bin/saorsa-client/cli.rs
@@ -1,0 +1,50 @@
+//! CLI definition for saorsa-client.
+
+use clap::{Parser, Subcommand};
+use std::net::SocketAddr;
+use std::path::PathBuf;
+
+/// Client CLI for chunk operations.
+#[derive(Parser, Debug)]
+#[command(name = "saorsa-client")]
+#[command(author, version, about, long_about = None)]
+pub struct Cli {
+    /// Bootstrap peer addresses.
+    #[arg(long, short)]
+    pub bootstrap: Vec<SocketAddr>,
+
+    /// Path to devnet manifest JSON (output of saorsa-devnet).
+    #[arg(long)]
+    pub devnet_manifest: Option<PathBuf>,
+
+    /// Timeout for network operations (seconds).
+    #[arg(long, default_value_t = 30)]
+    pub timeout_secs: u64,
+
+    /// Log level for client process.
+    #[arg(long, default_value = "info")]
+    pub log_level: String,
+
+    /// Command to run.
+    #[command(subcommand)]
+    pub command: ClientCommand,
+}
+
+/// Client commands.
+#[derive(Subcommand, Debug)]
+pub enum ClientCommand {
+    /// Put a chunk. Reads from --file or stdin.
+    Put {
+        /// Input file (defaults to stdin if omitted).
+        #[arg(long)]
+        file: Option<PathBuf>,
+    },
+    /// Get a chunk. Writes to --out or stdout.
+    Get {
+        /// Hex-encoded chunk address (64 hex chars).
+        address: String,
+        /// Output file (defaults to stdout if omitted).
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
+}

--- a/src/bin/saorsa-client/main.rs
+++ b/src/bin/saorsa-client/main.rs
@@ -1,0 +1,141 @@
+//! saorsa-client CLI entry point.
+
+mod cli;
+
+use bytes::Bytes;
+use clap::Parser;
+use cli::{Cli, ClientCommand};
+use saorsa_core::P2PNode;
+use saorsa_node::client::{QuantumClient, QuantumConfig, XorName};
+use saorsa_node::devnet::DevnetManifest;
+use saorsa_node::error::Error;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tracing::info;
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+/// Length of an `XorName` address in bytes.
+const XORNAME_BYTE_LEN: usize = 32;
+
+/// Default replica count for client chunk operations.
+const DEFAULT_CLIENT_REPLICA_COUNT: u8 = 1;
+
+#[tokio::main]
+async fn main() -> color_eyre::Result<()> {
+    color_eyre::install()?;
+
+    let cli = Cli::parse();
+
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(&cli.log_level));
+
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(filter)
+        .init();
+
+    info!("saorsa-client v{}", env!("CARGO_PKG_VERSION"));
+
+    let bootstrap = resolve_bootstrap(&cli)?;
+    let node = create_client_node(bootstrap).await?;
+    let client = QuantumClient::new(QuantumConfig {
+        timeout_secs: cli.timeout_secs,
+        replica_count: DEFAULT_CLIENT_REPLICA_COUNT,
+        encrypt_data: false,
+    })
+    .with_node(node);
+
+    match cli.command {
+        ClientCommand::Put { file } => {
+            let content = read_input(file)?;
+            let address = client.put_chunk(Bytes::from(content)).await?;
+            println!("{}", hex::encode(address));
+        }
+        ClientCommand::Get { address, out } => {
+            let addr = parse_address(&address)?;
+            let result = client.get_chunk(&addr).await?;
+            match result {
+                Some(chunk) => write_output(&chunk.content, out)?,
+                None => {
+                    return Err(color_eyre::eyre::eyre!(
+                        "Chunk not found for address {address}"
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn resolve_bootstrap(cli: &Cli) -> color_eyre::Result<Vec<std::net::SocketAddr>> {
+    if !cli.bootstrap.is_empty() {
+        return Ok(cli.bootstrap.clone());
+    }
+
+    if let Some(ref manifest_path) = cli.devnet_manifest {
+        let data = std::fs::read_to_string(manifest_path)?;
+        let manifest: DevnetManifest = serde_json::from_str(&data)?;
+        return Ok(manifest.bootstrap);
+    }
+
+    Err(color_eyre::eyre::eyre!(
+        "No bootstrap peers provided. Use --bootstrap or --devnet-manifest."
+    ))
+}
+
+async fn create_client_node(bootstrap: Vec<std::net::SocketAddr>) -> Result<Arc<P2PNode>, Error> {
+    let mut core_config = saorsa_core::NodeConfig::new()
+        .map_err(|e| Error::Config(format!("Failed to create core config: {e}")))?;
+    core_config.listen_addr = "0.0.0.0:0"
+        .parse()
+        .map_err(|e| Error::Config(format!("Invalid listen addr: {e}")))?;
+    core_config.listen_addrs = vec![core_config.listen_addr];
+    core_config.enable_ipv6 = false;
+    core_config.bootstrap_peers = bootstrap;
+
+    let node = P2PNode::new(core_config)
+        .await
+        .map_err(|e| Error::Network(format!("Failed to create P2P node: {e}")))?;
+    node.start()
+        .await
+        .map_err(|e| Error::Network(format!("Failed to start P2P node: {e}")))?;
+
+    Ok(Arc::new(node))
+}
+
+fn parse_address(address: &str) -> color_eyre::Result<XorName> {
+    let bytes = hex::decode(address)?;
+    if bytes.len() != XORNAME_BYTE_LEN {
+        return Err(color_eyre::eyre::eyre!(
+            "Invalid address length: expected {} bytes, got {}",
+            XORNAME_BYTE_LEN,
+            bytes.len()
+        ));
+    }
+    let mut out = [0u8; XORNAME_BYTE_LEN];
+    out.copy_from_slice(&bytes);
+    Ok(out)
+}
+
+fn read_input(file: Option<PathBuf>) -> color_eyre::Result<Vec<u8>> {
+    if let Some(path) = file {
+        return Ok(std::fs::read(path)?);
+    }
+
+    let mut buf = Vec::new();
+    std::io::stdin().read_to_end(&mut buf)?;
+    Ok(buf)
+}
+
+fn write_output(content: &Bytes, out: Option<PathBuf>) -> color_eyre::Result<()> {
+    if let Some(path) = out {
+        std::fs::write(path, content)?;
+        return Ok(());
+    }
+
+    let mut stdout = std::io::stdout();
+    stdout.write_all(content)?;
+    Ok(())
+}

--- a/src/bin/saorsa-devnet/cli.rs
+++ b/src/bin/saorsa-devnet/cli.rs
@@ -1,0 +1,50 @@
+//! CLI definition for saorsa-devnet.
+
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Local devnet runner for saorsa-node.
+#[derive(Parser, Debug)]
+#[command(name = "saorsa-devnet")]
+#[command(author, version, about, long_about = None)]
+pub struct Cli {
+    /// Node count to spawn.
+    #[arg(long)]
+    pub nodes: Option<usize>,
+
+    /// Bootstrap node count (first N nodes).
+    #[arg(long)]
+    pub bootstrap_count: Option<usize>,
+
+    /// Base port for node allocation (0 for auto).
+    #[arg(long)]
+    pub base_port: Option<u16>,
+
+    /// Data directory for node state.
+    #[arg(long)]
+    pub data_dir: Option<PathBuf>,
+
+    /// Remove data directory on shutdown.
+    #[arg(long, default_value_t = true)]
+    pub cleanup: bool,
+
+    /// Spawn delay in milliseconds.
+    #[arg(long)]
+    pub spawn_delay_ms: Option<u64>,
+
+    /// Stabilization timeout in seconds.
+    #[arg(long)]
+    pub stabilization_timeout_secs: Option<u64>,
+
+    /// Preset: minimal, small, default.
+    #[arg(long)]
+    pub preset: Option<String>,
+
+    /// Path to write a devnet manifest JSON.
+    #[arg(long)]
+    pub manifest: Option<PathBuf>,
+
+    /// Log level for devnet process.
+    #[arg(long, default_value = "info")]
+    pub log_level: String,
+}

--- a/src/bin/saorsa-devnet/main.rs
+++ b/src/bin/saorsa-devnet/main.rs
@@ -1,0 +1,80 @@
+//! saorsa-devnet CLI entry point.
+
+mod cli;
+
+use clap::Parser;
+use cli::Cli;
+use saorsa_node::devnet::{Devnet, DevnetConfig, DevnetManifest};
+use tracing::info;
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+#[tokio::main]
+async fn main() -> color_eyre::Result<()> {
+    color_eyre::install()?;
+
+    let cli = Cli::parse();
+
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(&cli.log_level));
+
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(filter)
+        .init();
+
+    info!("saorsa-devnet v{}", env!("CARGO_PKG_VERSION"));
+
+    let mut config =
+        cli.preset
+            .as_deref()
+            .map_or_else(DevnetConfig::default, |preset| match preset {
+                "minimal" => DevnetConfig::minimal(),
+                "small" => DevnetConfig::small(),
+                _ => DevnetConfig::default(),
+            });
+
+    if let Some(count) = cli.nodes {
+        config.node_count = count;
+    }
+    if let Some(bootstrap) = cli.bootstrap_count {
+        config.bootstrap_count = bootstrap;
+    }
+    if let Some(base_port) = cli.base_port {
+        config.base_port = base_port;
+    }
+    if let Some(dir) = cli.data_dir {
+        config.data_dir = dir;
+    }
+    config.cleanup_data_dir = cli.cleanup;
+    if let Some(delay_ms) = cli.spawn_delay_ms {
+        config.spawn_delay = std::time::Duration::from_millis(delay_ms);
+    }
+    if let Some(timeout_secs) = cli.stabilization_timeout_secs {
+        config.stabilization_timeout = std::time::Duration::from_secs(timeout_secs);
+    }
+
+    let mut devnet = Devnet::new(config).await?;
+    devnet.start().await?;
+
+    let manifest = DevnetManifest {
+        base_port: devnet.config().base_port,
+        node_count: devnet.config().node_count,
+        bootstrap: devnet.bootstrap_addrs(),
+        data_dir: devnet.config().data_dir.clone(),
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+
+    let json = serde_json::to_string_pretty(&manifest)?;
+    if let Some(path) = cli.manifest {
+        tokio::fs::write(&path, &json).await?;
+        info!("Wrote manifest to {}", path.display());
+    } else {
+        println!("{json}");
+    }
+
+    info!("Devnet running. Press Ctrl+C to stop.");
+    tokio::signal::ctrl_c().await?;
+
+    devnet.shutdown().await?;
+    Ok(())
+}

--- a/src/devnet.rs
+++ b/src/devnet.rs
@@ -1,0 +1,727 @@
+//! Local devnet infrastructure for spawning and managing multiple nodes.
+//!
+//! This module provides a local, in-process devnet suitable for running
+//! multi-node networks on a single machine.
+
+use crate::ant_protocol::CHUNK_PROTOCOL_ID;
+use crate::payment::{
+    EvmVerifierConfig, PaymentVerifier, PaymentVerifierConfig, QuoteGenerator,
+    QuotingMetricsTracker,
+};
+use crate::storage::{AntProtocol, DiskStorage, DiskStorageConfig};
+use ant_evm::RewardsAddress;
+use rand::Rng;
+use saorsa_core::{NodeConfig as CoreNodeConfig, P2PEvent, P2PNode};
+use serde::{Deserialize, Serialize};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{broadcast, RwLock};
+use tokio::task::JoinHandle;
+use tokio::time::Instant;
+use tracing::{debug, info, warn};
+
+// =============================================================================
+// Devnet Constants
+// =============================================================================
+
+/// Minimum port for random devnet allocation.
+pub const DEVNET_PORT_RANGE_MIN: u16 = 20_000;
+
+/// Maximum port for random devnet allocation.
+pub const DEVNET_PORT_RANGE_MAX: u16 = 60_000;
+
+/// Maximum nodes supported in a devnet.
+pub const MAX_DEVNET_NODE_COUNT: usize = 1000;
+
+// =============================================================================
+// Default Timing Constants
+// =============================================================================
+
+/// Default delay between spawning nodes (milliseconds).
+const DEFAULT_SPAWN_DELAY_MS: u64 = 200;
+
+/// Default timeout for network stabilization (seconds).
+const DEFAULT_STABILIZATION_TIMEOUT_SECS: u64 = 120;
+
+/// Default timeout for single node startup (seconds).
+const DEFAULT_NODE_STARTUP_TIMEOUT_SECS: u64 = 30;
+
+/// Stabilization timeout for minimal network (seconds).
+const MINIMAL_STABILIZATION_TIMEOUT_SECS: u64 = 30;
+
+/// Stabilization timeout for small network (seconds).
+const SMALL_STABILIZATION_TIMEOUT_SECS: u64 = 60;
+
+/// Polling interval when waiting for individual nodes to become ready (milliseconds).
+const NODE_READY_POLL_INTERVAL_MS: u64 = 100;
+
+/// Polling interval when waiting for network stabilization (seconds).
+const STABILIZATION_POLL_INTERVAL_SECS: u64 = 1;
+
+/// Maximum minimum connections required per node during stabilization.
+const STABILIZATION_MIN_CONNECTIONS_CAP: usize = 3;
+
+/// Health monitor check interval (seconds).
+const HEALTH_CHECK_INTERVAL_SECS: u64 = 5;
+
+/// Shutdown broadcast channel capacity.
+const SHUTDOWN_CHANNEL_CAPACITY: usize = 1;
+
+// =============================================================================
+// AntProtocol Devnet Configuration
+// =============================================================================
+
+/// Payment cache capacity for devnet nodes.
+const DEVNET_PAYMENT_CACHE_CAPACITY: usize = 1000;
+
+/// Devnet rewards address (20 bytes, all 0x01).
+const DEVNET_REWARDS_ADDRESS: [u8; 20] = [0x01; 20];
+
+/// Max records for quoting metrics (devnet value).
+const DEVNET_MAX_RECORDS: usize = 100_000;
+
+/// Initial records for quoting metrics (devnet value).
+const DEVNET_INITIAL_RECORDS: usize = 1000;
+
+// =============================================================================
+// Default Node Counts
+// =============================================================================
+
+/// Default number of nodes in a full devnet.
+pub const DEFAULT_NODE_COUNT: usize = 25;
+
+/// Default number of bootstrap nodes.
+pub const DEFAULT_BOOTSTRAP_COUNT: usize = 3;
+
+/// Number of nodes in a minimal devnet.
+pub const MINIMAL_NODE_COUNT: usize = 5;
+
+/// Number of bootstrap nodes in a minimal network.
+pub const MINIMAL_BOOTSTRAP_COUNT: usize = 2;
+
+/// Number of nodes in a small devnet.
+pub const SMALL_NODE_COUNT: usize = 10;
+
+/// Error type for devnet operations.
+#[derive(Debug, thiserror::Error)]
+pub enum DevnetError {
+    /// Configuration error
+    #[error("Configuration error: {0}")]
+    Config(String),
+
+    /// Node startup error
+    #[error("Node startup error: {0}")]
+    Startup(String),
+
+    /// Network stabilization error
+    #[error("Network stabilization error: {0}")]
+    Stabilization(String),
+
+    /// IO error
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Core error
+    #[error("Core error: {0}")]
+    Core(String),
+}
+
+/// Result type for devnet operations.
+pub type Result<T> = std::result::Result<T, DevnetError>;
+
+/// Configuration for the devnet.
+///
+/// Each configuration is automatically isolated with unique ports and
+/// data directories to prevent collisions when running multiple devnets.
+#[derive(Debug, Clone)]
+pub struct DevnetConfig {
+    /// Number of nodes to spawn (default: 25).
+    pub node_count: usize,
+
+    /// Base port for node allocation (0 = auto).
+    pub base_port: u16,
+
+    /// Number of bootstrap nodes (first N nodes, default: 3).
+    pub bootstrap_count: usize,
+
+    /// Root directory for devnet data.
+    pub data_dir: PathBuf,
+
+    /// Delay between node spawns (default: 200ms).
+    pub spawn_delay: Duration,
+
+    /// Timeout for network stabilization (default: 120s).
+    pub stabilization_timeout: Duration,
+
+    /// Timeout for single node startup (default: 30s).
+    pub node_startup_timeout: Duration,
+
+    /// Enable verbose logging for devnet nodes.
+    pub enable_node_logging: bool,
+
+    /// Whether to remove the data directory on shutdown.
+    pub cleanup_data_dir: bool,
+}
+
+impl Default for DevnetConfig {
+    fn default() -> Self {
+        let mut rng = rand::thread_rng();
+
+        #[allow(clippy::cast_possible_truncation)] // DEFAULT_NODE_COUNT is 25, always fits u16
+        let max_base_port = DEVNET_PORT_RANGE_MAX.saturating_sub(DEFAULT_NODE_COUNT as u16);
+        let base_port = rng.gen_range(DEVNET_PORT_RANGE_MIN..max_base_port);
+
+        let suffix: u64 = rng.gen();
+        let data_dir = std::env::temp_dir().join(format!("saorsa_devnet_{suffix:x}"));
+
+        Self {
+            node_count: DEFAULT_NODE_COUNT,
+            base_port,
+            bootstrap_count: DEFAULT_BOOTSTRAP_COUNT,
+            data_dir,
+            spawn_delay: Duration::from_millis(DEFAULT_SPAWN_DELAY_MS),
+            stabilization_timeout: Duration::from_secs(DEFAULT_STABILIZATION_TIMEOUT_SECS),
+            node_startup_timeout: Duration::from_secs(DEFAULT_NODE_STARTUP_TIMEOUT_SECS),
+            enable_node_logging: false,
+            cleanup_data_dir: true,
+        }
+    }
+}
+
+impl DevnetConfig {
+    /// Minimal devnet preset (5 nodes).
+    #[must_use]
+    pub fn minimal() -> Self {
+        Self {
+            node_count: MINIMAL_NODE_COUNT,
+            bootstrap_count: MINIMAL_BOOTSTRAP_COUNT,
+            stabilization_timeout: Duration::from_secs(MINIMAL_STABILIZATION_TIMEOUT_SECS),
+            ..Self::default()
+        }
+    }
+
+    /// Small devnet preset (10 nodes).
+    #[must_use]
+    pub fn small() -> Self {
+        Self {
+            node_count: SMALL_NODE_COUNT,
+            bootstrap_count: MINIMAL_BOOTSTRAP_COUNT,
+            stabilization_timeout: Duration::from_secs(SMALL_STABILIZATION_TIMEOUT_SECS),
+            ..Self::default()
+        }
+    }
+}
+
+/// Devnet manifest for client discovery.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DevnetManifest {
+    /// Base port for nodes.
+    pub base_port: u16,
+    /// Node count.
+    pub node_count: usize,
+    /// Bootstrap addresses.
+    pub bootstrap: Vec<SocketAddr>,
+    /// Data directory.
+    pub data_dir: PathBuf,
+    /// Creation time in RFC3339.
+    pub created_at: String,
+}
+
+/// Network state for devnet startup lifecycle.
+#[derive(Debug, Clone)]
+pub enum NetworkState {
+    /// Not started.
+    Uninitialized,
+    /// Bootstrapping nodes are starting.
+    BootstrappingPhase,
+    /// Regular nodes are starting.
+    NodeSpawningPhase,
+    /// Waiting for stabilization.
+    Stabilizing,
+    /// Network is ready.
+    Ready,
+    /// Shutting down.
+    ShuttingDown,
+    /// Stopped.
+    Stopped,
+}
+
+/// Node state for devnet nodes.
+#[derive(Debug, Clone)]
+pub enum NodeState {
+    /// Not started yet.
+    Pending,
+    /// Starting up.
+    Starting,
+    /// Running.
+    Running,
+    /// Connected to peers.
+    Connected,
+    /// Stopped.
+    Stopped,
+    /// Failed to start.
+    Failed(String),
+}
+
+/// A single devnet node instance.
+#[allow(dead_code)]
+pub struct DevnetNode {
+    index: usize,
+    node_id: String,
+    port: u16,
+    address: SocketAddr,
+    data_dir: PathBuf,
+    p2p_node: Option<Arc<P2PNode>>,
+    ant_protocol: Option<Arc<AntProtocol>>,
+    is_bootstrap: bool,
+    state: Arc<RwLock<NodeState>>,
+    bootstrap_addrs: Vec<SocketAddr>,
+    protocol_task: Option<JoinHandle<()>>,
+}
+
+impl DevnetNode {
+    /// Get the node's peer count.
+    pub async fn peer_count(&self) -> usize {
+        if let Some(ref node) = self.p2p_node {
+            node.peer_count().await
+        } else {
+            0
+        }
+    }
+}
+
+/// A local devnet composed of multiple nodes.
+pub struct Devnet {
+    config: DevnetConfig,
+    nodes: Vec<DevnetNode>,
+    shutdown_tx: broadcast::Sender<()>,
+    state: Arc<RwLock<NetworkState>>,
+    health_monitor: Option<JoinHandle<()>>,
+}
+
+impl Devnet {
+    /// Create a new devnet with the given configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DevnetError::Config` if the configuration is invalid (e.g. bootstrap
+    /// count exceeds node count, port range overflow, or node count exceeds maximum).
+    /// Returns `DevnetError::Io` if the data directory cannot be created.
+    pub async fn new(mut config: DevnetConfig) -> Result<Self> {
+        if config.bootstrap_count >= config.node_count {
+            return Err(DevnetError::Config(
+                "Bootstrap count must be less than node count".to_string(),
+            ));
+        }
+
+        if config.bootstrap_count == 0 {
+            return Err(DevnetError::Config(
+                "At least one bootstrap node is required".to_string(),
+            ));
+        }
+
+        if config.node_count > MAX_DEVNET_NODE_COUNT {
+            return Err(DevnetError::Config(format!(
+                "Node count {} exceeds maximum {}",
+                config.node_count, MAX_DEVNET_NODE_COUNT
+            )));
+        }
+
+        if config.base_port == 0 {
+            let mut rng = rand::thread_rng();
+            // node_count is validated <= MAX_DEVNET_NODE_COUNT (1000) above, fits u16
+            #[allow(clippy::cast_possible_truncation)]
+            let max_base_port = DEVNET_PORT_RANGE_MAX.saturating_sub(config.node_count as u16);
+            config.base_port = rng.gen_range(DEVNET_PORT_RANGE_MIN..max_base_port);
+        }
+
+        let node_count_u16 = u16::try_from(config.node_count).map_err(|_| {
+            DevnetError::Config(format!("Node count {} exceeds u16::MAX", config.node_count))
+        })?;
+        let max_port = config
+            .base_port
+            .checked_add(node_count_u16)
+            .ok_or_else(|| {
+                DevnetError::Config(format!(
+                    "Port range overflow: base_port {} + node_count {} exceeds u16::MAX",
+                    config.base_port, config.node_count
+                ))
+            })?;
+        if max_port > DEVNET_PORT_RANGE_MAX {
+            return Err(DevnetError::Config(format!(
+                "Port range overflow: max port {max_port} exceeds DEVNET_PORT_RANGE_MAX {DEVNET_PORT_RANGE_MAX}"
+            )));
+        }
+
+        tokio::fs::create_dir_all(&config.data_dir).await?;
+
+        let (shutdown_tx, _) = broadcast::channel(SHUTDOWN_CHANNEL_CAPACITY);
+
+        Ok(Self {
+            config,
+            nodes: Vec::new(),
+            shutdown_tx,
+            state: Arc::new(RwLock::new(NetworkState::Uninitialized)),
+            health_monitor: None,
+        })
+    }
+
+    /// Start the devnet.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DevnetError::Startup` if any node fails to start, or
+    /// `DevnetError::Stabilization` if the network does not stabilize within the timeout.
+    pub async fn start(&mut self) -> Result<()> {
+        info!(
+            "Starting devnet with {} nodes ({} bootstrap)",
+            self.config.node_count, self.config.bootstrap_count
+        );
+
+        *self.state.write().await = NetworkState::BootstrappingPhase;
+        self.start_bootstrap_nodes().await?;
+
+        *self.state.write().await = NetworkState::NodeSpawningPhase;
+        self.start_regular_nodes().await?;
+
+        *self.state.write().await = NetworkState::Stabilizing;
+        self.wait_for_stabilization().await?;
+
+        self.start_health_monitor();
+
+        *self.state.write().await = NetworkState::Ready;
+        info!("Devnet is ready");
+        Ok(())
+    }
+
+    /// Shutdown the devnet.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DevnetError::Io` if the data directory cleanup fails.
+    pub async fn shutdown(&mut self) -> Result<()> {
+        info!("Shutting down devnet");
+        *self.state.write().await = NetworkState::ShuttingDown;
+
+        let _ = self.shutdown_tx.send(());
+
+        if let Some(handle) = self.health_monitor.take() {
+            handle.abort();
+        }
+
+        for node in self.nodes.iter_mut().rev() {
+            debug!("Stopping node {}", node.index);
+            if let Some(handle) = node.protocol_task.take() {
+                handle.abort();
+            }
+            if let Some(ref p2p) = node.p2p_node {
+                if let Err(e) = p2p.shutdown().await {
+                    warn!("Error shutting down node {}: {}", node.index, e);
+                }
+            }
+            *node.state.write().await = NodeState::Stopped;
+        }
+
+        if self.config.cleanup_data_dir {
+            if let Err(e) = tokio::fs::remove_dir_all(&self.config.data_dir).await {
+                warn!("Failed to cleanup devnet data directory: {}", e);
+            }
+        }
+
+        *self.state.write().await = NetworkState::Stopped;
+        info!("Devnet shutdown complete");
+        Ok(())
+    }
+
+    /// Get devnet configuration.
+    #[must_use]
+    pub fn config(&self) -> &DevnetConfig {
+        &self.config
+    }
+
+    /// Get bootstrap addresses.
+    #[must_use]
+    pub fn bootstrap_addrs(&self) -> Vec<SocketAddr> {
+        self.nodes
+            .iter()
+            .take(self.config.bootstrap_count)
+            .map(|n| n.address)
+            .collect()
+    }
+
+    async fn start_bootstrap_nodes(&mut self) -> Result<()> {
+        info!("Starting {} bootstrap nodes", self.config.bootstrap_count);
+
+        for i in 0..self.config.bootstrap_count {
+            let node = self.create_node(i, true, vec![]).await?;
+            self.start_node(node).await?;
+            tokio::time::sleep(self.config.spawn_delay).await;
+        }
+
+        self.wait_for_nodes_ready(0..self.config.bootstrap_count)
+            .await?;
+
+        info!("All bootstrap nodes are ready");
+        Ok(())
+    }
+
+    async fn start_regular_nodes(&mut self) -> Result<()> {
+        let regular_count = self.config.node_count - self.config.bootstrap_count;
+        info!("Starting {} regular nodes", regular_count);
+
+        let bootstrap_addrs: Vec<SocketAddr> = self.nodes[0..self.config.bootstrap_count]
+            .iter()
+            .map(|n| n.address)
+            .collect();
+
+        for i in self.config.bootstrap_count..self.config.node_count {
+            let node = self.create_node(i, false, bootstrap_addrs.clone()).await?;
+            self.start_node(node).await?;
+            tokio::time::sleep(self.config.spawn_delay).await;
+        }
+
+        info!("All regular nodes started");
+        Ok(())
+    }
+
+    async fn create_node(
+        &self,
+        index: usize,
+        is_bootstrap: bool,
+        bootstrap_addrs: Vec<SocketAddr>,
+    ) -> Result<DevnetNode> {
+        let index_u16 = u16::try_from(index)
+            .map_err(|_| DevnetError::Config(format!("Node index {index} exceeds u16::MAX")))?;
+        let port = self.config.base_port + index_u16;
+        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+        let node_id = format!("devnet_node_{index}");
+        let data_dir = self.config.data_dir.join(&node_id);
+
+        tokio::fs::create_dir_all(&data_dir).await?;
+
+        let ant_protocol = Self::create_ant_protocol(&data_dir).await?;
+
+        Ok(DevnetNode {
+            index,
+            node_id,
+            port,
+            address,
+            data_dir,
+            p2p_node: None,
+            ant_protocol: Some(Arc::new(ant_protocol)),
+            is_bootstrap,
+            state: Arc::new(RwLock::new(NodeState::Pending)),
+            bootstrap_addrs,
+            protocol_task: None,
+        })
+    }
+
+    async fn create_ant_protocol(data_dir: &std::path::Path) -> Result<AntProtocol> {
+        let storage_config = DiskStorageConfig {
+            root_dir: data_dir.to_path_buf(),
+            verify_on_read: true,
+            max_chunks: 0,
+        };
+        let storage = DiskStorage::new(storage_config)
+            .await
+            .map_err(|e| DevnetError::Core(format!("Failed to create disk storage: {e}")))?;
+
+        let payment_config = PaymentVerifierConfig {
+            evm: EvmVerifierConfig {
+                enabled: false,
+                ..Default::default()
+            },
+            cache_capacity: DEVNET_PAYMENT_CACHE_CAPACITY,
+        };
+        let payment_verifier = PaymentVerifier::new(payment_config);
+
+        let rewards_address = RewardsAddress::new(DEVNET_REWARDS_ADDRESS);
+        let metrics_tracker =
+            QuotingMetricsTracker::new(DEVNET_MAX_RECORDS, DEVNET_INITIAL_RECORDS);
+        let quote_generator = QuoteGenerator::new(rewards_address, metrics_tracker);
+
+        Ok(AntProtocol::new(
+            Arc::new(storage),
+            Arc::new(payment_verifier),
+            Arc::new(quote_generator),
+        ))
+    }
+
+    async fn start_node(&mut self, mut node: DevnetNode) -> Result<()> {
+        debug!("Starting node {} on port {}", node.index, node.port);
+        *node.state.write().await = NodeState::Starting;
+
+        let mut core_config = CoreNodeConfig::new()
+            .map_err(|e| DevnetError::Core(format!("Failed to create core config: {e}")))?;
+
+        core_config.listen_addr = node.address;
+        core_config.listen_addrs = vec![node.address];
+        core_config.enable_ipv6 = false;
+        core_config
+            .bootstrap_peers
+            .clone_from(&node.bootstrap_addrs);
+
+        let p2p_node = P2PNode::new(core_config).await.map_err(|e| {
+            DevnetError::Startup(format!("Failed to create node {}: {e}", node.index))
+        })?;
+
+        p2p_node.start().await.map_err(|e| {
+            DevnetError::Startup(format!("Failed to start node {}: {e}", node.index))
+        })?;
+
+        node.p2p_node = Some(Arc::new(p2p_node));
+        *node.state.write().await = NodeState::Running;
+
+        if let (Some(ref p2p), Some(ref protocol)) = (&node.p2p_node, &node.ant_protocol) {
+            let mut events = p2p.subscribe_events();
+            let p2p_clone = Arc::clone(p2p);
+            let protocol_clone = Arc::clone(protocol);
+            let node_index = node.index;
+            node.protocol_task = Some(tokio::spawn(async move {
+                while let Ok(event) = events.recv().await {
+                    if let P2PEvent::Message {
+                        topic,
+                        source,
+                        data,
+                    } = event
+                    {
+                        if topic == CHUNK_PROTOCOL_ID {
+                            debug!(
+                                "Node {} received chunk protocol message from {}",
+                                node_index, source
+                            );
+                            let protocol = Arc::clone(&protocol_clone);
+                            let p2p = Arc::clone(&p2p_clone);
+                            tokio::spawn(async move {
+                                match protocol.handle_message(&data).await {
+                                    Ok(response) => {
+                                        if let Err(e) = p2p
+                                            .send_message(
+                                                &source,
+                                                CHUNK_PROTOCOL_ID,
+                                                response.to_vec(),
+                                            )
+                                            .await
+                                        {
+                                            warn!(
+                                                "Node {} failed to send response to {}: {}",
+                                                node_index, source, e
+                                            );
+                                        }
+                                    }
+                                    Err(e) => {
+                                        warn!("Node {} protocol handler error: {}", node_index, e);
+                                    }
+                                }
+                            });
+                        }
+                    }
+                }
+            }));
+        }
+
+        debug!("Node {} started successfully", node.index);
+        self.nodes.push(node);
+        Ok(())
+    }
+
+    async fn wait_for_nodes_ready(&self, range: std::ops::Range<usize>) -> Result<()> {
+        let deadline = Instant::now() + self.config.node_startup_timeout;
+
+        for i in range {
+            while Instant::now() < deadline {
+                let state = self.nodes[i].state.read().await.clone();
+                match state {
+                    NodeState::Running | NodeState::Connected => break,
+                    NodeState::Failed(ref e) => {
+                        return Err(DevnetError::Startup(format!("Node {i} failed: {e}")));
+                    }
+                    _ => {
+                        tokio::time::sleep(Duration::from_millis(NODE_READY_POLL_INTERVAL_MS))
+                            .await;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn wait_for_stabilization(&self) -> Result<()> {
+        let deadline = Instant::now() + self.config.stabilization_timeout;
+        let min_connections = self
+            .config
+            .bootstrap_count
+            .min(STABILIZATION_MIN_CONNECTIONS_CAP);
+
+        info!(
+            "Waiting for devnet stabilization (min {} connections per node)",
+            min_connections
+        );
+
+        while Instant::now() < deadline {
+            let mut all_connected = true;
+            let mut total_connections = 0;
+
+            for node in &self.nodes {
+                let peer_count = node.peer_count().await;
+                total_connections += peer_count;
+
+                if peer_count < min_connections {
+                    all_connected = false;
+                }
+            }
+
+            if all_connected {
+                info!("Devnet stabilized: {} total connections", total_connections);
+                return Ok(());
+            }
+
+            debug!(
+                "Waiting for stabilization: {} total connections",
+                total_connections
+            );
+            tokio::time::sleep(Duration::from_secs(STABILIZATION_POLL_INTERVAL_SECS)).await;
+        }
+
+        Err(DevnetError::Stabilization(
+            "Devnet failed to stabilize within timeout".to_string(),
+        ))
+    }
+
+    fn start_health_monitor(&mut self) {
+        let nodes: Vec<Arc<P2PNode>> = self
+            .nodes
+            .iter()
+            .filter_map(|n| n.p2p_node.clone())
+            .collect();
+        let mut shutdown_rx = self.shutdown_tx.subscribe();
+
+        self.health_monitor = Some(tokio::spawn(async move {
+            let check_interval = Duration::from_secs(HEALTH_CHECK_INTERVAL_SECS);
+
+            loop {
+                tokio::select! {
+                    _ = shutdown_rx.recv() => break,
+                    () = tokio::time::sleep(check_interval) => {
+                        for (i, node) in nodes.iter().enumerate() {
+                            if !node.is_running().await {
+                                warn!("Node {} appears unhealthy", i);
+                            }
+                        }
+                    }
+                }
+            }
+        }));
+    }
+}
+
+impl Drop for Devnet {
+    fn drop(&mut self) {
+        let _ = self.shutdown_tx.send(());
+        if let Some(handle) = self.health_monitor.take() {
+            handle.abort();
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod ant_protocol;
 pub mod attestation;
 pub mod client;
 pub mod config;
+pub mod devnet;
 pub mod error;
 pub mod event;
 pub mod node;
@@ -58,6 +59,7 @@ pub use ant_protocol::{
 };
 pub use client::{compute_address, DataChunk, QuantumClient, QuantumConfig, XorName};
 pub use config::{BootstrapCacheConfig, NodeConfig, StorageConfig};
+pub use devnet::{Devnet, DevnetConfig, DevnetManifest};
 pub use error::{Error, Result};
 pub use event::{NodeEvent, NodeEventsChannel};
 pub use node::{NodeBuilder, RunningNode};


### PR DESCRIPTION
## Summary

- Add `saorsa-devnet` binary for spawning local multi-node networks with configurable presets (minimal/small/default), health monitoring, and JSON manifest output
- Add `saorsa-client` binary for chunk put/get operations against a running network (supports `--bootstrap` or `--devnet-manifest` for peer discovery)
- Add `src/devnet.rs` library module with `Devnet`, `DevnetConfig`, and `DevnetManifest` types

## Usage

### Start a local devnet

```bash
# Minimal devnet (5 nodes, fastest startup)
cargo run --release --bin saorsa-devnet -- --preset minimal --manifest /tmp/devnet.json

# Small devnet (10 nodes)
cargo run --release --bin saorsa-devnet -- --preset small --manifest /tmp/devnet.json

# Default devnet (25 nodes)
cargo run --release --bin saorsa-devnet -- --manifest /tmp/devnet.json

# Custom configuration
cargo run --release --bin saorsa-devnet -- --nodes 15 --bootstrap-count 3 --manifest /tmp/devnet.json
```

The devnet runs until you press Ctrl+C. The `--manifest` flag writes a JSON file with bootstrap addresses that the client can use for peer discovery.

### Upload and retrieve a chunk

```bash
# Upload a file
cargo run --release --bin saorsa-client -- --devnet-manifest /tmp/devnet.json put --file myfile.txt

# Upload from stdin
echo "hello world" | cargo run --release --bin saorsa-client -- --devnet-manifest /tmp/devnet.json put

# Retrieve a chunk by address
cargo run --release --bin saorsa-client -- --devnet-manifest /tmp/devnet.json get $ADDRESS --out retrieved.txt

# Retrieve to stdout
cargo run --release --bin saorsa-client -- --devnet-manifest /tmp/devnet.json get $ADDRESS
```

You can also connect directly to bootstrap peers instead of using a manifest:

```bash
cargo run --release --bin saorsa-client -- --bootstrap 127.0.0.1:20000 put --file myfile.txt
```

## Test plan

- [ ] `cargo build --release` compiles all three binaries
- [ ] `cargo test` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] `saorsa-devnet --preset minimal --manifest /tmp/devnet.json` spawns a local network
- [ ] `saorsa-client --devnet-manifest /tmp/devnet.json put --file <testfile>` stores a chunk and prints its address
- [ ] `saorsa-client --devnet-manifest /tmp/devnet.json get <address> --out <outfile>` retrieves it

🤖 Generated with [Claude Code](https://claude.com/claude-code)