### PR TITLE
feat: Kademlia DHT lookup for closest-peer chunk routing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ path = "src/bin/saorsa-client/main.rs"
 
 [dependencies]
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
-saorsa-core = "0.10.4"
+saorsa-core = "0.11.0"
 saorsa-pqc = "0.4.0"
 
 # Payment verification - autonomi network lookup + EVM payment

--- a/src/client/data_types.rs
+++ b/src/client/data_types.rs
@@ -18,6 +18,32 @@ pub fn compute_address(content: &[u8]) -> XorName {
     address
 }
 
+/// Compute the XOR distance between two 32-byte addresses.
+///
+/// Lexicographic comparison of the result gives correct Kademlia distance ordering.
+#[must_use]
+pub fn xor_distance(a: &XorName, b: &XorName) -> XorName {
+    let mut result = [0u8; 32];
+    for i in 0..32 {
+        result[i] = a[i] ^ b[i];
+    }
+    result
+}
+
+/// Convert a hex-encoded peer ID string to an `XorName`.
+///
+/// Returns `None` if the string is not valid hex or is not exactly 32 bytes (64 hex chars).
+#[must_use]
+pub fn peer_id_to_xor_name(peer_id: &str) -> Option<XorName> {
+    let bytes = hex::decode(peer_id).ok()?;
+    if bytes.len() != 32 {
+        return None;
+    }
+    let mut name = [0u8; 32];
+    name.copy_from_slice(&bytes);
+    Some(name)
+}
+
 /// A content-addressed identifier (32 bytes).
 ///
 /// The address is computed as SHA256(content) for chunks,
@@ -116,6 +142,55 @@ mod tests {
         assert_eq!(chunk.address, expected);
         assert_eq!(chunk.content, content);
         assert!(chunk.verify());
+    }
+
+    #[test]
+    fn test_xor_distance_identity() {
+        let a = [0xAB; 32];
+        assert_eq!(xor_distance(&a, &a), [0u8; 32]);
+    }
+
+    #[test]
+    fn test_xor_distance_symmetry() {
+        let a = [0x01; 32];
+        let b = [0xFF; 32];
+        assert_eq!(xor_distance(&a, &b), xor_distance(&b, &a));
+    }
+
+    #[test]
+    fn test_xor_distance_known_values() {
+        let a = [0x00; 32];
+        let b = [0xFF; 32];
+        assert_eq!(xor_distance(&a, &b), [0xFF; 32]);
+
+        let mut c = [0x00; 32];
+        c[0] = 0x80;
+        let mut expected = [0x00; 32];
+        expected[0] = 0x80;
+        assert_eq!(xor_distance(&a, &c), expected);
+    }
+
+    #[test]
+    fn test_peer_id_to_xor_name_valid() {
+        let hex_str = "ab".repeat(32);
+        let result = peer_id_to_xor_name(&hex_str);
+        assert_eq!(result, Some([0xAB; 32]));
+    }
+
+    #[test]
+    fn test_peer_id_to_xor_name_invalid_hex() {
+        assert_eq!(peer_id_to_xor_name("not_hex_at_all!"), None);
+    }
+
+    #[test]
+    fn test_peer_id_to_xor_name_wrong_length() {
+        // 16 bytes instead of 32
+        let short = "ab".repeat(16);
+        assert_eq!(peer_id_to_xor_name(&short), None);
+
+        // 33 bytes
+        let long = "ab".repeat(33);
+        assert_eq!(peer_id_to_xor_name(&long), None);
     }
 
     #[test]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -58,5 +58,7 @@ mod data_types;
 mod quantum;
 
 pub use chunk_protocol::send_and_await_chunk_response;
-pub use data_types::{compute_address, ChunkStats, DataChunk, XorName};
+pub use data_types::{
+    compute_address, peer_id_to_xor_name, xor_distance, ChunkStats, DataChunk, XorName,
+};
 pub use quantum::{QuantumClient, QuantumConfig};

