### PR TITLE
chore: bump saorsa-core to 0.14.0 and set NodeMode::Client in CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ path = "src/bin/saorsa-cli/main.rs"
 
 [dependencies]
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
-saorsa-core = "0.13.0"
+saorsa-core = "0.14.0"
 saorsa-pqc = "0.4.0"
 
 # Payment verification - autonomi network lookup + EVM payment

--- a/src/bin/saorsa-cli/main.rs
+++ b/src/bin/saorsa-cli/main.rs
@@ -339,6 +339,7 @@ async fn create_client_node(bootstrap: Vec<std::net::SocketAddr>) -> Result<Arc<
     core_config.enable_ipv6 = false;
     core_config.bootstrap_peers = bootstrap;
     core_config.max_message_size = Some(MAX_WIRE_MESSAGE_SIZE);
+    core_config.mode = saorsa_core::NodeMode::Client;
 
     let node = P2PNode::new(core_config)
         .await


### PR DESCRIPTION
## Summary

- Bumps `saorsa-core` dependency from 0.13.0 to 0.14.0
- Sets `NodeMode::Client` on the core config in `saorsa-cli` so the node identifies as a client rather than a full node

## Test plan
- [ ] `cargo build --release` succeeds with saorsa-core 0.14.0
- [ ] `cargo test` passes
- [ ] saorsa-cli connects and operates correctly with `NodeMode::Client`

🤖 Generated with [Claude Code](https://claude.com/claude-code)