### PR TITLE
chore: bump saorsa-core to 0.14.1 and saorsa-pqc to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ path = "src/bin/saorsa-cli/main.rs"
 
 [dependencies]
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
-saorsa-core = "0.14.0"
-saorsa-pqc = "0.4.0"
+saorsa-core = "0.14.1"
+saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment
 ant-evm = "0.1.19"


### PR DESCRIPTION
## Summary
- Bump `saorsa-core` from 0.14.0 to 0.14.1
- Bump `saorsa-pqc` from 0.4.0 to 0.5

## Test plan
- [ ] Verify `cargo build --release` succeeds
- [ ] Verify `cargo test` passes
- [ ] Verify node starts and connects to bootstrap peers

🤖 Generated with [Claude Code](https://claude.com/claude-code)