--- a/src/client/quantum.rs
+++ b/src/client/quantum.rs
@@ -328,8 +328,8 @@ impl QuantumClient {
     /// Queries the DHT for the `CLOSE_GROUP_SIZE` closest nodes to the target
     /// address and returns the single closest remote peer (excluding ourselves).
     async fn pick_target_peer(node: &P2PNode, target: &XorName) -> Result<String> {
-        let local_dht_hex =
-            hex::encode(saorsa_core::dht::derive_dht_key_from_peer_id(node.peer_id()));
+        let local_peer_id = node.peer_id();
+        let local_transport_id = node.transport_peer_id();
 
         let closest_nodes = node
             .dht()
@@ -339,7 +339,12 @@ impl QuantumClient {
 
         let closest = closest_nodes
             .into_iter()
-            .find(|n| n.peer_id != local_dht_hex)
+            .find(|n| {
+                n.peer_id != *local_peer_id
+                    && local_transport_id
+                        .as_ref()
+                        .map_or(true, |tid| n.peer_id != *tid)
+            })
             .ok_or_else(|| Error::Network("No remote peers found near target address".into()))?;
 
         debug!(

--- a/src/client/quantum.rs
+++ b/src/client/quantum.rs
@@ -33,6 +33,9 @@ use tracing::{debug, info, warn};
 /// Default timeout for network operations in seconds.
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
 
+/// Number of closest peers to consider for chunk routing.
+const CLOSE_GROUP_SIZE: usize = 8;
+
 /// Default number of replicas for data redundancy.
 const DEFAULT_REPLICA_COUNT: u8 = 4;
 
@@ -126,7 +129,7 @@ impl QuantumClient {
             return Err(Error::Network("P2P node not configured".into()));
         };
 
-        let target_peer = Self::pick_target_peer(node).await?;
+        let target_peer = Self::pick_target_peer(node, address).await?;
 
         // Create and send GET request
         let request_id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
@@ -231,10 +234,10 @@ impl QuantumClient {
             return Err(Error::Network("P2P node not configured".into()));
         };
 
-        let target_peer = Self::pick_target_peer(node).await?;
-
-        // Compute content address using SHA-256
+        // Compute content address using SHA-256 (before peer selection so we can route by it)
         let address = crate::client::compute_address(&content);
+
+        let target_peer = Self::pick_target_peer(node, &address).await?;
 
         // Create PUT request with empty payment proof
         let empty_payment = rmp_serde::to_vec(&ant_evm::ProofOfPayment {
@@ -320,13 +323,32 @@ impl QuantumClient {
         self.get_chunk(address).await.map(|opt| opt.is_some())
     }
 
-    /// Pick a target peer from the connected peers list.
-    async fn pick_target_peer(node: &P2PNode) -> Result<String> {
-        let peers = node.connected_peers().await;
-        peers
+    /// Pick the closest peer to `target` using an iterative Kademlia network lookup.
+    ///
+    /// Queries the DHT for the `CLOSE_GROUP_SIZE` closest nodes to the target
+    /// address and returns the single closest remote peer (excluding ourselves).
+    async fn pick_target_peer(node: &P2PNode, target: &XorName) -> Result<String> {
+        let local_dht_hex =
+            hex::encode(saorsa_core::dht::derive_dht_key_from_peer_id(node.peer_id()));
+
+        let closest_nodes = node
+            .dht()
+            .find_closest_nodes(target, CLOSE_GROUP_SIZE)
+            .await
+            .map_err(|e| Error::Network(format!("Kademlia closest-nodes lookup failed: {e}")))?;
+
+        let closest = closest_nodes
             .into_iter()
-            .next()
-            .ok_or_else(|| Error::Network("No connected peers available".into()))
+            .find(|n| n.peer_id != local_dht_hex)
+            .ok_or_else(|| Error::Network("No remote peers found near target address".into()))?;
+
+        debug!(
+            "Selected closest peer {} for target {}",
+            closest.peer_id,
+            hex::encode(target)
+        );
+
+        Ok(closest.peer_id)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,10 @@ pub use ant_protocol::{
     ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkMessageBody, ChunkPutRequest,
     ChunkPutResponse, ChunkQuoteRequest, ChunkQuoteResponse, CHUNK_PROTOCOL_ID, MAX_CHUNK_SIZE,
 };
-pub use client::{compute_address, DataChunk, QuantumClient, QuantumConfig, XorName};
+pub use client::{
+    compute_address, peer_id_to_xor_name, xor_distance, DataChunk, QuantumClient, QuantumConfig,
+    XorName,
+};
 pub use config::{BootstrapCacheConfig, NodeConfig, StorageConfig};
 pub use devnet::{Devnet, DevnetConfig, DevnetManifest};
 pub use error::{Error, Result};


### PR DESCRIPTION
## Summary
- Replace naive first-connected-peer selection with iterative Kademlia network queries (`find_closest_nodes`) so chunks are routed to the peer whose BLAKE3-derived DHT key is closest to the chunk address by XOR distance
- Exclude the local node from results by comparing against its own BLAKE3 DHT key hex

**This is still a WIP** — further testing and refinement needed before merging.

## Test plan
- [ ] Verify chunk routing targets the closest peer by XOR distance
- [ ] Confirm local node is excluded from routing candidates
- [ ] E2E test with multi-node setup
- [ ] Run full test suite (`cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)