### PR TITLE
fix: configure max message size for devnet protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,4 @@ proptest-regressions/
 # Claude/AI assistant files
 .claude/
 .cache/
+/devnet-manifest.json

--- a/src/bin/saorsa-client/main.rs
+++ b/src/bin/saorsa-client/main.rs
@@ -6,6 +6,7 @@ use bytes::Bytes;
 use clap::Parser;
 use cli::{Cli, ClientCommand};
 use saorsa_core::P2PNode;
+use saorsa_node::ant_protocol::MAX_WIRE_MESSAGE_SIZE;
 use saorsa_node::client::{QuantumClient, QuantumConfig, XorName};
 use saorsa_node::devnet::DevnetManifest;
 use saorsa_node::error::Error;
@@ -94,6 +95,7 @@ async fn create_client_node(bootstrap: Vec<std::net::SocketAddr>) -> Result<Arc<
     core_config.listen_addrs = vec![core_config.listen_addr];
     core_config.enable_ipv6 = false;
     core_config.bootstrap_peers = bootstrap;
+    core_config.max_message_size = Some(MAX_WIRE_MESSAGE_SIZE);
 
     let node = P2PNode::new(core_config)
         .await

--- a/src/devnet.rs
+++ b/src/devnet.rs
@@ -571,6 +571,7 @@ impl Devnet {
         core_config
             .bootstrap_peers
             .clone_from(&node.bootstrap_addrs);
+        core_config.max_message_size = Some(crate::ant_protocol::MAX_WIRE_MESSAGE_SIZE);
 
         let p2p_node = P2PNode::new(core_config).await.map_err(|e| {
             DevnetError::Startup(format!("Failed to create node {}: {e}", node.index))


### PR DESCRIPTION
## Summary
- Configure `max_message_size` to `MAX_WIRE_MESSAGE_SIZE` on the saorsa-client and devnet P2P nodes so they match the protocol's expected message size limit
- Add `devnet-manifest.json` to `.gitignore`

## Test plan
- [ ] Verify devnet nodes start successfully with the configured message size
- [ ] Verify saorsa-client can connect and exchange messages with devnet nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)