### PR TITLE
feat: extend automatic upgrades with caching, cross-platform support, and clean restarts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,8 +262,8 @@ jobs:
         shell: pwsh
         run: |
           $tag = "${{ needs.validate.outputs.version }}"
-          # Remove 'v' prefix and convert to MSI format (x.y.z.0)
-          $version = $tag -replace '^v', ''
+          # Remove 'v' prefix and strip any pre-release suffix (e.g., -rc.1, -beta.2)
+          $version = $tag -replace '^v', '' -replace '-.*$', ''
           # Ensure 4-part version for MSI (add .0 if needed)
           $parts = $version.Split('.')
           while ($parts.Length -lt 4) {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ serde_json = "1"
 # Archive extraction for auto-upgrade
 flate2 = "1"
 tar = "0.4"
+zip = "2"
 
 # SHA-256 hashing for binary cache integrity
 sha2 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,10 @@ postcard = { version = "1.1.3", features = ["use-std"] }
 [target.'cfg(windows)'.dependencies]
 self-replace = "1"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", features = ["NSProcessInfo", "NSString"] }
+
 [dev-dependencies]
 tokio-test = "0.4"
 proptest = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Saorsa decentralized network"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/dirvine/saorsa-node"
+repository = "https://github.com/saorsa-labs/saorsa-node"
 keywords = ["p2p", "decentralized", "quantum-safe", "post-quantum", "dht"]
 categories = ["network-programming", "cryptography"]
 rust-version = "1.75"
@@ -93,8 +93,17 @@ serde_json = "1"
 flate2 = "1"
 tar = "0.4"
 
+# SHA-256 hashing for binary cache integrity
+sha2 = "0.10"
+
+# Cross-platform file locking for upgrade caches
+fs2 = "0.4"
+
 # Protocol serialization
 postcard = { version = "1.1.3", features = ["use-std"] }
+
+[target.'cfg(windows)'.dependencies]
+self-replace = "1"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,7 @@ assets = [
     { source = "target/release/saorsa-node", dest = "/usr/bin/saorsa-node", mode = "755" },
     { source = "target/release/saorsa-keygen", dest = "/usr/bin/saorsa-keygen", mode = "755" },
     { source = "README.md", dest = "/usr/share/doc/saorsa-node/README.md", mode = "644" },
+    { source = "systemd/saorsa-node.service", dest = "/usr/lib/systemd/system/saorsa-node.service", mode = "644" },
 ]
 
 [package.metadata.generate-rpm.requires]

--- a/README.md
+++ b/README.md
@@ -713,10 +713,10 @@ This enables node operators to deploy and forget, knowing their nodes will stay 
 
 ```bash
 # Use stable channel (default)
-saorsa-node --auto-upgrade --upgrade-channel stable
+saorsa-node --upgrade-channel stable
 
 # Use beta channel for testing
-saorsa-node --auto-upgrade --upgrade-channel beta
+saorsa-node --upgrade-channel beta
 ```
 
 ### Configuration
@@ -820,7 +820,6 @@ cargo build --release
     --root-dir ~/.saorsa \
     --port 12000 \
     --ip-version dual \
-    --auto-upgrade \
     --upgrade-channel stable \
     --migrate-ant-data auto \
     --log-level info
@@ -853,9 +852,6 @@ Options:
     --migrate-ant-data <PATH>
         Path to ant-node data directory to migrate
         Use 'auto' for automatic detection
-
-    --auto-upgrade
-        Enable automatic upgrades from GitHub releases
 
     --upgrade-channel <CHANNEL>
         Release channel: stable, beta

--- a/README.md
+++ b/README.md
@@ -724,11 +724,11 @@ saorsa-node --upgrade-channel beta
 
 ```toml
 [upgrade]
-enabled = true
 channel = "stable"
 check_interval_hours = 1
 github_repo = "saorsa-labs/saorsa-node"
-# max_random_delay_hours = 24  # For staged rollout
+stop_on_upgrade = false  # Set true when running under a service manager
+# staged_rollout_hours = 24  # For staged rollout
 ```
 
 ---
@@ -980,10 +980,11 @@ bootstrap = [
 ]
 
 [upgrade]
-enabled = true
+# Upgrades are always enabled; configure behavior here
 channel = "stable"
 check_interval_hours = 1
 github_repo = "saorsa-labs/saorsa-node"
+stop_on_upgrade = false
 
 [migration]
 auto_detect = true

--- a/README.md
+++ b/README.md
@@ -726,7 +726,7 @@ saorsa-node --auto-upgrade --upgrade-channel beta
 enabled = true
 channel = "stable"
 check_interval_hours = 1
-github_repo = "dirvine/saorsa-node"
+github_repo = "saorsa-labs/saorsa-node"
 # max_random_delay_hours = 24  # For staged rollout
 ```
 
@@ -778,7 +778,7 @@ saorsa-node
 
 ```bash
 # Clone the repository
-git clone https://github.com/dirvine/saorsa-node
+git clone https://github.com/saorsa-labs/saorsa-node
 cd saorsa-node
 
 # Build release binary
@@ -913,7 +913,7 @@ bootstrap = [
 enabled = true
 channel = "stable"
 check_interval_hours = 1
-github_repo = "dirvine/saorsa-node"
+github_repo = "saorsa-labs/saorsa-node"
 
 [migration]
 auto_detect = true

--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ saorsa-node is the next-generation node software for the Autonomi decentralized 
 7. [Migration from ant-node](#migration-from-ant-node)
 8. [Development Status](#development-status)
 9. [Auto-Upgrade System](#auto-upgrade-system)
-10. [Architecture](#architecture)
-11. [Quick Start](#quick-start)
-12. [CLI Reference](#cli-reference)
-13. [Configuration](#configuration)
-14. [Security Considerations](#security-considerations)
-15. [Related Projects](#related-projects)
+10. [Running as a Service](#running-as-a-service)
+11. [Architecture](#architecture)
+12. [Quick Start](#quick-start)
+13. [CLI Reference](#cli-reference)
+14. [Configuration](#configuration)
+15. [Security Considerations](#security-considerations)
+16. [Related Projects](#related-projects)
 
 ---
 
@@ -729,6 +730,79 @@ check_interval_hours = 1
 github_repo = "saorsa-labs/saorsa-node"
 # max_random_delay_hours = 24  # For staged rollout
 ```
+
+---
+
+## Running as a Service
+
+For production deployments, run saorsa-node under a service manager so it restarts automatically after upgrades.
+
+### systemd (Linux)
+
+A service file is included at `systemd/saorsa-node.service` and installed automatically by RPM/DEB packages.
+
+```bash
+# Install and enable
+sudo cp systemd/saorsa-node.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now saorsa-node
+```
+
+Key settings:
+- `--stop-on-upgrade` tells the node to exit cleanly after applying an upgrade
+- `Restart=always` ensures systemd restarts the node after the upgrade exit
+- Security hardening (NoNewPrivileges, ProtectSystem, etc.) is pre-configured
+
+### launchd (macOS)
+
+Create a plist at `~/Library/LaunchAgents/com.saorsa.node.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.saorsa.node</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/saorsa-node</string>
+        <string>--stop-on-upgrade</string>
+    </array>
+    <key>KeepAlive</key>
+    <true/>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+```
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.saorsa.node.plist
+```
+
+### Windows Service
+
+Use [WinSW](https://github.com/winsw/winsw) or [NSSM](https://nssm.cc/) to wrap saorsa-node as a Windows service.
+
+With WinSW, create `saorsa-node-service.xml`:
+
+```xml
+<service>
+  <id>saorsa-node</id>
+  <name>Saorsa Node</name>
+  <executable>C:\saorsa\saorsa-node.exe</executable>
+  <arguments>--stop-on-upgrade</arguments>
+  <onfailure action="restart" delay="5 sec"/>
+</service>
+```
+
+The node exits with code 100 on upgrade, which WinSW treats as a failure and restarts.
+
+### Standalone Mode (No Service Manager)
+
+Without `--stop-on-upgrade`, the node spawns the upgraded binary as a new process before exiting. This is the default behavior and requires no service manager.
 
 ---
 

--- a/deploy/scripts/spawn-nodes.sh
+++ b/deploy/scripts/spawn-nodes.sh
@@ -32,7 +32,7 @@ download_binary() {
         *) echo "Unsupported architecture: $arch"; exit 1 ;;
     esac
 
-    local url="https://github.com/dirvine/saorsa-node/releases/download/v${version}/saorsa-node-cli-${PLATFORM}.tar.gz"
+    local url="https://github.com/saorsa-labs/saorsa-node/releases/download/v${version}/saorsa-node-cli-${PLATFORM}.tar.gz"
 
     echo "Downloading saorsa-node v${version} for ${PLATFORM}..."
     curl -L -o /tmp/saorsa-node.tar.gz "$url"

--- a/deploy/terraform/cloud-init/worker.yml
+++ b/deploy/terraform/cloud-init/worker.yml
@@ -35,7 +35,7 @@ write_files:
         *) echo "Unsupported architecture: $${ARCH}"; exit 1 ;;
       esac
 
-      ARCHIVE_URL="https://github.com/dirvine/saorsa-node/releases/download/v$${SAORSA_VERSION}/saorsa-node-cli-$${PLATFORM}.tar.gz"
+      ARCHIVE_URL="https://github.com/saorsa-labs/saorsa-node/releases/download/v$${SAORSA_VERSION}/saorsa-node-cli-$${PLATFORM}.tar.gz"
       SIG_URL="$${ARCHIVE_URL}.sig"
       BINARY_PATH="/usr/local/bin/saorsa-node"
       KEYGEN_PATH="/usr/local/bin/saorsa-keygen"

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -391,7 +391,7 @@ pub struct NodeLifecycle {
 - [ ] ML-DSA-65 signature verification for binaries
 - [ ] Process replacement with state preservation
 - [ ] Rollback functionality (backup current binary)
-- [ ] CLI flags: `--auto-upgrade`, `--upgrade-channel`
+- [ ] CLI flag: `--upgrade-channel`
 
 ### Phase 3: ant-node Data Migration
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -335,7 +335,7 @@ node.report_trust_event(&peer, event)  // Report trust signals
 ```rust
 /// Auto-upgrade system (not in saorsa-core)
 pub struct UpgradeMonitor {
-    github_repo: String,                      // "dirvine/saorsa-node"
+    github_repo: String,                      // "saorsa-labs/saorsa-node"
     release_signing_key: MlDsaPublicKey,      // Embedded in binary
     check_interval: Duration,                 // Default: 1 hour
     rollback_dir: PathBuf,                    // For failed upgrades
@@ -376,7 +376,7 @@ pub struct NodeLifecycle {
 
 ### Phase 1: Repository Setup & Core Structure
 
-- [ ] Initialize git repo, push to `dirvine/saorsa-node` on GitHub
+- [ ] Initialize git repo, push to `saorsa-labs/saorsa-node` on GitHub
 - [ ] Create Cargo.toml with saorsa-core, saorsa-pqc dependencies
 - [ ] Create project structure
 - [ ] Implement NodeBuilder that configures and creates NetworkCoordinator

--- a/scripts/testnet/build-and-deploy.sh
+++ b/scripts/testnet/build-and-deploy.sh
@@ -50,7 +50,7 @@ ssh -o StrictHostKeyChecking=no "root@${BUILD_HOST}" "
         git fetch origin
         git reset --hard origin/main
     else
-        git clone https://github.com/dirvine/saorsa-node.git /root/saorsa-node
+        git clone https://github.com/saorsa-labs/saorsa-node.git /root/saorsa-node
         cd /root/saorsa-node
     fi
 

--- a/scripts/testnet/deploy-all.sh
+++ b/scripts/testnet/deploy-all.sh
@@ -13,7 +13,7 @@ WORKERS=(
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BINARY_URL="https://github.com/dirvine/saorsa-node/releases/download/v0.2.0/saorsa-node-cli-linux-x64.tar.gz"
+BINARY_URL="https://github.com/saorsa-labs/saorsa-node/releases/download/v0.2.0/saorsa-node-cli-linux-x64.tar.gz"
 
 echo "=== Saorsa Testnet Deployment ==="
 echo "Deploying to ${#WORKERS[@]} droplets"

--- a/scripts/testnet/spawn-nodes.sh
+++ b/scripts/testnet/spawn-nodes.sh
@@ -63,7 +63,6 @@ ExecStart=/usr/local/bin/saorsa-node \\
     ${BOOTSTRAP_FLAGS} \\
     --metrics-port ${METRICS} \\
     --log-level info \\
-    --auto-upgrade \\
     --upgrade-channel stable \\
     --evm-network arbitrum-sepolia \\
     --disable-payment-verification

--- a/scripts/testnet/start-genesis.sh
+++ b/scripts/testnet/start-genesis.sh
@@ -26,7 +26,6 @@ ExecStart=/usr/local/bin/saorsa-node \
     --ip-version ipv4 \
     --metrics-port 9100 \
     --log-level info \
-    --auto-upgrade \
     --upgrade-channel stable \
     --evm-network arbitrum-sepolia \
     --disable-payment-verification
@@ -69,7 +68,6 @@ ExecStart=/usr/local/bin/saorsa-node \
     -b 142.93.52.129:12000 \
     --metrics-port 9100 \
     --log-level info \
-    --auto-upgrade \
     --upgrade-channel stable \
     --evm-network arbitrum-sepolia \
     --disable-payment-verification

--- a/scripts/testnet/upgrade-test.sh
+++ b/scripts/testnet/upgrade-test.sh
@@ -28,19 +28,14 @@ get_all_versions() {
     echo ""
 }
 
-# Check if auto-upgrade is enabled
+# Check node count on each worker
 check_upgrade_config() {
-    echo "--- Checking Upgrade Configuration ---"
+    echo "--- Checking Node Configuration ---"
     for i in "${!WORKERS[@]}"; do
         IP="${WORKERS[$i]}"
         echo -n "Worker $((i+1)) ($IP): "
-        # Check if nodes have auto-upgrade enabled (look for --auto-upgrade in service files)
-        HAS_UPGRADE=$(ssh -o StrictHostKeyChecking=no root@$IP "grep -l 'auto-upgrade' /etc/systemd/system/saorsa-node-*.service 2>/dev/null | wc -l" || echo "0")
-        if [ "$HAS_UPGRADE" -gt "0" ]; then
-            echo "Auto-upgrade enabled ($HAS_UPGRADE services)"
-        else
-            echo "Auto-upgrade NOT enabled"
-        fi
+        RUNNING=$(ssh -o StrictHostKeyChecking=no root@$IP "pgrep -c saorsa-node 2>/dev/null" || echo "0")
+        echo "$RUNNING nodes running (auto-upgrade always enabled)"
     done
     echo ""
 }

--- a/src/bin/saorsa-node/cli.rs
+++ b/src/bin/saorsa-node/cli.rs
@@ -3,7 +3,7 @@
 use clap::{Parser, ValueEnum};
 use saorsa_node::config::{
     BootstrapCacheConfig, EvmNetworkConfig, IpVersion, NetworkMode, NodeConfig, PaymentConfig,
-    UpgradeChannel, UpgradeConfig,
+    UpgradeChannel,
 };
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -28,10 +28,6 @@ pub struct Cli {
     /// Bootstrap peer addresses.
     #[arg(long, short, env = "SAORSA_BOOTSTRAP")]
     pub bootstrap: Vec<SocketAddr>,
-
-    /// Enable automatic upgrades.
-    #[arg(long, env = "SAORSA_AUTO_UPGRADE")]
-    pub auto_upgrade: bool,
 
     /// Release channel for upgrades.
     #[arg(
@@ -208,11 +204,7 @@ impl Cli {
         config.network_mode = self.network_mode.into();
 
         // Upgrade config
-        config.upgrade = UpgradeConfig {
-            enabled: self.auto_upgrade,
-            channel: self.upgrade_channel.into(),
-            ..config.upgrade
-        };
+        config.upgrade.channel = self.upgrade_channel.into();
 
         // Payment config (payment verification is always on)
         config.payment = PaymentConfig {

--- a/src/bin/saorsa-node/cli.rs
+++ b/src/bin/saorsa-node/cli.rs
@@ -93,6 +93,12 @@ pub struct Cli {
     #[arg(long, short)]
     pub config: Option<PathBuf>,
 
+    /// Exit cleanly on upgrade instead of spawning a new process.
+    /// Use when running under a service manager (systemd, launchd, Windows Service)
+    /// that will restart the process automatically.
+    #[arg(long)]
+    pub stop_on_upgrade: bool,
+
     /// Disable persistent bootstrap cache.
     #[arg(long)]
     pub disable_bootstrap_cache: bool,
@@ -205,6 +211,7 @@ impl Cli {
 
         // Upgrade config
         config.upgrade.channel = self.upgrade_channel.into();
+        config.upgrade.stop_on_upgrade = self.stop_on_upgrade;
 
         // Payment config (payment verification is always on)
         config.payment = PaymentConfig {

--- a/src/bin/saorsa-node/main.rs
+++ b/src/bin/saorsa-node/main.rs
@@ -1,11 +1,12 @@
 //! saorsa-node CLI entry point.
 
 mod cli;
+mod platform;
 
 use clap::Parser;
 use cli::{Cli, CliLogFormat};
 use saorsa_node::NodeBuilder;
-use tracing::info;
+use tracing::{info, warn};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter, Layer};
 
@@ -80,6 +81,20 @@ async fn main() -> color_eyre::Result<()> {
         commit = env!("SAORSA_GIT_COMMIT"),
         "saorsa-node starting"
     );
+
+    // Prevent macOS App Nap from throttling background timer operations.
+    // _activity must live for the duration of main() — dropping it re-enables App Nap.
+    #[allow(clippy::collection_is_never_read)]
+    let _activity = match platform::disable_app_nap() {
+        Ok(activity) => {
+            info!("App Nap prevention enabled");
+            Some(activity)
+        }
+        Err(e) => {
+            warn!("Failed to disable App Nap: {e}");
+            None
+        }
+    };
 
     // Build configuration
     let config = cli.into_config()?;

--- a/src/bin/saorsa-node/platform.rs
+++ b/src/bin/saorsa-node/platform.rs
@@ -30,7 +30,7 @@ pub fn disable_app_nap() -> Result<AppNapActivity, String> {
     // wrappers. `processInfo` returns a shared singleton and
     // `beginActivityWithOptions:reason:` is thread-safe.
     unsafe {
-        use objc2::msg_send_id;
+        use objc2::msg_send;
         use objc2_foundation::{NSProcessInfo, NSString};
 
         let process_info = NSProcessInfo::processInfo();
@@ -42,7 +42,7 @@ pub fn disable_app_nap() -> Result<AppNapActivity, String> {
         let reason =
             NSString::from_str("saorsa-node: P2P network daemon performing background operations");
 
-        let activity: AppNapActivity = msg_send_id![
+        let activity: AppNapActivity = msg_send![
             &process_info,
             beginActivityWithOptions: options,
             reason: &*reason,
@@ -54,6 +54,7 @@ pub fn disable_app_nap() -> Result<AppNapActivity, String> {
 
 /// No-op on non-macOS platforms.
 #[cfg(not(target_os = "macos"))]
+#[allow(clippy::unnecessary_wraps)] // signature must match macOS variant for caller compatibility
 pub fn disable_app_nap() -> Result<(), String> {
     Ok(())
 }

--- a/src/bin/saorsa-node/platform.rs
+++ b/src/bin/saorsa-node/platform.rs
@@ -1,0 +1,60 @@
+//! Platform-specific process configuration.
+//!
+//! On macOS, prevents App Nap from throttling the node process. macOS
+//! aggressively suspends background processes that have no visible UI,
+//! coalescing timers and reducing CPU priority. This makes scheduled
+//! operations (like upgrade checks) unreliable — timers can be deferred
+//! by minutes or even tens of minutes.
+
+/// Opaque handle representing an active App Nap prevention activity.
+/// The activity remains active as long as this value is alive.
+#[cfg(target_os = "macos")]
+pub type AppNapActivity = objc2::rc::Retained<objc2::runtime::NSObject>;
+
+/// Prevent macOS App Nap from throttling this process.
+///
+/// Calls `NSProcessInfo.processInfo.beginActivity(_:reason:)` with
+/// `NSActivityUserInitiated` to tell macOS this process is performing
+/// important work that should not be deferred.
+///
+/// The returned handle must be held for the lifetime of the process.
+/// When dropped, macOS may resume App Nap.
+///
+/// # Errors
+///
+/// Returns an error string if the activity could not be created.
+#[cfg(target_os = "macos")]
+pub fn disable_app_nap() -> Result<AppNapActivity, String> {
+    #[allow(unsafe_code)]
+    // SAFETY: We call well-documented Cocoa APIs through the objc2 safe
+    // wrappers. `processInfo` returns a shared singleton and
+    // `beginActivityWithOptions:reason:` is thread-safe.
+    unsafe {
+        use objc2::msg_send_id;
+        use objc2_foundation::{NSProcessInfo, NSString};
+
+        let process_info = NSProcessInfo::processInfo();
+
+        // NSActivityUserInitiated (0x00FFFFFFU) includes latency-critical
+        // timer firing, App Nap prevention, and idle sleep prevention.
+        let options: u64 = 0x00FF_FFFF;
+
+        let reason = NSString::from_str(
+            "saorsa-node: P2P network daemon performing background operations",
+        );
+
+        let activity: AppNapActivity = msg_send_id![
+            &process_info,
+            beginActivityWithOptions: options,
+            reason: &*reason,
+        ];
+
+        Ok(activity)
+    }
+}
+
+/// No-op on non-macOS platforms.
+#[cfg(not(target_os = "macos"))]
+pub fn disable_app_nap() -> Result<(), String> {
+    Ok(())
+}

--- a/src/bin/saorsa-node/platform.rs
+++ b/src/bin/saorsa-node/platform.rs
@@ -39,9 +39,8 @@ pub fn disable_app_nap() -> Result<AppNapActivity, String> {
         // timer firing, App Nap prevention, and idle sleep prevention.
         let options: u64 = 0x00FF_FFFF;
 
-        let reason = NSString::from_str(
-            "saorsa-node: P2P network daemon performing background operations",
-        );
+        let reason =
+            NSString::from_str("saorsa-node: P2P network daemon performing background operations");
 
         let activity: AppNapActivity = msg_send_id![
             &process_info,

--- a/src/config.rs
+++ b/src/config.rs
@@ -330,7 +330,7 @@ impl Default for UpgradeConfig {
 }
 
 fn default_github_repo() -> String {
-    "dirvine/saorsa-node".to_string()
+    "saorsa-labs/saorsa-node".to_string()
 }
 
 /// Default base directory for node data (platform data dir for "saorsa").

--- a/src/config.rs
+++ b/src/config.rs
@@ -153,10 +153,6 @@ pub struct NodeConfig {
 /// Auto-upgrade configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpgradeConfig {
-    /// Enable automatic upgrades.
-    #[serde(default)]
-    pub enabled: bool,
-
     /// Release channel.
     #[serde(default)]
     pub channel: UpgradeChannel,
@@ -320,7 +316,6 @@ impl NodeConfig {
 impl Default for UpgradeConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
             channel: UpgradeChannel::default(),
             check_interval_hours: default_check_interval(),
             github_repo: default_github_repo(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -174,6 +174,15 @@ pub struct UpgradeConfig {
     /// Set to 0 to disable staged rollout (apply upgrades immediately).
     #[serde(default = "default_staged_rollout_hours")]
     pub staged_rollout_hours: u64,
+
+    /// Exit cleanly on upgrade instead of spawning a new process.
+    ///
+    /// When true, the node exits after applying an upgrade and relies on
+    /// an external service manager (systemd, launchd, Windows Service) to
+    /// restart it. When false (default), the node spawns the new binary
+    /// as a child process before exiting.
+    #[serde(default)]
+    pub stop_on_upgrade: bool,
 }
 
 /// EVM network for payment processing.
@@ -320,6 +329,7 @@ impl Default for UpgradeConfig {
             check_interval_hours: default_check_interval(),
             github_repo: default_github_repo(),
             staged_rollout_hours: default_staged_rollout_hours(),
+            stop_on_upgrade: false,
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -477,7 +477,10 @@ impl RunningNode {
         let actual_port = listen_addrs
             .first()
             .map_or(self.config.port, std::net::SocketAddr::port);
-        info!(port = actual_port, "Node is running on port: {}", actual_port);
+        info!(
+            port = actual_port,
+            "Node is running on port: {}", actual_port
+        );
 
         // Emit started event
         if let Err(e) = self.events_tx.send(NodeEvent::Started) {
@@ -495,8 +498,7 @@ impl RunningNode {
 
             tokio::spawn(async move {
                 let mut monitor = monitor;
-                let mut upgrader = AutoApplyUpgrader::new()
-                    .with_stop_on_upgrade(stop_on_upgrade);
+                let mut upgrader = AutoApplyUpgrader::new().with_stop_on_upgrade(stop_on_upgrade);
                 if let Ok(cache_dir) = upgrade_cache_dir() {
                     upgrader = upgrader.with_binary_cache(BinaryCache::new(cache_dir));
                 }
@@ -565,7 +567,15 @@ impl RunningNode {
                                     }
                                 }
                                 Ok(None) => {
-                                    info!("Already running latest version");
+                                    if let Some(remaining) = monitor.time_until_upgrade() {
+                                        info!(
+                                            "Upgrade pending, rollout delay remaining: {}m {}s",
+                                            remaining.as_secs() / 60,
+                                            remaining.as_secs() % 60
+                                        );
+                                    } else {
+                                        info!("No upgrade available");
+                                    }
                                 }
                                 Err(e) => {
                                     warn!("Error during upgrade process: {}", e);

--- a/src/node.rs
+++ b/src/node.rs
@@ -481,7 +481,7 @@ impl RunningNode {
         // Extract the actual bound port (config port may be 0 = auto-select)
         let actual_port = listen_addrs
             .first()
-            .and_then(|addr| addr.port())
+            .and_then(MultiAddr::port)
             .unwrap_or(self.config.port);
         info!(
             port = actual_port,

--- a/src/node.rs
+++ b/src/node.rs
@@ -107,12 +107,10 @@ impl NodeBuilder {
             .await
             .map_err(|e| Error::Startup(format!("Failed to create P2P node: {e}")))?;
 
-        // Create upgrade monitor if enabled
-        let upgrade_monitor = if self.config.upgrade.enabled {
+        // Create upgrade monitor
+        let upgrade_monitor = {
             let node_id_seed = p2p_node.peer_id().as_bytes();
             Some(Self::build_upgrade_monitor(&self.config, node_id_seed))
-        } else {
-            None
         };
 
         // Initialize bootstrap cache manager if enabled
@@ -740,7 +738,6 @@ mod tests {
     fn test_build_upgrade_monitor_staged_rollout_enabled() {
         let config = NodeConfig {
             upgrade: crate::config::UpgradeConfig {
-                enabled: true,
                 staged_rollout_hours: 24,
                 ..Default::default()
             },
@@ -756,7 +753,6 @@ mod tests {
     fn test_build_upgrade_monitor_staged_rollout_disabled() {
         let config = NodeConfig {
             upgrade: crate::config::UpgradeConfig {
-                enabled: true,
                 staged_rollout_hours: 0,
                 ..Default::default()
             },

--- a/src/node.rs
+++ b/src/node.rs
@@ -11,8 +11,9 @@ use crate::payment::metrics::QuotingMetricsTracker;
 use crate::payment::wallet::parse_rewards_address;
 use crate::payment::{EvmVerifierConfig, PaymentVerifier, PaymentVerifierConfig, QuoteGenerator};
 use crate::storage::{AntProtocol, LmdbStorage, LmdbStorageConfig};
-use crate::upgrade::{AutoApplyUpgrader, UpgradeMonitor, UpgradeResult};
-
+use crate::upgrade::{
+    upgrade_cache_dir, AutoApplyUpgrader, BinaryCache, ReleaseCache, UpgradeMonitor, UpgradeResult,
+};
 use evmlib::Network as EvmNetwork;
 use saorsa_core::identity::NodeIdentity;
 use saorsa_core::{
@@ -300,17 +301,25 @@ impl NodeBuilder {
     }
 
     fn build_upgrade_monitor(config: &NodeConfig, node_id_seed: &[u8]) -> Arc<UpgradeMonitor> {
-        let monitor = UpgradeMonitor::new(
+        let mut monitor = UpgradeMonitor::new(
             config.upgrade.github_repo.clone(),
             config.upgrade.channel,
             config.upgrade.check_interval_hours,
         );
 
-        if config.upgrade.staged_rollout_hours > 0 {
-            Arc::new(monitor.with_staged_rollout(node_id_seed, config.upgrade.staged_rollout_hours))
-        } else {
-            Arc::new(monitor)
+        if let Ok(cache_dir) = upgrade_cache_dir() {
+            monitor = monitor.with_release_cache(ReleaseCache::new(
+                cache_dir,
+                std::time::Duration::from_secs(3600),
+            ));
         }
+
+        if config.upgrade.staged_rollout_hours > 0 {
+            monitor =
+                monitor.with_staged_rollout(node_id_seed, config.upgrade.staged_rollout_hours);
+        }
+
+        Arc::new(monitor)
     }
 
     /// Build the ANT protocol handler from config.
@@ -453,6 +462,7 @@ impl RunningNode {
     /// # Errors
     ///
     /// Returns an error if the node encounters a fatal error.
+    #[allow(clippy::too_many_lines)]
     pub async fn run(&mut self) -> Result<()> {
         info!("Node runtime loop starting");
 
@@ -462,8 +472,14 @@ impl RunningNode {
             .await
             .map_err(|e| Error::Startup(format!("Failed to start P2P node: {e}")))?;
 
-        let addrs = self.p2p_node.listen_addrs().await;
-        info!(listen_addrs = ?addrs, "P2P node started");
+        let listen_addrs = self.p2p_node.listen_addrs().await;
+        info!(listen_addrs = ?listen_addrs, "P2P node started");
+
+        // Extract the actual bound port (config port may be 0 = auto-select)
+        let actual_port = listen_addrs
+            .first()
+            .map_or(self.config.port, std::net::SocketAddr::port);
+        info!(port = actual_port, "Node is running on port: {}", actual_port);
 
         // Emit started event
         if let Err(e) = self.events_tx.send(NodeEvent::Started) {
@@ -480,7 +496,10 @@ impl RunningNode {
             let shutdown = self.shutdown.clone();
 
             tokio::spawn(async move {
-                let upgrader = AutoApplyUpgrader::new();
+                let mut upgrader = AutoApplyUpgrader::new();
+                if let Ok(cache_dir) = upgrade_cache_dir() {
+                    upgrader = upgrader.with_binary_cache(BinaryCache::new(cache_dir));
+                }
 
                 loop {
                     tokio::select! {
@@ -488,39 +507,49 @@ impl RunningNode {
                             break;
                         }
                         result = monitor.check_for_updates() => {
-                            if let Ok(Some(upgrade_info)) = result {
-                                info!(
-                                    current_version = %upgrader.current_version(),
-                                    new_version = %upgrade_info.version,
-                                    "Upgrade available"
-                                );
+                            match result {
+                                Ok(Some(upgrade_info)) => {
+                                    info!(
+                                        current_version = %upgrader.current_version(),
+                                        new_version = %upgrade_info.version,
+                                        "Upgrade available"
+                                    );
 
-                                // Send notification event
-                                if let Err(e) = events_tx.send(NodeEvent::UpgradeAvailable {
-                                    version: upgrade_info.version.to_string(),
-                                }) {
-                                    warn!("Failed to send UpgradeAvailable event: {e}");
+                                    // Send notification event
+                                    if let Err(e) = events_tx.send(NodeEvent::UpgradeAvailable {
+                                        version: upgrade_info.version.to_string(),
+                                    }) {
+                                        warn!("Failed to send UpgradeAvailable event: {e}");
+                                    }
+
+                                    // Auto-apply the upgrade
+                                    info!("Starting auto-apply upgrade...");
+                                    match upgrader.apply_upgrade(&upgrade_info).await {
+                                        Ok(UpgradeResult::Success { version }) => {
+                                            info!("Upgrade to {} successful! Process will restart.", version);
+                                            // If we reach here, exec() failed or not supported
+                                        }
+                                        Ok(UpgradeResult::RolledBack { reason }) => {
+                                            warn!("Error during upgrade process: {}", reason);
+                                        }
+                                        Ok(UpgradeResult::NoUpgrade) => {
+                                            info!("Already running latest version");
+                                        }
+                                        Err(e) => {
+                                            error!("Error during upgrade process: {}", e);
+                                        }
+                                    }
                                 }
-
-                                // Auto-apply the upgrade
-                                info!("Starting auto-apply upgrade...");
-                                match upgrader.apply_upgrade(&upgrade_info).await {
-                                    Ok(UpgradeResult::Success { version }) => {
-                                        info!(version = %version, "Upgrade successful, process will restart");
-                                        // If we reach here, exec() failed or not supported
-                                    }
-                                    Ok(UpgradeResult::RolledBack { reason }) => {
-                                        warn!("Upgrade rolled back: {reason}");
-                                    }
-                                    Ok(UpgradeResult::NoUpgrade) => {
-                                        debug!("No upgrade needed");
-                                    }
-                                    Err(e) => {
-                                        error!("Critical upgrade error: {e}");
-                                    }
+                                Ok(None) => {
+                                    info!("Already running latest version");
+                                }
+                                Err(e) => {
+                                    warn!("Error during upgrade process: {}", e);
                                 }
                             }
-                            // Wait for next check interval
+                            // Schedule next check
+                            let next_check = chrono::Utc::now() + chrono::Duration::from_std(monitor.check_interval()).unwrap_or_else(|_| chrono::Duration::hours(1));
+                            info!("Next upgrade check scheduled for {}", next_check.to_rfc3339());
                             tokio::time::sleep(monitor.check_interval()).await;
                         }
                     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -501,6 +501,30 @@ impl RunningNode {
                     upgrader = upgrader.with_binary_cache(BinaryCache::new(cache_dir));
                 }
 
+                // Add randomized jitter before the first upgrade check to prevent all nodes
+                // from hitting the GitHub API simultaneously when started together.
+                // Uses ±5% of the check interval, matching the autonomi project's approach.
+                {
+                    let interval_secs = monitor.check_interval().as_secs();
+                    let variance = interval_secs / 20; // 5%
+                    let jitter_secs = if variance > 0 {
+                        use rand::Rng;
+                        rand::thread_rng().gen_range(0..=variance * 2)
+                    } else {
+                        0
+                    };
+                    let jitter_duration = std::time::Duration::from_secs(jitter_secs);
+                    let first_check_time = chrono::Utc::now()
+                        + chrono::Duration::from_std(jitter_duration)
+                            .unwrap_or_else(|_| chrono::Duration::minutes(1));
+                    info!(
+                        "First upgrade check scheduled for {} (jitter: {}s)",
+                        first_check_time.to_rfc3339(),
+                        jitter_secs
+                    );
+                    tokio::time::sleep(jitter_duration).await;
+                }
+
                 loop {
                     tokio::select! {
                         () = shutdown.cancelled() => {

--- a/src/node.rs
+++ b/src/node.rs
@@ -491,10 +491,12 @@ impl RunningNode {
         if let Some(monitor) = self.upgrade_monitor.take() {
             let events_tx = self.events_tx.clone();
             let shutdown = self.shutdown.clone();
+            let stop_on_upgrade = self.config.upgrade.stop_on_upgrade;
 
             tokio::spawn(async move {
                 let mut monitor = monitor;
-                let mut upgrader = AutoApplyUpgrader::new();
+                let mut upgrader = AutoApplyUpgrader::new()
+                    .with_stop_on_upgrade(stop_on_upgrade);
                 if let Ok(cache_dir) = upgrade_cache_dir() {
                     upgrader = upgrader.with_binary_cache(BinaryCache::new(cache_dir));
                 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -481,7 +481,8 @@ impl RunningNode {
         // Extract the actual bound port (config port may be 0 = auto-select)
         let actual_port = listen_addrs
             .first()
-            .map_or(self.config.port, std::net::SocketAddr::port);
+            .and_then(|addr| addr.port())
+            .unwrap_or(self.config.port);
         info!(
             port = actual_port,
             "Node is running on port: {}", actual_port

--- a/src/node.rs
+++ b/src/node.rs
@@ -15,6 +15,7 @@ use crate::upgrade::{
     upgrade_cache_dir, AutoApplyUpgrader, BinaryCache, ReleaseCache, UpgradeMonitor, UpgradeResult,
 };
 use evmlib::Network as EvmNetwork;
+use rand::Rng;
 use saorsa_core::identity::NodeIdentity;
 use saorsa_core::{
     BootstrapConfig as CoreBootstrapConfig, BootstrapManager,
@@ -22,6 +23,7 @@ use saorsa_core::{
     P2PNode,
 };
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
@@ -141,6 +143,7 @@ impl NodeBuilder {
             bootstrap_manager,
             ant_protocol,
             protocol_task: None,
+            upgrade_exit_code: Arc::new(AtomicI32::new(-1)),
         };
 
         Ok(node)
@@ -433,6 +436,8 @@ pub struct RunningNode {
     ant_protocol: Option<Arc<AntProtocol>>,
     /// Protocol message routing background task.
     protocol_task: Option<JoinHandle<()>>,
+    /// Exit code requested by a successful upgrade (-1 = no upgrade exit pending).
+    upgrade_exit_code: Arc<AtomicI32>,
 }
 
 impl RunningNode {
@@ -495,6 +500,7 @@ impl RunningNode {
             let events_tx = self.events_tx.clone();
             let shutdown = self.shutdown.clone();
             let stop_on_upgrade = self.config.upgrade.stop_on_upgrade;
+            let upgrade_exit_code = Arc::clone(&self.upgrade_exit_code);
 
             tokio::spawn(async move {
                 let mut monitor = monitor;
@@ -505,24 +511,17 @@ impl RunningNode {
 
                 // Add randomized jitter before the first upgrade check to prevent all nodes
                 // from hitting the GitHub API simultaneously when started together.
-                // Uses ±5% of the check interval, matching the autonomi project's approach.
                 {
-                    let interval_secs = monitor.check_interval().as_secs();
-                    let variance = interval_secs / 20; // 5%
-                    let jitter_secs = if variance > 0 {
-                        use rand::Rng;
-                        rand::thread_rng().gen_range(0..=variance * 2)
-                    } else {
-                        0
-                    };
-                    let jitter_duration = std::time::Duration::from_secs(jitter_secs);
+                    let jitter_duration = jittered_interval(monitor.check_interval());
                     let first_check_time = chrono::Utc::now()
-                        + chrono::Duration::from_std(jitter_duration)
-                            .unwrap_or_else(|_| chrono::Duration::minutes(1));
+                        + chrono::Duration::from_std(jitter_duration).unwrap_or_else(|e| {
+                            warn!("chrono::Duration::from_std failed for jitter ({e}), defaulting to 1 minute");
+                            chrono::Duration::minutes(1)
+                        });
                     info!(
                         "First upgrade check scheduled for {} (jitter: {}s)",
                         first_check_time.to_rfc3339(),
-                        jitter_secs
+                        jitter_duration.as_secs()
                     );
                     tokio::time::sleep(jitter_duration).await;
                 }
@@ -551,9 +550,11 @@ impl RunningNode {
                                     // Auto-apply the upgrade
                                     info!("Starting auto-apply upgrade...");
                                     match upgrader.apply_upgrade(&upgrade_info).await {
-                                        Ok(UpgradeResult::Success { version }) => {
-                                            info!("Upgrade to {} successful! Process will restart.", version);
-                                            // If we reach here, exec() failed or not supported
+                                        Ok(UpgradeResult::Success { version, exit_code }) => {
+                                            info!("Upgrade to {} successful, initiating graceful shutdown", version);
+                                            upgrade_exit_code.store(exit_code, Ordering::SeqCst);
+                                            shutdown.cancel();
+                                            break;
                                         }
                                         Ok(UpgradeResult::RolledBack { reason }) => {
                                             warn!("Error during upgrade process: {}", reason);
@@ -582,20 +583,13 @@ impl RunningNode {
                                 }
                             }
                             // Schedule next check with jitter to prevent fleet re-alignment
-                            let base_interval = monitor.check_interval();
-                            let interval_secs = base_interval.as_secs();
-                            let variance = interval_secs / 20; // 5%
-                            let jittered_secs = if variance > 0 {
-                                use rand::Rng;
-                                let jitter = rand::thread_rng().gen_range(0..=variance * 2);
-                                interval_secs.saturating_sub(variance) + jitter
-                            } else {
-                                interval_secs
-                            };
-                            let jittered_duration = std::time::Duration::from_secs(jittered_secs);
+                            let jittered_duration =
+                                jittered_interval(monitor.check_interval());
                             let next_check = chrono::Utc::now()
-                                + chrono::Duration::from_std(jittered_duration)
-                                    .unwrap_or_else(|_| chrono::Duration::hours(1));
+                                + chrono::Duration::from_std(jittered_duration).unwrap_or_else(|e| {
+                                    warn!("chrono::Duration::from_std failed for interval ({e}), defaulting to 1 hour");
+                                    chrono::Duration::hours(1)
+                                });
                             info!("Next upgrade check scheduled for {}", next_check.to_rfc3339());
                             tokio::time::sleep(jittered_duration).await;
                         }
@@ -633,6 +627,16 @@ impl RunningNode {
             warn!("Failed to send ShuttingDown event: {e}");
         }
         info!("Node shutdown complete");
+
+        // If an upgrade triggered the shutdown, exit with the requested code.
+        // This happens *after* all cleanup (P2P shutdown, log flush, etc.) so
+        // that destructors and async resources are properly torn down.
+        let exit_code = self.upgrade_exit_code.load(Ordering::SeqCst);
+        if exit_code >= 0 {
+            info!("Exiting with code {} for upgrade restart", exit_code);
+            std::process::exit(exit_code);
+        }
+
         Ok(())
     }
 
@@ -751,6 +755,18 @@ impl RunningNode {
     pub fn shutdown(&self) {
         self.shutdown.cancel();
     }
+}
+
+/// Apply ±5% jitter to a base interval to prevent thundering-herd behaviour
+/// when multiple nodes check for upgrades on the same schedule.
+fn jittered_interval(base: std::time::Duration) -> std::time::Duration {
+    let secs = base.as_secs();
+    let variance = secs / 20; // 5%
+    if variance == 0 {
+        return base;
+    }
+    let jitter = rand::thread_rng().gen_range(0..=variance * 2);
+    std::time::Duration::from_secs(secs.saturating_sub(variance) + jitter)
 }
 
 #[cfg(test)]

--- a/src/node.rs
+++ b/src/node.rs
@@ -300,7 +300,7 @@ impl NodeBuilder {
         Ok(dirs)
     }
 
-    fn build_upgrade_monitor(config: &NodeConfig, node_id_seed: &[u8]) -> Arc<UpgradeMonitor> {
+    fn build_upgrade_monitor(config: &NodeConfig, node_id_seed: &[u8]) -> UpgradeMonitor {
         let mut monitor = UpgradeMonitor::new(
             config.upgrade.github_repo.clone(),
             config.upgrade.channel,
@@ -319,7 +319,7 @@ impl NodeBuilder {
                 monitor.with_staged_rollout(node_id_seed, config.upgrade.staged_rollout_hours);
         }
 
-        Arc::new(monitor)
+        monitor
     }
 
     /// Build the ANT protocol handler from config.
@@ -428,7 +428,7 @@ pub struct RunningNode {
     shutdown: CancellationToken,
     events_tx: NodeEventsSender,
     events_rx: Option<NodeEventsChannel>,
-    upgrade_monitor: Option<Arc<UpgradeMonitor>>,
+    upgrade_monitor: Option<UpgradeMonitor>,
     /// Bootstrap cache manager for persistent peer storage.
     bootstrap_manager: Option<BootstrapManager>,
     /// ANT protocol handler for chunk storage.
@@ -490,12 +490,12 @@ impl RunningNode {
         self.start_protocol_routing();
 
         // Start upgrade monitor if enabled
-        if let Some(ref monitor) = self.upgrade_monitor {
-            let monitor = Arc::clone(monitor);
+        if let Some(monitor) = self.upgrade_monitor.take() {
             let events_tx = self.events_tx.clone();
             let shutdown = self.shutdown.clone();
 
             tokio::spawn(async move {
+                let mut monitor = monitor;
                 let mut upgrader = AutoApplyUpgrader::new();
                 if let Ok(cache_dir) = upgrade_cache_dir() {
                     upgrader = upgrader.with_binary_cache(BinaryCache::new(cache_dir));
@@ -506,7 +506,7 @@ impl RunningNode {
                         () = shutdown.cancelled() => {
                             break;
                         }
-                        result = monitor.check_for_updates() => {
+                        result = monitor.check_for_ready_upgrade() => {
                             match result {
                                 Ok(Some(upgrade_info)) => {
                                     info!(

--- a/src/node.rs
+++ b/src/node.rs
@@ -581,10 +581,23 @@ impl RunningNode {
                                     warn!("Error during upgrade process: {}", e);
                                 }
                             }
-                            // Schedule next check
-                            let next_check = chrono::Utc::now() + chrono::Duration::from_std(monitor.check_interval()).unwrap_or_else(|_| chrono::Duration::hours(1));
+                            // Schedule next check with jitter to prevent fleet re-alignment
+                            let base_interval = monitor.check_interval();
+                            let interval_secs = base_interval.as_secs();
+                            let variance = interval_secs / 20; // 5%
+                            let jittered_secs = if variance > 0 {
+                                use rand::Rng;
+                                let jitter = rand::thread_rng().gen_range(0..=variance * 2);
+                                interval_secs.saturating_sub(variance) + jitter
+                            } else {
+                                interval_secs
+                            };
+                            let jittered_duration = std::time::Duration::from_secs(jittered_secs);
+                            let next_check = chrono::Utc::now()
+                                + chrono::Duration::from_std(jittered_duration)
+                                    .unwrap_or_else(|_| chrono::Duration::hours(1));
                             info!("Next upgrade check scheduled for {}", next_check.to_rfc3339());
-                            tokio::time::sleep(monitor.check_interval()).await;
+                            tokio::time::sleep(jittered_duration).await;
                         }
                     }
                 }

--- a/src/upgrade/apply.rs
+++ b/src/upgrade/apply.rs
@@ -361,8 +361,30 @@ impl AutoApplyUpgrader {
         Ok(extracted_binary)
     }
 
-    /// Extract the saorsa-node binary from a tar.gz archive.
+    /// Extract the saorsa-node binary from an archive (tar.gz or zip).
+    ///
+    /// The archive format is detected by magic bytes:
+    /// - `1f 8b` → gzip (tar.gz)
+    /// - `50 4b` → zip
     fn extract_binary(archive_path: &Path, dest_dir: &Path) -> Result<PathBuf> {
+        let mut file = File::open(archive_path)?;
+        let mut magic = [0u8; 2];
+        file.read_exact(&mut magic)
+            .map_err(|e| Error::Upgrade(format!("Failed to read archive header: {e}")))?;
+        drop(file);
+
+        match magic {
+            [0x1f, 0x8b] => Self::extract_from_tar_gz(archive_path, dest_dir),
+            [0x50, 0x4b] => Self::extract_from_zip(archive_path, dest_dir),
+            _ => Err(Error::Upgrade(format!(
+                "Unknown archive format (magic bytes: {:02x} {:02x})",
+                magic[0], magic[1]
+            ))),
+        }
+    }
+
+    /// Extract the saorsa-node binary from a tar.gz archive.
+    fn extract_from_tar_gz(archive_path: &Path, dest_dir: &Path) -> Result<PathBuf> {
         let file = File::open(archive_path)?;
         let decoder = GzDecoder::new(file);
         let mut archive = Archive::new(decoder);
@@ -388,7 +410,7 @@ impl AutoApplyUpgrader {
             if let Some(name) = path.file_name() {
                 let name_str = name.to_string_lossy();
                 if name_str == "saorsa-node" || name_str == "saorsa-node.exe" {
-                    debug!("Found binary in archive: {}", path.display());
+                    debug!("Found binary in tar.gz archive: {}", path.display());
 
                     // Read and write the binary
                     let mut contents = Vec::new();
@@ -413,7 +435,61 @@ impl AutoApplyUpgrader {
         }
 
         Err(Error::Upgrade(
-            "saorsa-node binary not found in archive".to_string(),
+            "saorsa-node binary not found in tar.gz archive".to_string(),
+        ))
+    }
+
+    /// Extract the saorsa-node binary from a zip archive.
+    fn extract_from_zip(archive_path: &Path, dest_dir: &Path) -> Result<PathBuf> {
+        let file = File::open(archive_path)?;
+        let mut archive = zip::ZipArchive::new(file)
+            .map_err(|e| Error::Upgrade(format!("Failed to open zip archive: {e}")))?;
+
+        let binary_name = if cfg!(windows) {
+            "saorsa-node.exe"
+        } else {
+            "saorsa-node"
+        };
+        let extracted_binary = dest_dir.join(binary_name);
+
+        for i in 0..archive.len() {
+            let mut entry = archive
+                .by_index(i)
+                .map_err(|e| Error::Upgrade(format!("Failed to read zip entry: {e}")))?;
+
+            let path = match entry.enclosed_name() {
+                Some(p) => p.clone(),
+                None => continue,
+            };
+
+            if let Some(name) = path.file_name() {
+                let name_str = name.to_string_lossy();
+                if name_str == "saorsa-node" || name_str == "saorsa-node.exe" {
+                    debug!("Found binary in zip archive: {}", path.display());
+
+                    let mut contents = Vec::new();
+                    entry
+                        .read_to_end(&mut contents)
+                        .map_err(|e| Error::Upgrade(format!("Failed to read binary: {e}")))?;
+
+                    fs::write(&extracted_binary, &contents)?;
+
+                    // Make executable on Unix
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::PermissionsExt;
+                        let mut perms = fs::metadata(&extracted_binary)?.permissions();
+                        perms.set_mode(0o755);
+                        fs::set_permissions(&extracted_binary, perms)?;
+                    }
+
+                    return Ok(extracted_binary);
+                }
+            }
+        }
+
+        Err(Error::Upgrade(
+            "saorsa-node binary not found in zip archive".to_string(),
         ))
     }
 
@@ -564,5 +640,157 @@ mod tests {
     fn test_default_impl() {
         let upgrader = AutoApplyUpgrader::default();
         assert!(!upgrader.current_version().to_string().is_empty());
+    }
+
+    /// Helper: create a tar.gz archive containing a fake binary.
+    fn create_tar_gz_archive(dir: &Path, binary_name: &str, content: &[u8]) -> PathBuf {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let archive_path = dir.join("test.tar.gz");
+        let file = File::create(&archive_path).unwrap();
+        let encoder = GzEncoder::new(file, Compression::default());
+        let mut builder = tar::Builder::new(encoder);
+
+        let mut header = tar::Header::new_gnu();
+        header.set_size(content.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, binary_name, content)
+            .unwrap();
+        builder.finish().unwrap();
+
+        archive_path
+    }
+
+    /// Helper: create a zip archive containing a fake binary.
+    fn create_zip_archive(dir: &Path, binary_name: &str, content: &[u8]) -> PathBuf {
+        use std::io::Write;
+
+        let archive_path = dir.join("test.zip");
+        let file = File::create(&archive_path).unwrap();
+        let mut zip_writer = zip::ZipWriter::new(file);
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored);
+        zip_writer.start_file(binary_name, options).unwrap();
+        zip_writer.write_all(content).unwrap();
+        zip_writer.finish().unwrap();
+
+        archive_path
+    }
+
+    #[test]
+    fn test_extract_binary_from_tar_gz() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = b"fake-binary-content";
+        let archive = create_tar_gz_archive(dir.path(), "saorsa-node", content);
+
+        let dest = tempfile::tempdir().unwrap();
+        let result = AutoApplyUpgrader::extract_binary(&archive, dest.path());
+        assert!(result.is_ok());
+
+        let extracted = result.unwrap();
+        assert!(extracted.exists());
+        assert_eq!(fs::read(&extracted).unwrap(), content);
+    }
+
+    #[test]
+    fn test_extract_binary_from_zip() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = b"fake-binary-content";
+        let archive = create_zip_archive(dir.path(), "saorsa-node", content);
+
+        let dest = tempfile::tempdir().unwrap();
+        let result = AutoApplyUpgrader::extract_binary(&archive, dest.path());
+        assert!(result.is_ok());
+
+        let extracted = result.unwrap();
+        assert!(extracted.exists());
+        assert_eq!(fs::read(&extracted).unwrap(), content);
+    }
+
+    #[test]
+    fn test_extract_binary_from_zip_with_exe() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = b"fake-windows-binary";
+        let archive = create_zip_archive(dir.path(), "saorsa-node.exe", content);
+
+        let dest = tempfile::tempdir().unwrap();
+        let result = AutoApplyUpgrader::extract_binary(&archive, dest.path());
+        assert!(result.is_ok());
+
+        let extracted = result.unwrap();
+        assert!(extracted.exists());
+        assert_eq!(fs::read(&extracted).unwrap(), content);
+    }
+
+    #[test]
+    fn test_extract_binary_from_tar_gz_nested_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = b"nested-binary";
+        let archive =
+            create_tar_gz_archive(dir.path(), "some/nested/path/saorsa-node", content);
+
+        let dest = tempfile::tempdir().unwrap();
+        let result = AutoApplyUpgrader::extract_binary(&archive, dest.path());
+        assert!(result.is_ok());
+
+        let extracted = result.unwrap();
+        assert!(extracted.exists());
+        assert_eq!(fs::read(&extracted).unwrap(), content);
+    }
+
+    #[test]
+    fn test_extract_binary_unknown_format() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive_path = dir.path().join("bad_archive");
+        fs::write(&archive_path, b"XX not a real archive").unwrap();
+
+        let dest = tempfile::tempdir().unwrap();
+        let result = AutoApplyUpgrader::extract_binary(&archive_path, dest.path());
+        assert!(result.is_err());
+
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Unknown archive format"));
+    }
+
+    #[test]
+    fn test_extract_binary_missing_binary_in_tar_gz() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = b"not-the-binary";
+        let archive = create_tar_gz_archive(dir.path(), "other-file", content);
+
+        let dest = tempfile::tempdir().unwrap();
+        let result = AutoApplyUpgrader::extract_binary(&archive, dest.path());
+        assert!(result.is_err());
+
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("not found in tar.gz archive"));
+    }
+
+    #[test]
+    fn test_extract_binary_missing_binary_in_zip() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = b"not-the-binary";
+        let archive = create_zip_archive(dir.path(), "other-file", content);
+
+        let dest = tempfile::tempdir().unwrap();
+        let result = AutoApplyUpgrader::extract_binary(&archive, dest.path());
+        assert!(result.is_err());
+
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("not found in zip archive"));
+    }
+
+    #[test]
+    fn test_extract_binary_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive_path = dir.path().join("empty");
+        fs::write(&archive_path, b"").unwrap();
+
+        let dest = tempfile::tempdir().unwrap();
+        let result = AutoApplyUpgrader::extract_binary(&archive_path, dest.path());
+        assert!(result.is_err());
     }
 }

--- a/src/upgrade/apply.rs
+++ b/src/upgrade/apply.rs
@@ -101,19 +101,26 @@ impl AutoApplyUpgrader {
         let invoked_path = env::args().next().map(PathBuf::from);
 
         if let Some(ref invoked) = invoked_path {
-            if invoked.exists() {
-                let path_str = invoked.to_string_lossy();
-                if path_str.ends_with(" (deleted)") {
-                    let cleaned = path_str.trim_end_matches(" (deleted)");
-                    debug!("Stripped '(deleted)' suffix from invoked path: {cleaned}");
-                    return Ok(PathBuf::from(cleaned));
-                }
+            // Check for "(deleted)" suffix first — on Linux, /proc/self/exe
+            // reports this when the on-disk binary has been replaced. The
+            // `exists()` check below would return false for the suffixed path,
+            // so we must strip it before testing existence.
+            let path_str = invoked.to_string_lossy();
+            let cleaned = if path_str.ends_with(" (deleted)") {
+                let stripped = path_str.trim_end_matches(" (deleted)");
+                debug!("Stripped '(deleted)' suffix from invoked path: {stripped}");
+                PathBuf::from(stripped)
+            } else {
+                invoked.clone()
+            };
+
+            if cleaned.exists() {
                 // Canonicalize to an absolute path so that trigger_restart
                 // works even if the CWD has changed since startup.
-                if let Ok(canonical) = invoked.canonicalize() {
+                if let Ok(canonical) = cleaned.canonicalize() {
                     return Ok(canonical);
                 }
-                return Ok(invoked.clone());
+                return Ok(cleaned);
             }
         }
 
@@ -200,9 +207,10 @@ impl AutoApplyUpgrader {
                     "Binary already upgraded to {} by another service, skipping replacement",
                     info.version
                 );
-                self.trigger_restart(&current_binary)?;
+                let exit_code = self.prepare_restart(&current_binary)?;
                 return Ok(UpgradeResult::Success {
                     version: info.version.clone(),
+                    exit_code,
                 });
             }
         }
@@ -222,9 +230,16 @@ impl AutoApplyUpgrader {
             });
         }
 
-        // Step 6: Replace binary
+        // Step 6: Replace binary (offloaded to blocking thread to avoid
+        // starving the tokio runtime, especially on Windows where retries sleep)
         info!("Replacing binary...");
-        if let Err(e) = Self::replace_binary(&extracted_binary, &current_binary) {
+        let new_bin = extracted_binary.clone();
+        let target_bin = current_binary.clone();
+        let replace_result =
+            tokio::task::spawn_blocking(move || Self::replace_binary(&new_bin, &target_bin))
+                .await
+                .map_err(|e| Error::Upgrade(format!("Binary replacement task panicked: {e}")))?;
+        if let Err(e) = replace_result {
             warn!("Binary replacement failed: {e}");
             // Attempt rollback
             if let Err(restore_err) = fs::copy(&backup_path, &current_binary) {
@@ -243,11 +258,12 @@ impl AutoApplyUpgrader {
             info.version
         );
 
-        // Step 7: Trigger restart
-        self.trigger_restart(&current_binary)?;
+        // Step 7: Prepare restart (spawn new process if standalone mode)
+        let exit_code = self.prepare_restart(&current_binary)?;
 
         Ok(UpgradeResult::Success {
             version: info.version.clone(),
+            exit_code,
         })
     }
 
@@ -527,6 +543,9 @@ impl AutoApplyUpgrader {
     }
 
     /// Replace the current binary with the new one.
+    ///
+    /// This is a blocking operation (filesystem I/O, and on Windows potentially
+    /// retries with back-off). Call via `spawn_blocking` from async context.
     fn replace_binary(new_binary: &Path, target: &Path) -> Result<()> {
         #[cfg(unix)]
         {
@@ -543,7 +562,7 @@ impl AutoApplyUpgrader {
         {
             let _ = target; // target is the current exe — self_replace handles it
                             // Retry with back-off: Windows file locks may delay replacement
-            let delays = [500, 1000, 2000];
+            let delays = [500u64, 1000, 2000];
             let mut last_err = None;
             for (attempt, delay_ms) in delays.iter().enumerate() {
                 match self_replace::self_replace(new_binary) {
@@ -572,45 +591,50 @@ impl AutoApplyUpgrader {
         Ok(())
     }
 
-    /// Trigger a restart of the node process after a successful upgrade.
+    /// Prepare for a restart after a successful upgrade.
+    ///
+    /// Returns the exit code that the process should use after graceful shutdown.
+    /// The caller is responsible for triggering graceful shutdown (e.g. via
+    /// `CancellationToken`) and then calling `std::process::exit()` with the
+    /// returned code **after** all async cleanup has completed.
     ///
     /// **Service manager mode** (`stop_on_upgrade = true`):
-    /// Exit cleanly and let the service manager (systemd, launchd, Windows Service)
-    /// restart the process. On Unix exits with code 0; on Windows exits with
-    /// [`RESTART_EXIT_CODE`] (100) because `WinSW` uses `RestartPolicy::OnFailure`.
+    /// Returns exit code 0 on Unix or [`RESTART_EXIT_CODE`] on Windows so the
+    /// service manager (systemd, launchd, Windows Service) restarts the process.
     ///
     /// **Standalone mode** (`stop_on_upgrade = false`):
-    /// Spawn the new binary as a child process with the same arguments, then exit.
-    /// This ensures continuity when no service manager is present.
-    fn trigger_restart(&self, binary_path: &Path) -> Result<()> {
+    /// Spawns the new binary as a child process with the same arguments, then
+    /// returns exit code 0.
+    fn prepare_restart(&self, binary_path: &Path) -> Result<i32> {
         if self.stop_on_upgrade {
-            // Service manager mode: exit and let the service manager restart us
+            let exit_code;
+
             #[cfg(unix)]
             {
-                info!("Exiting with code 0 for service manager restart");
-                std::thread::sleep(std::time::Duration::from_millis(100));
-                std::process::exit(0);
+                info!("Service manager mode: will exit with code 0 after graceful shutdown");
+                exit_code = 0;
             }
 
             #[cfg(windows)]
             {
                 let _ = binary_path;
                 info!(
-                    "Exiting with code {} to signal service manager restart",
+                    "Service manager mode: will exit with code {} after graceful shutdown",
                     RESTART_EXIT_CODE
                 );
-                std::thread::sleep(std::time::Duration::from_millis(100));
-                std::process::exit(RESTART_EXIT_CODE);
+                exit_code = RESTART_EXIT_CODE;
             }
 
             #[cfg(not(any(unix, windows)))]
             {
                 let _ = binary_path;
                 warn!("Auto-restart not supported on this platform. Please restart manually.");
-                Ok(())
+                exit_code = 0;
             }
+
+            Ok(exit_code)
         } else {
-            // Standalone mode: spawn new process then exit
+            // Standalone mode: spawn new process, then exit after graceful shutdown
             let args: Vec<String> = env::args().skip(1).collect();
 
             info!("Spawning new process: {} {:?}", binary_path.display(), args);
@@ -623,9 +647,8 @@ impl AutoApplyUpgrader {
                 .spawn()
                 .map_err(|e| Error::Upgrade(format!("Failed to spawn new binary: {e}")))?;
 
-            info!("New process spawned, exiting old process");
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            std::process::exit(0);
+            info!("New process spawned, will exit after graceful shutdown");
+            Ok(0)
         }
     }
 }

--- a/src/upgrade/apply.rs
+++ b/src/upgrade/apply.rs
@@ -8,6 +8,7 @@
 //! 5. Restart the node process
 
 use crate::error::{Error, Result};
+use crate::upgrade::binary_cache::BinaryCache;
 use crate::upgrade::{signature, UpgradeInfo, UpgradeResult};
 use flate2::read::GzDecoder;
 use semver::Version;
@@ -21,12 +22,21 @@ use tracing::{debug, error, info, warn};
 /// Maximum allowed upgrade archive size (200 MiB).
 const MAX_ARCHIVE_SIZE_BYTES: usize = 200 * 1024 * 1024;
 
+/// Exit code that signals the service manager to restart the process.
+///
+/// On Windows, `trigger_restart` exits with this code instead of using
+/// `exec()`.  The wrapping service (e.g. NSSM or Windows Service) should be
+/// configured to restart on this exit code.
+pub const RESTART_EXIT_CODE: i32 = 100;
+
 /// Auto-apply upgrader with archive support.
 pub struct AutoApplyUpgrader {
     /// Current running version.
     current_version: Version,
     /// HTTP client for downloads.
     client: reqwest::Client,
+    /// Shared binary cache (optional).
+    binary_cache: Option<BinaryCache>,
 }
 
 impl AutoApplyUpgrader {
@@ -43,7 +53,18 @@ impl AutoApplyUpgrader {
                 .timeout(std::time::Duration::from_secs(300))
                 .build()
                 .unwrap_or_else(|_| reqwest::Client::new()),
+            binary_cache: None,
         }
+    }
+
+    /// Configure a shared binary cache for downloaded upgrades.
+    ///
+    /// When set, `apply_upgrade` will check the cache before downloading
+    /// and store freshly verified binaries so other nodes can reuse them.
+    #[must_use]
+    pub fn with_binary_cache(mut self, cache: BinaryCache) -> Self {
+        self.binary_cache = Some(cache);
+        self
     }
 
     /// Get the current version.
@@ -102,48 +123,43 @@ impl AutoApplyUpgrader {
             .tempdir_in(binary_dir)
             .map_err(|e| Error::Upgrade(format!("Failed to create temp dir: {e}")))?;
 
-        let archive_path = temp_dir.path().join("archive");
-        let sig_path = temp_dir.path().join("signature");
+        let version_str = info.version.to_string();
 
-        // Step 1: Download archive
-        info!("Downloading upgrade archive...");
-        if let Err(e) = self.download(&info.download_url, &archive_path).await {
-            warn!("Archive download failed: {e}");
-            return Ok(UpgradeResult::RolledBack {
-                reason: format!("Download failed: {e}"),
-            });
-        }
-
-        // Step 2: Download signature
-        info!("Downloading signature...");
-        if let Err(e) = self.download(&info.signature_url, &sig_path).await {
-            warn!("Signature download failed: {e}");
-            return Ok(UpgradeResult::RolledBack {
-                reason: format!("Signature download failed: {e}"),
-            });
-        }
-
-        // Step 3: Verify signature on archive BEFORE extraction (security: verify before unpacking)
-        info!("Verifying ML-DSA signature on archive...");
-        if let Err(e) = signature::verify_from_file(&archive_path, &sig_path) {
-            warn!("Signature verification failed: {e}");
-            return Ok(UpgradeResult::RolledBack {
-                reason: format!("Signature verification failed: {e}"),
-            });
-        }
-        info!("Archive signature verified successfully");
-
-        // Step 4: Extract binary from verified archive
-        info!("Extracting binary from archive...");
-        let extracted_binary = match Self::extract_binary(&archive_path, temp_dir.path()) {
-            Ok(path) => path,
-            Err(e) => {
-                warn!("Extraction failed: {e}");
-                return Ok(UpgradeResult::RolledBack {
-                    reason: format!("Extraction failed: {e}"),
-                });
+        // Try the binary cache first
+        let extracted_binary = if let Some(ref cache) = self.binary_cache {
+            if let Some(cached_path) = cache.get_verified(&version_str) {
+                info!("Cached binary verified for version {}", version_str);
+                // Copy from cache (not move) to preserve for other nodes
+                let dest = temp_dir.path().join(
+                    cached_path
+                        .file_name()
+                        .unwrap_or_else(|| std::ffi::OsStr::new("saorsa-node")),
+                );
+                if let Err(e) = fs::copy(&cached_path, &dest) {
+                    warn!("Failed to copy from cache, will re-download: {e}");
+                    self.download_verify_extract(info, temp_dir.path(), Some(cache))
+                        .await?
+                } else {
+                    dest
+                }
+            } else {
+                // Cache miss — acquire download lock, double-check, then download
+                self.download_verify_extract(info, temp_dir.path(), Some(cache))
+                    .await?
             }
+        } else {
+            // No cache configured — use the original download path
+            self.download_verify_extract(info, temp_dir.path(), None)
+                .await?
         };
+
+        // Handle RolledBack sentinel (empty path means a step failed gracefully)
+        if !extracted_binary.exists() {
+            // download_verify_extract already logged the issue
+            return Ok(UpgradeResult::RolledBack {
+                reason: "Download/verify/extract failed (see earlier logs)".to_string(),
+            });
+        }
 
         // Step 5: Create backup of current binary
         let backup_path = binary_dir.join(format!(
@@ -225,13 +241,76 @@ impl AutoApplyUpgrader {
         Ok(())
     }
 
+    /// Download archive, verify signature, extract binary, and optionally
+    /// store in the binary cache.
+    ///
+    /// Returns the path to the extracted binary inside `dest_dir`.  On any
+    /// recoverable failure the path will not exist (caller checks
+    /// `.exists()`).
+    async fn download_verify_extract(
+        &self,
+        info: &UpgradeInfo,
+        dest_dir: &Path,
+        cache: Option<&BinaryCache>,
+    ) -> Result<PathBuf> {
+        let archive_path = dest_dir.join("archive");
+        let sig_path = dest_dir.join("signature");
+
+        // Step 1: Download archive
+        info!("Downloading saorsa-node binary...");
+        if let Err(e) = self.download(&info.download_url, &archive_path).await {
+            warn!("Archive download failed: {e}");
+            return Ok(dest_dir.join("_failed_"));
+        }
+
+        // Step 2: Download signature
+        info!("Downloading signature...");
+        if let Err(e) = self.download(&info.signature_url, &sig_path).await {
+            warn!("Signature download failed: {e}");
+            return Ok(dest_dir.join("_failed_"));
+        }
+
+        // Step 3: Verify signature on archive BEFORE extraction
+        info!("Verifying ML-DSA signature on archive...");
+        if let Err(e) = signature::verify_from_file(&archive_path, &sig_path) {
+            warn!("Signature verification failed: {e}");
+            return Ok(dest_dir.join("_failed_"));
+        }
+        info!("Archive signature verified successfully");
+
+        // Step 4: Extract binary from verified archive
+        info!("Extracting binary from archive...");
+        let extracted_binary = match Self::extract_binary(&archive_path, dest_dir) {
+            Ok(path) => path,
+            Err(e) => {
+                warn!("Extraction failed: {e}");
+                return Ok(dest_dir.join("_failed_"));
+            }
+        };
+
+        // Store in binary cache if available
+        if let Some(c) = cache {
+            let version_str = info.version.to_string();
+            if let Err(e) = c.store(&version_str, &extracted_binary) {
+                warn!("Failed to store binary in cache: {e}");
+            }
+        }
+
+        Ok(extracted_binary)
+    }
+
     /// Extract the saorsa-node binary from a tar.gz archive.
     fn extract_binary(archive_path: &Path, dest_dir: &Path) -> Result<PathBuf> {
         let file = File::open(archive_path)?;
         let decoder = GzDecoder::new(file);
         let mut archive = Archive::new(decoder);
 
-        let extracted_binary = dest_dir.join("saorsa-node");
+        let binary_name = if cfg!(windows) {
+            "saorsa-node.exe"
+        } else {
+            "saorsa-node"
+        };
+        let extracted_binary = dest_dir.join(binary_name);
 
         for entry in archive
             .entries()
@@ -278,17 +357,46 @@ impl AutoApplyUpgrader {
 
     /// Replace the current binary with the new one.
     fn replace_binary(new_binary: &Path, target: &Path) -> Result<()> {
-        // Preserve original permissions on Unix
         #[cfg(unix)]
         {
+            // Preserve original permissions on Unix
             if let Ok(meta) = fs::metadata(target) {
                 let perms = meta.permissions();
                 fs::set_permissions(new_binary, perms)?;
             }
+            // Atomic rename
+            fs::rename(new_binary, target)?;
         }
 
-        // Atomic rename
-        fs::rename(new_binary, target)?;
+        #[cfg(windows)]
+        {
+            let _ = target; // target is the current exe — self_replace handles it
+            // Retry with back-off: Windows file locks may delay replacement
+            let delays = [500, 1000, 2000];
+            let mut last_err = None;
+            for (attempt, delay_ms) in delays.iter().enumerate() {
+                match self_replace::self_replace(new_binary) {
+                    Ok(()) => {
+                        last_err = None;
+                        break;
+                    }
+                    Err(e) => {
+                        warn!(
+                            "self_replace attempt {} failed: {e}, retrying in {delay_ms}ms",
+                            attempt + 1
+                        );
+                        last_err = Some(e);
+                        std::thread::sleep(std::time::Duration::from_millis(*delay_ms));
+                    }
+                }
+            }
+            if let Some(e) = last_err {
+                return Err(Error::Upgrade(format!(
+                    "self_replace failed after retries: {e}"
+                )));
+            }
+        }
+
         debug!("Binary replacement complete");
         Ok(())
     }
@@ -296,7 +404,8 @@ impl AutoApplyUpgrader {
     /// Trigger a restart of the node process.
     ///
     /// On Unix, uses `exec()` to replace the current process.
-    /// The calling code should ensure graceful shutdown before calling this.
+    /// On Windows, exits with [`RESTART_EXIT_CODE`] so the service manager
+    /// can restart the process.
     fn trigger_restart(binary_path: &Path) -> Result<()> {
         #[cfg(unix)]
         {
@@ -314,11 +423,19 @@ impl AutoApplyUpgrader {
             Err(Error::Upgrade(format!("Failed to exec new binary: {err}")))
         }
 
-        #[cfg(not(unix))]
+        #[cfg(windows)]
         {
-            // On Windows, we can't replace a running binary
-            // Just log and let the user restart manually
-            let _ = binary_path; // Suppress unused warning on Windows
+            let _ = binary_path;
+            info!(
+                "Exiting with code {} to signal service manager restart",
+                RESTART_EXIT_CODE
+            );
+            std::process::exit(RESTART_EXIT_CODE);
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = binary_path;
             warn!("Auto-restart not supported on this platform. Please restart manually.");
             Ok(())
         }

--- a/src/upgrade/apply.rs
+++ b/src/upgrade/apply.rs
@@ -108,6 +108,11 @@ impl AutoApplyUpgrader {
                     debug!("Stripped '(deleted)' suffix from invoked path: {cleaned}");
                     return Ok(PathBuf::from(cleaned));
                 }
+                // Canonicalize to an absolute path so that trigger_restart
+                // works even if the CWD has changed since startup.
+                if let Ok(canonical) = invoked.canonicalize() {
+                    return Ok(canonical);
+                }
                 return Ok(invoked.clone());
             }
         }
@@ -172,45 +177,24 @@ impl AutoApplyUpgrader {
 
         let version_str = info.version.to_string();
 
-        // Try the binary cache first
-        let extracted_binary = if let Some(ref cache) = self.binary_cache {
-            if let Some(cached_path) = cache.get_verified(&version_str) {
-                info!("Cached binary verified for version {}", version_str);
-                // Copy from cache (not move) to preserve for other nodes
-                let dest = temp_dir.path().join(
-                    cached_path
-                        .file_name()
-                        .unwrap_or_else(|| std::ffi::OsStr::new("saorsa-node")),
-                );
-                if let Err(e) = fs::copy(&cached_path, &dest) {
-                    warn!("Failed to copy from cache, will re-download: {e}");
-                    self.download_verify_extract(info, temp_dir.path(), Some(cache))
-                        .await?
-                } else {
-                    dest
-                }
-            } else {
-                // Cache miss — acquire download lock, double-check, then download
-                self.download_verify_extract(info, temp_dir.path(), Some(cache))
-                    .await?
+        // Try the binary cache first; download/verify/extract errors are
+        // recoverable and result in RolledBack rather than a hard error.
+        let extracted_binary = match self
+            .resolve_upgrade_binary(info, temp_dir.path(), &version_str)
+            .await
+        {
+            Ok(path) => path,
+            Err(e) => {
+                warn!("Download/verify/extract failed: {e}");
+                return Ok(UpgradeResult::RolledBack {
+                    reason: format!("{e}"),
+                });
             }
-        } else {
-            // No cache configured — use the original download path
-            self.download_verify_extract(info, temp_dir.path(), None)
-                .await?
         };
-
-        // Handle RolledBack sentinel (empty path means a step failed gracefully)
-        if !extracted_binary.exists() {
-            // download_verify_extract already logged the issue
-            return Ok(UpgradeResult::RolledBack {
-                reason: "Download/verify/extract failed (see earlier logs)".to_string(),
-            });
-        }
 
         // Check if the on-disk binary has already been upgraded by a sibling service.
         // This prevents redundant backup/replace cycles when multiple nodes share one binary.
-        if let Some(disk_version) = on_disk_version(&current_binary) {
+        if let Some(disk_version) = on_disk_version(&current_binary).await {
             if disk_version == info.version {
                 info!(
                     "Binary already upgraded to {} by another service, skipping replacement",
@@ -303,12 +287,81 @@ impl AutoApplyUpgrader {
         Ok(())
     }
 
+    /// Resolve the upgrade binary, checking the cache first and falling back
+    /// to a full download/verify/extract cycle.
+    ///
+    /// On a cache miss the exclusive download lock is acquired (via
+    /// `spawn_blocking` to avoid blocking the tokio runtime), the cache is
+    /// re-checked, and if still missing the full download runs while the lock
+    /// is held so that only one node downloads per version.
+    async fn resolve_upgrade_binary(
+        &self,
+        info: &UpgradeInfo,
+        dest_dir: &Path,
+        version_str: &str,
+    ) -> Result<PathBuf> {
+        if let Some(ref cache) = self.binary_cache {
+            // Fast path — cache hit without locking
+            if let Some(cached_path) = cache.get_verified(version_str) {
+                info!("Cached binary verified for version {}", version_str);
+                let dest = dest_dir.join(
+                    cached_path
+                        .file_name()
+                        .unwrap_or_else(|| std::ffi::OsStr::new("saorsa-node")),
+                );
+                if let Err(e) = fs::copy(&cached_path, &dest) {
+                    warn!("Failed to copy from cache, will re-download: {e}");
+                    return self
+                        .download_verify_extract(info, dest_dir, Some(cache))
+                        .await;
+                }
+                return Ok(dest);
+            }
+
+            // Cache miss — acquire exclusive download lock via spawn_blocking
+            // to avoid blocking the tokio runtime while waiting for the lock.
+            let cache_clone = cache.clone();
+            // Named `lock_guard` (not `_lock_guard`) so the compiler keeps it
+            // alive across the `.await` below — dropping it would release the
+            // file lock before the download completes.
+            let lock_guard =
+                tokio::task::spawn_blocking(move || cache_clone.acquire_download_lock())
+                    .await
+                    .map_err(|e| Error::Upgrade(format!("Lock task failed: {e}")))??;
+
+            // Re-check cache under the lock — another node may have populated it
+            if let Some(cached_path) = cache.get_verified(version_str) {
+                info!(
+                    "Cached binary became available under lock for version {}",
+                    version_str
+                );
+                let dest = dest_dir.join(
+                    cached_path
+                        .file_name()
+                        .unwrap_or_else(|| std::ffi::OsStr::new("saorsa-node")),
+                );
+                fs::copy(&cached_path, &dest)?;
+                return Ok(dest);
+            }
+
+            // Still missing — download while holding the lock
+            let result = self
+                .download_verify_extract(info, dest_dir, Some(cache))
+                .await;
+            drop(lock_guard);
+            result
+        } else {
+            self.download_verify_extract(info, dest_dir, None).await
+        }
+    }
+
     /// Download archive, verify signature, extract binary, and optionally
     /// store in the binary cache.
     ///
-    /// Returns the path to the extracted binary inside `dest_dir`.  On any
-    /// recoverable failure the path will not exist (caller checks
-    /// `.exists()`).
+    /// # Errors
+    ///
+    /// Returns an error if any step (download, signature verification,
+    /// extraction) fails.
     async fn download_verify_extract(
         &self,
         info: &UpgradeInfo,
@@ -320,35 +373,20 @@ impl AutoApplyUpgrader {
 
         // Step 1: Download archive
         info!("Downloading saorsa-node binary...");
-        if let Err(e) = self.download(&info.download_url, &archive_path).await {
-            warn!("Archive download failed: {e}");
-            return Ok(dest_dir.join("_failed_"));
-        }
+        self.download(&info.download_url, &archive_path).await?;
 
         // Step 2: Download signature
         info!("Downloading signature...");
-        if let Err(e) = self.download(&info.signature_url, &sig_path).await {
-            warn!("Signature download failed: {e}");
-            return Ok(dest_dir.join("_failed_"));
-        }
+        self.download(&info.signature_url, &sig_path).await?;
 
         // Step 3: Verify signature on archive BEFORE extraction
         info!("Verifying ML-DSA signature on archive...");
-        if let Err(e) = signature::verify_from_file(&archive_path, &sig_path) {
-            warn!("Signature verification failed: {e}");
-            return Ok(dest_dir.join("_failed_"));
-        }
+        signature::verify_from_file(&archive_path, &sig_path)?;
         info!("Archive signature verified successfully");
 
         // Step 4: Extract binary from verified archive
         info!("Extracting binary from archive...");
-        let extracted_binary = match Self::extract_binary(&archive_path, dest_dir) {
-            Ok(path) => path,
-            Err(e) => {
-                warn!("Extraction failed: {e}");
-                return Ok(dest_dir.join("_failed_"));
-            }
-        };
+        let extracted_binary = Self::extract_binary(&archive_path, dest_dir)?;
 
         // Store in binary cache if available
         if let Some(c) = cache {
@@ -412,13 +450,10 @@ impl AutoApplyUpgrader {
                 if name_str == "saorsa-node" || name_str == "saorsa-node.exe" {
                     debug!("Found binary in tar.gz archive: {}", path.display());
 
-                    // Read and write the binary
-                    let mut contents = Vec::new();
-                    entry
-                        .read_to_end(&mut contents)
-                        .map_err(|e| Error::Upgrade(format!("Failed to read binary: {e}")))?;
-
-                    fs::write(&extracted_binary, &contents)?;
+                    // Stream directly to disk to avoid large heap allocations
+                    let mut out = File::create(&extracted_binary)?;
+                    std::io::copy(&mut entry, &mut out)
+                        .map_err(|e| Error::Upgrade(format!("Failed to write binary: {e}")))?;
 
                     // Make executable on Unix
                     #[cfg(unix)]
@@ -467,12 +502,10 @@ impl AutoApplyUpgrader {
                 if name_str == "saorsa-node" || name_str == "saorsa-node.exe" {
                     debug!("Found binary in zip archive: {}", path.display());
 
-                    let mut contents = Vec::new();
-                    entry
-                        .read_to_end(&mut contents)
-                        .map_err(|e| Error::Upgrade(format!("Failed to read binary: {e}")))?;
-
-                    fs::write(&extracted_binary, &contents)?;
+                    // Stream directly to disk to avoid large heap allocations
+                    let mut out = File::create(&extracted_binary)?;
+                    std::io::copy(&mut entry, &mut out)
+                        .map_err(|e| Error::Upgrade(format!("Failed to write binary: {e}")))?;
 
                     // Make executable on Unix
                     #[cfg(unix)]
@@ -599,13 +632,21 @@ impl AutoApplyUpgrader {
 
 /// Run the on-disk binary with `--version` and parse the reported version.
 ///
-/// Returns `None` if the binary cannot be executed or the output cannot be parsed.
+/// Returns `None` if the binary cannot be executed, times out, or the output
+/// cannot be parsed.  Uses `tokio::process::Command` with a 5-second timeout
+/// to avoid blocking the async runtime.
+///
 /// Output format is expected to be "saorsa-node X.Y.Z" or "saorsa-node X.Y.Z-rc.N".
-fn on_disk_version(binary_path: &Path) -> Option<Version> {
-    let output = std::process::Command::new(binary_path)
-        .arg("--version")
-        .output()
-        .ok()?;
+async fn on_disk_version(binary_path: &Path) -> Option<Version> {
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        tokio::process::Command::new(binary_path)
+            .arg("--version")
+            .output(),
+    )
+    .await
+    .ok()?
+    .ok()?;
     let stdout = String::from_utf8_lossy(&output.stdout);
     let version_str = stdout.trim().strip_prefix("saorsa-node ")?;
     Version::parse(version_str).ok()
@@ -729,8 +770,7 @@ mod tests {
     fn test_extract_binary_from_tar_gz_nested_path() {
         let dir = tempfile::tempdir().unwrap();
         let content = b"nested-binary";
-        let archive =
-            create_tar_gz_archive(dir.path(), "some/nested/path/saorsa-node", content);
+        let archive = create_tar_gz_archive(dir.path(), "some/nested/path/saorsa-node", content);
 
         let dest = tempfile::tempdir().unwrap();
         let result = AutoApplyUpgrader::extract_binary(&archive, dest.path());

--- a/src/upgrade/apply.rs
+++ b/src/upgrade/apply.rs
@@ -96,8 +96,25 @@ impl AutoApplyUpgrader {
     ///
     /// Returns an error if the binary path cannot be determined.
     pub fn current_binary_path() -> Result<PathBuf> {
-        let path =
-            env::current_exe().map_err(|e| Error::Upgrade(format!("Cannot determine binary path: {e}")))?;
+        // Prefer the invoked path (argv[0]) if it exists, as it preserves symlinks.
+        // Fall back to current_exe() which resolves symlinks via /proc/self/exe.
+        let invoked_path = env::args().next().map(PathBuf::from);
+
+        if let Some(ref invoked) = invoked_path {
+            if invoked.exists() {
+                let path_str = invoked.to_string_lossy();
+                if path_str.ends_with(" (deleted)") {
+                    let cleaned = path_str.trim_end_matches(" (deleted)");
+                    debug!("Stripped '(deleted)' suffix from invoked path: {cleaned}");
+                    return Ok(PathBuf::from(cleaned));
+                }
+                return Ok(invoked.clone());
+            }
+        }
+
+        // Fall back to current_exe (resolves symlinks on Linux)
+        let path = env::current_exe()
+            .map_err(|e| Error::Upgrade(format!("Cannot determine binary path: {e}")))?;
 
         #[cfg(unix)]
         {
@@ -189,6 +206,21 @@ impl AutoApplyUpgrader {
             return Ok(UpgradeResult::RolledBack {
                 reason: "Download/verify/extract failed (see earlier logs)".to_string(),
             });
+        }
+
+        // Check if the on-disk binary has already been upgraded by a sibling service.
+        // This prevents redundant backup/replace cycles when multiple nodes share one binary.
+        if let Some(disk_version) = on_disk_version(&current_binary) {
+            if disk_version == info.version {
+                info!(
+                    "Binary already upgraded to {} by another service, skipping replacement",
+                    info.version
+                );
+                self.trigger_restart(&current_binary)?;
+                return Ok(UpgradeResult::Success {
+                    version: info.version.clone(),
+                });
+            }
         }
 
         // Step 5: Create backup of current binary
@@ -401,7 +433,7 @@ impl AutoApplyUpgrader {
         #[cfg(windows)]
         {
             let _ = target; // target is the current exe — self_replace handles it
-            // Retry with back-off: Windows file locks may delay replacement
+                            // Retry with back-off: Windows file locks may delay replacement
             let delays = [500, 1000, 2000];
             let mut last_err = None;
             for (attempt, delay_ms) in delays.iter().enumerate() {
@@ -447,6 +479,7 @@ impl AutoApplyUpgrader {
             #[cfg(unix)]
             {
                 info!("Exiting with code 0 for service manager restart");
+                std::thread::sleep(std::time::Duration::from_millis(100));
                 std::process::exit(0);
             }
 
@@ -457,6 +490,7 @@ impl AutoApplyUpgrader {
                     "Exiting with code {} to signal service manager restart",
                     RESTART_EXIT_CODE
                 );
+                std::thread::sleep(std::time::Duration::from_millis(100));
                 std::process::exit(RESTART_EXIT_CODE);
             }
 
@@ -470,11 +504,7 @@ impl AutoApplyUpgrader {
             // Standalone mode: spawn new process then exit
             let args: Vec<String> = env::args().skip(1).collect();
 
-            info!(
-                "Spawning new process: {} {:?}",
-                binary_path.display(),
-                args
-            );
+            info!("Spawning new process: {} {:?}", binary_path.display(), args);
 
             std::process::Command::new(binary_path)
                 .args(&args)
@@ -482,14 +512,27 @@ impl AutoApplyUpgrader {
                 .stdout(std::process::Stdio::inherit())
                 .stderr(std::process::Stdio::inherit())
                 .spawn()
-                .map_err(|e| {
-                    Error::Upgrade(format!("Failed to spawn new binary: {e}"))
-                })?;
+                .map_err(|e| Error::Upgrade(format!("Failed to spawn new binary: {e}")))?;
 
             info!("New process spawned, exiting old process");
+            std::thread::sleep(std::time::Duration::from_millis(100));
             std::process::exit(0);
         }
     }
+}
+
+/// Run the on-disk binary with `--version` and parse the reported version.
+///
+/// Returns `None` if the binary cannot be executed or the output cannot be parsed.
+/// Output format is expected to be "saorsa-node X.Y.Z" or "saorsa-node X.Y.Z-rc.N".
+fn on_disk_version(binary_path: &Path) -> Option<Version> {
+    let output = std::process::Command::new(binary_path)
+        .arg("--version")
+        .output()
+        .ok()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let version_str = stdout.trim().strip_prefix("saorsa-node ")?;
+    Version::parse(version_str).ok()
 }
 
 impl Default for AutoApplyUpgrader {

--- a/src/upgrade/apply.rs
+++ b/src/upgrade/apply.rs
@@ -37,6 +37,8 @@ pub struct AutoApplyUpgrader {
     client: reqwest::Client,
     /// Shared binary cache (optional).
     binary_cache: Option<BinaryCache>,
+    /// When true, exit cleanly for service manager restart instead of spawning.
+    stop_on_upgrade: bool,
 }
 
 impl AutoApplyUpgrader {
@@ -54,6 +56,7 @@ impl AutoApplyUpgrader {
                 .build()
                 .unwrap_or_else(|_| reqwest::Client::new()),
             binary_cache: None,
+            stop_on_upgrade: false,
         }
     }
 
@@ -64,6 +67,16 @@ impl AutoApplyUpgrader {
     #[must_use]
     pub fn with_binary_cache(mut self, cache: BinaryCache) -> Self {
         self.binary_cache = Some(cache);
+        self
+    }
+
+    /// Configure the upgrader to exit cleanly instead of spawning a new process.
+    ///
+    /// When enabled, the node exits after applying an upgrade, relying on an
+    /// external service manager (systemd, launchd, Windows Service) to restart it.
+    #[must_use]
+    pub fn with_stop_on_upgrade(mut self, stop: bool) -> Self {
+        self.stop_on_upgrade = stop;
         self
     }
 
@@ -215,7 +228,7 @@ impl AutoApplyUpgrader {
         );
 
         // Step 7: Trigger restart
-        Self::trigger_restart(&current_binary)?;
+        self.trigger_restart(&current_binary)?;
 
         Ok(UpgradeResult::Success {
             version: info.version.clone(),
@@ -418,43 +431,63 @@ impl AutoApplyUpgrader {
         Ok(())
     }
 
-    /// Trigger a restart of the node process.
+    /// Trigger a restart of the node process after a successful upgrade.
     ///
-    /// On Unix, uses `exec()` to replace the current process.
-    /// On Windows, exits with [`RESTART_EXIT_CODE`] so the service manager
-    /// can restart the process.
-    fn trigger_restart(binary_path: &Path) -> Result<()> {
-        #[cfg(unix)]
-        {
-            use std::os::unix::process::CommandExt;
+    /// **Service manager mode** (`stop_on_upgrade = true`):
+    /// Exit cleanly and let the service manager (systemd, launchd, Windows Service)
+    /// restart the process. On Unix exits with code 0; on Windows exits with
+    /// [`RESTART_EXIT_CODE`] (100) because `WinSW` uses `RestartPolicy::OnFailure`.
+    ///
+    /// **Standalone mode** (`stop_on_upgrade = false`):
+    /// Spawn the new binary as a child process with the same arguments, then exit.
+    /// This ensures continuity when no service manager is present.
+    fn trigger_restart(&self, binary_path: &Path) -> Result<()> {
+        if self.stop_on_upgrade {
+            // Service manager mode: exit and let the service manager restart us
+            #[cfg(unix)]
+            {
+                info!("Exiting with code 0 for service manager restart");
+                std::process::exit(0);
+            }
 
-            // Collect current args (skip the binary name)
+            #[cfg(windows)]
+            {
+                let _ = binary_path;
+                info!(
+                    "Exiting with code {} to signal service manager restart",
+                    RESTART_EXIT_CODE
+                );
+                std::process::exit(RESTART_EXIT_CODE);
+            }
+
+            #[cfg(not(any(unix, windows)))]
+            {
+                let _ = binary_path;
+                warn!("Auto-restart not supported on this platform. Please restart manually.");
+                Ok(())
+            }
+        } else {
+            // Standalone mode: spawn new process then exit
             let args: Vec<String> = env::args().skip(1).collect();
 
-            info!("Executing restart: {} {:?}", binary_path.display(), args);
-
-            // exec() replaces the current process
-            let err = std::process::Command::new(binary_path).args(&args).exec();
-
-            // If we get here, exec failed
-            Err(Error::Upgrade(format!("Failed to exec new binary: {err}")))
-        }
-
-        #[cfg(windows)]
-        {
-            let _ = binary_path;
             info!(
-                "Exiting with code {} to signal service manager restart",
-                RESTART_EXIT_CODE
+                "Spawning new process: {} {:?}",
+                binary_path.display(),
+                args
             );
-            std::process::exit(RESTART_EXIT_CODE);
-        }
 
-        #[cfg(not(any(unix, windows)))]
-        {
-            let _ = binary_path;
-            warn!("Auto-restart not supported on this platform. Please restart manually.");
-            Ok(())
+            std::process::Command::new(binary_path)
+                .args(&args)
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::inherit())
+                .stderr(std::process::Stdio::inherit())
+                .spawn()
+                .map_err(|e| {
+                    Error::Upgrade(format!("Failed to spawn new binary: {e}"))
+                })?;
+
+            info!("New process spawned, exiting old process");
+            std::process::exit(0);
         }
     }
 }

--- a/src/upgrade/apply.rs
+++ b/src/upgrade/apply.rs
@@ -75,11 +75,28 @@ impl AutoApplyUpgrader {
 
     /// Get the path to the currently running binary.
     ///
+    /// On Linux, `/proc/self/exe` may have a `" (deleted)"` suffix when the on-disk binary has
+    /// been replaced by another node's upgrade. This function strips that suffix so that backup
+    /// creation, binary replacement, and restart all target the correct on-disk path.
+    ///
     /// # Errors
     ///
     /// Returns an error if the binary path cannot be determined.
     pub fn current_binary_path() -> Result<PathBuf> {
-        env::current_exe().map_err(|e| Error::Upgrade(format!("Cannot determine binary path: {e}")))
+        let path =
+            env::current_exe().map_err(|e| Error::Upgrade(format!("Cannot determine binary path: {e}")))?;
+
+        #[cfg(unix)]
+        {
+            let path_str = path.to_string_lossy();
+            if path_str.ends_with(" (deleted)") {
+                let cleaned = path_str.trim_end_matches(" (deleted)");
+                debug!("Stripped '(deleted)' suffix from binary path: {cleaned}");
+                return Ok(PathBuf::from(cleaned));
+            }
+        }
+
+        Ok(path)
     }
 
     /// Perform the complete auto-apply upgrade workflow.

--- a/src/upgrade/binary_cache.rs
+++ b/src/upgrade/binary_cache.rs
@@ -1,0 +1,237 @@
+//! Disk cache for downloaded upgrade binaries.
+//!
+//! When multiple saorsa-node instances detect the same upgrade, only the first
+//! one needs to download and verify the archive.  `BinaryCache` stores the
+//! extracted binary alongside a SHA-256 integrity metadata file so that
+//! subsequent nodes can copy it directly.
+//!
+//! **Security note:** SHA-256 is used only for cache integrity (detecting
+//! corruption or partial writes).  The actual security gate remains the
+//! ML-DSA-65 signature verification performed during the initial download.
+
+use crate::error::{Error, Result};
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use tracing::{debug, warn};
+
+/// On-disk cache for downloaded upgrade binaries.
+pub struct BinaryCache {
+    /// Directory that holds cached binaries and metadata.
+    cache_dir: PathBuf,
+}
+
+/// Metadata written alongside each cached binary.
+#[derive(Serialize, Deserialize)]
+struct CachedBinaryMeta {
+    /// Semantic version string (e.g. "1.2.3").
+    version: String,
+    /// Hex-encoded SHA-256 digest of the cached binary.
+    sha256: String,
+    /// When the binary was cached (seconds since UNIX epoch).
+    cached_at_epoch_secs: u64,
+}
+
+impl BinaryCache {
+    /// Create a new binary cache backed by the given directory.
+    #[must_use]
+    pub fn new(cache_dir: PathBuf) -> Self {
+        Self { cache_dir }
+    }
+
+    /// Return the path where a cached binary for `version` would be stored.
+    #[must_use]
+    pub fn cached_binary_path(&self, version: &str) -> PathBuf {
+        let name = if cfg!(windows) {
+            format!("saorsa-node-{version}.exe")
+        } else {
+            format!("saorsa-node-{version}")
+        };
+        self.cache_dir.join(name)
+    }
+
+    /// Return the cached binary path if it exists and its SHA-256 matches
+    /// the stored metadata.  Returns `None` on any mismatch or error.
+    #[must_use]
+    pub fn get_verified(&self, version: &str) -> Option<PathBuf> {
+        let bin_path = self.cached_binary_path(version);
+        let meta_path = self.meta_path(version);
+
+        let meta_data = fs::read_to_string(&meta_path).ok()?;
+        let meta: CachedBinaryMeta = serde_json::from_str(&meta_data).ok()?;
+
+        if meta.version != version {
+            debug!("Binary cache version mismatch in metadata");
+            return None;
+        }
+
+        let actual_hash = sha256_file(&bin_path).ok()?;
+        if actual_hash != meta.sha256 {
+            warn!(
+                "Binary cache SHA-256 mismatch for version {version} (expected {}, got {})",
+                meta.sha256, actual_hash
+            );
+            return None;
+        }
+
+        Some(bin_path)
+    }
+
+    /// Store a binary in the cache.
+    ///
+    /// Computes the SHA-256 digest, copies the binary, and writes a
+    /// `.meta.json` sidecar file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the binary cannot be read or the cache files
+    /// cannot be written.
+    pub fn store(&self, version: &str, source_path: &std::path::Path) -> Result<()> {
+        let hash = sha256_file(source_path)?;
+
+        let dest = self.cached_binary_path(version);
+        fs::copy(source_path, &dest)?;
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| Error::Upgrade(format!("System clock error: {e}")))?
+            .as_secs();
+
+        let meta = CachedBinaryMeta {
+            version: version.to_string(),
+            sha256: hash,
+            cached_at_epoch_secs: now,
+        };
+
+        let meta_json = serde_json::to_string(&meta)
+            .map_err(|e| Error::Upgrade(format!("Failed to serialize binary cache meta: {e}")))?;
+
+        let meta_path = self.meta_path(version);
+        let mut f = File::create(&meta_path)?;
+        f.write_all(meta_json.as_bytes())?;
+        f.sync_all()?;
+
+        debug!("Cached binary for version {version} at {}", dest.display());
+        Ok(())
+    }
+
+    /// Execute `f` while holding an exclusive download lock.
+    ///
+    /// This prevents multiple nodes from downloading the same archive
+    /// concurrently — the first acquires the lock and downloads, the rest
+    /// wait and then find the binary already cached.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the lock cannot be acquired or `f` fails.
+    pub fn with_download_lock<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce() -> Result<T>,
+    {
+        let lock_path = self.cache_dir.join("download.lock");
+        let lock = File::create(&lock_path)
+            .map_err(|e| Error::Upgrade(format!("Failed to create download lock: {e}")))?;
+        lock.lock_exclusive()
+            .map_err(|e| Error::Upgrade(format!("Failed to acquire download lock: {e}")))?;
+
+        let result = f();
+
+        drop(lock); // Dropping the file releases the exclusive lock
+        result
+    }
+
+    // -- private helpers -----------------------------------------------------
+
+    fn meta_path(&self, version: &str) -> PathBuf {
+        let name = if cfg!(windows) {
+            format!("saorsa-node-{version}.exe.meta.json")
+        } else {
+            format!("saorsa-node-{version}.meta.json")
+        };
+        self.cache_dir.join(name)
+    }
+}
+
+/// Compute the hex-encoded SHA-256 digest of a file.
+fn sha256_file(path: &std::path::Path) -> Result<String> {
+    let mut file = File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        let n = file
+            .read(&mut buf)
+            .map_err(|e| Error::Upgrade(format!("Failed to read file for hashing: {e}")))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_miss_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let cache = BinaryCache::new(tmp.path().to_path_buf());
+        assert!(cache.get_verified("1.0.0").is_none());
+    }
+
+    #[test]
+    fn test_store_and_get_verified() {
+        let tmp = TempDir::new().unwrap();
+        let cache = BinaryCache::new(tmp.path().to_path_buf());
+
+        // Create a fake binary
+        let src = tmp.path().join("source-bin");
+        fs::write(&src, b"hello world binary").unwrap();
+
+        cache.store("1.2.3", &src).unwrap();
+
+        let result = cache.get_verified("1.2.3");
+        assert!(result.is_some());
+        let cached_path = result.unwrap();
+        assert_eq!(fs::read(&cached_path).unwrap(), b"hello world binary");
+    }
+
+    #[test]
+    fn test_sha256_mismatch_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let cache = BinaryCache::new(tmp.path().to_path_buf());
+
+        // Store a valid binary
+        let src = tmp.path().join("source-bin");
+        fs::write(&src, b"original content").unwrap();
+        cache.store("1.0.0", &src).unwrap();
+
+        // Corrupt the cached binary
+        let cached = cache.cached_binary_path("1.0.0");
+        fs::write(&cached, b"corrupted content").unwrap();
+
+        assert!(cache.get_verified("1.0.0").is_none());
+    }
+
+    #[test]
+    fn test_missing_meta_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let cache = BinaryCache::new(tmp.path().to_path_buf());
+
+        // Write a binary but no meta file
+        let cached = cache.cached_binary_path("1.0.0");
+        fs::write(&cached, b"binary data").unwrap();
+
+        assert!(cache.get_verified("1.0.0").is_none());
+    }
+}

--- a/src/upgrade/binary_cache.rs
+++ b/src/upgrade/binary_cache.rs
@@ -19,6 +19,7 @@ use std::path::PathBuf;
 use tracing::{debug, warn};
 
 /// On-disk cache for downloaded upgrade binaries.
+#[derive(Clone)]
 pub struct BinaryCache {
     /// Directory that holds cached binaries and metadata.
     cache_dir: PathBuf,
@@ -82,8 +83,9 @@ impl BinaryCache {
 
     /// Store a binary in the cache.
     ///
-    /// Computes the SHA-256 digest, copies the binary, and writes a
-    /// `.meta.json` sidecar file.
+    /// Uses a write-to-temp-then-rename strategy so that readers never
+    /// observe partially written files.  The metadata file is written last
+    /// so that `get_verified` only succeeds once both files are complete.
     ///
     /// # Errors
     ///
@@ -93,7 +95,14 @@ impl BinaryCache {
         let hash = sha256_file(source_path)?;
 
         let dest = self.cached_binary_path(version);
-        fs::copy(source_path, &dest)?;
+        let meta_path = self.meta_path(version);
+
+        // Write binary to a temp file then rename into place.
+        // Remove dest first on Windows where rename fails if it exists.
+        let tmp_bin = self.cache_dir.join(format!(".saorsa-node-{version}.tmp"));
+        fs::copy(source_path, &tmp_bin)?;
+        let _ = fs::remove_file(&dest);
+        fs::rename(&tmp_bin, &dest)?;
 
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -109,38 +118,42 @@ impl BinaryCache {
         let meta_json = serde_json::to_string(&meta)
             .map_err(|e| Error::Upgrade(format!("Failed to serialize binary cache meta: {e}")))?;
 
-        let meta_path = self.meta_path(version);
-        let mut f = File::create(&meta_path)?;
+        // Write metadata to a temp file then rename into place
+        let tmp_meta = self
+            .cache_dir
+            .join(format!(".saorsa-node-{version}.meta.tmp"));
+        let mut f = File::create(&tmp_meta)?;
         f.write_all(meta_json.as_bytes())?;
         f.sync_all()?;
+        drop(f);
+        let _ = fs::remove_file(&meta_path);
+        fs::rename(&tmp_meta, &meta_path)?;
 
         debug!("Cached binary for version {version} at {}", dest.display());
         Ok(())
     }
 
-    /// Execute `f` while holding an exclusive download lock.
+    /// Acquire an exclusive download lock and return the guard.
     ///
     /// This prevents multiple nodes from downloading the same archive
     /// concurrently — the first acquires the lock and downloads, the rest
     /// wait and then find the binary already cached.
     ///
+    /// The lock is released when the returned guard is dropped.
+    ///
+    /// **Note:** `lock_exclusive()` blocks the calling thread.  Callers in
+    /// async contexts should wrap this call in `tokio::task::spawn_blocking`.
+    ///
     /// # Errors
     ///
-    /// Returns an error if the lock cannot be acquired or `f` fails.
-    pub fn with_download_lock<F, T>(&self, f: F) -> Result<T>
-    where
-        F: FnOnce() -> Result<T>,
-    {
+    /// Returns an error if the lock file cannot be created or acquired.
+    pub fn acquire_download_lock(&self) -> Result<DownloadLockGuard> {
         let lock_path = self.cache_dir.join("download.lock");
         let lock = File::create(&lock_path)
             .map_err(|e| Error::Upgrade(format!("Failed to create download lock: {e}")))?;
         lock.lock_exclusive()
             .map_err(|e| Error::Upgrade(format!("Failed to acquire download lock: {e}")))?;
-
-        let result = f();
-
-        drop(lock); // Dropping the file releases the exclusive lock
-        result
+        Ok(DownloadLockGuard { _file: lock })
     }
 
     // -- private helpers -----------------------------------------------------
@@ -153,6 +166,13 @@ impl BinaryCache {
         };
         self.cache_dir.join(name)
     }
+}
+
+/// RAII guard that holds an exclusive download lock.
+///
+/// The underlying file lock is released when this guard is dropped.
+pub struct DownloadLockGuard {
+    _file: File,
 }
 
 /// Compute the hex-encoded SHA-256 digest of a file.

--- a/src/upgrade/cache_dir.rs
+++ b/src/upgrade/cache_dir.rs
@@ -1,0 +1,43 @@
+//! Shared cache directory for upgrade artifacts.
+//!
+//! Multiple saorsa-node instances on the same machine share a single cache
+//! directory so that release metadata and downloaded binaries are fetched only
+//! once, reducing GitHub API calls and bandwidth.
+
+use crate::error::{Error, Result};
+use std::fs;
+use std::path::PathBuf;
+
+/// Return the shared upgrade cache directory, creating it on demand.
+///
+/// The path is `{data_dir}/upgrades/` where `data_dir` comes from
+/// `directories::ProjectDirs` (e.g. `~/.local/share/saorsa/upgrades/` on
+/// Linux).
+///
+/// # Errors
+///
+/// Returns an error if the platform data directory cannot be determined or
+/// the directory cannot be created.
+pub fn upgrade_cache_dir() -> Result<PathBuf> {
+    let project_dirs = directories::ProjectDirs::from("", "", "saorsa").ok_or_else(|| {
+        Error::Upgrade("Cannot determine platform data directory for upgrade cache".to_string())
+    })?;
+
+    let cache_dir = project_dirs.data_dir().join("upgrades");
+    fs::create_dir_all(&cache_dir)?;
+
+    Ok(cache_dir)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_upgrade_cache_dir_returns_path() {
+        let dir = upgrade_cache_dir().unwrap();
+        assert!(dir.exists());
+        assert!(dir.ends_with("upgrades"));
+    }
+}

--- a/src/upgrade/cache_dir.rs
+++ b/src/upgrade/cache_dir.rs
@@ -34,6 +34,11 @@ pub fn upgrade_cache_dir() -> Result<PathBuf> {
 mod tests {
     use super::*;
 
+    /// Verify the function succeeds and returns a path ending in "upgrades".
+    ///
+    /// Note: this creates a real directory under the platform data dir.
+    /// Modifying env vars to isolate this requires `unsafe` (due to
+    /// `deny(unsafe_code)`), so we accept the minor side-effect.
     #[test]
     fn test_upgrade_cache_dir_returns_path() {
         let dir = upgrade_cache_dir().unwrap();

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -8,12 +8,18 @@
 //! - Auto-apply: download, extract, verify, replace, restart
 
 mod apply;
+mod binary_cache;
+mod cache_dir;
 mod monitor;
+mod release_cache;
 mod rollout;
 mod signature;
 
-pub use apply::AutoApplyUpgrader;
+pub use apply::{AutoApplyUpgrader, RESTART_EXIT_CODE};
+pub use binary_cache::BinaryCache;
+pub use cache_dir::upgrade_cache_dir;
 pub use monitor::{find_platform_asset, version_from_tag, Asset, GitHubRelease, UpgradeMonitor};
+pub use release_cache::ReleaseCache;
 pub use rollout::StagedRollout;
 pub use signature::{
     verify_binary_signature, verify_binary_signature_with_key, verify_from_file,
@@ -347,9 +353,9 @@ impl Upgrader {
 
     /// Whether the current platform supports in-place auto-upgrade.
     ///
-    /// On Windows, replacing a running executable is typically blocked by file locks.
+    /// Supported on Unix (via `exec()`) and Windows (via `self-replace` crate).
     const fn auto_upgrade_supported() -> bool {
-        !cfg!(windows)
+        true
     }
 }
 
@@ -687,11 +693,7 @@ mod tests {
     }
 
     #[test]
-    fn test_auto_upgrade_supported_flag_matches_platform() {
-        if cfg!(windows) {
-            assert!(!Upgrader::auto_upgrade_supported());
-        } else {
-            assert!(Upgrader::auto_upgrade_supported());
-        }
+    fn test_auto_upgrade_supported_on_all_platforms() {
+        assert!(Upgrader::auto_upgrade_supported());
     }
 }

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -54,10 +54,13 @@ pub struct UpgradeInfo {
 /// Result of an upgrade operation.
 #[derive(Debug)]
 pub enum UpgradeResult {
-    /// Upgrade was successful.
+    /// Upgrade was successful and the process should exit to complete the restart.
     Success {
         /// The new version.
         version: Version,
+        /// Exit code to use when terminating the process.
+        /// The caller should trigger graceful shutdown, then exit with this code.
+        exit_code: i32,
     },
     /// Upgrade failed, rolled back.
     RolledBack {
@@ -348,6 +351,7 @@ impl Upgrader {
         info!("Successfully upgraded to version {}", info.version);
         Ok(UpgradeResult::Success {
             version: info.version.clone(),
+            exit_code: 0,
         })
     }
 
@@ -615,6 +619,7 @@ mod tests {
     fn test_upgrade_result_variants() {
         let success = UpgradeResult::Success {
             version: Version::new(1, 0, 0),
+            exit_code: 0,
         };
         assert!(matches!(success, UpgradeResult::Success { .. }));
 

--- a/src/upgrade/monitor.rs
+++ b/src/upgrade/monitor.rs
@@ -9,6 +9,7 @@
 
 use crate::config::UpgradeChannel;
 use crate::error::{Error, Result};
+use crate::upgrade::release_cache::ReleaseCache;
 use crate::upgrade::rollout::StagedRollout;
 use crate::upgrade::UpgradeInfo;
 use semver::Version;
@@ -54,6 +55,8 @@ pub struct UpgradeMonitor {
     client: reqwest::Client,
     /// Staged rollout calculator (optional).
     staged_rollout: Option<StagedRollout>,
+    /// Disk cache for GitHub release metadata (shared across instances).
+    release_cache: Option<ReleaseCache>,
     /// When the current pending upgrade was first detected.
     pending_upgrade_detected: Option<Instant>,
     /// The version of the pending upgrade (for tracking rollout state).
@@ -89,9 +92,21 @@ impl UpgradeMonitor {
             current_version,
             client,
             staged_rollout: None,
+            release_cache: None,
             pending_upgrade_detected: None,
             pending_upgrade_version: None,
         }
+    }
+
+    /// Configure a shared disk cache for release metadata.
+    ///
+    /// When set, `check_for_updates` will consult the cache before hitting
+    /// the GitHub API.  Fresh results are written back so that other nodes
+    /// on the same machine can reuse them.
+    #[must_use]
+    pub fn with_release_cache(mut self, cache: ReleaseCache) -> Self {
+        self.release_cache = Some(cache);
+        self
     }
 
     /// Configure staged rollout for this monitor.
@@ -134,6 +149,7 @@ impl UpgradeMonitor {
             current_version,
             client,
             staged_rollout: None,
+            release_cache: None,
             pending_upgrade_detected: None,
             pending_upgrade_version: None,
         }
@@ -179,6 +195,22 @@ impl UpgradeMonitor {
     ///
     /// Returns an error if the GitHub API request fails.
     pub async fn check_for_updates(&self) -> Result<Option<UpgradeInfo>> {
+        // Try the shared disk cache first
+        if let Some(ref cache) = self.release_cache {
+            if let Some(cached_releases) = cache.read_if_valid(&self.repo) {
+                info!(
+                    "Using cached release info ({} releases)",
+                    cached_releases.len()
+                );
+                return Ok(select_upgrade_from_releases(
+                    &cached_releases,
+                    &self.current_version,
+                    self.channel,
+                ));
+            }
+            info!("No valid cache, fetching from API");
+        }
+
         let api_url = format!("https://api.github.com/repos/{}/releases", self.repo);
 
         debug!("Checking for updates from: {}", api_url);
@@ -202,6 +234,13 @@ impl UpgradeMonitor {
             .json()
             .await
             .map_err(|e| Error::Network(format!("Failed to parse releases: {e}")))?;
+
+        // Write fresh results to the shared cache for other nodes
+        if let Some(ref cache) = self.release_cache {
+            if let Err(e) = cache.write(&self.repo, &releases) {
+                warn!("Failed to write release cache: {e}");
+            }
+        }
 
         Ok(select_upgrade_from_releases(
             &releases,
@@ -234,6 +273,11 @@ impl UpgradeMonitor {
 
         // If staged rollout is not enabled, return immediately
         let Some(ref rollout) = self.staged_rollout else {
+            let restart_time = chrono::Utc::now();
+            info!(
+                "Node will stop/restart for upgrade at {}",
+                restart_time.to_rfc3339()
+            );
             return Ok(Some(info));
         };
 
@@ -249,11 +293,17 @@ impl UpgradeMonitor {
             self.pending_upgrade_version = Some(info.version.clone());
 
             let delay = rollout.calculate_delay_for_version(&info.version);
+            let restart_time = chrono::Utc::now()
+                + chrono::Duration::from_std(delay).unwrap_or_else(|_| chrono::Duration::hours(1));
             info!(
                 new_version = %info.version,
                 delay_hours = delay.as_secs() / 3600,
                 delay_minutes = (delay.as_secs() % 3600) / 60,
                 "New version detected, staged rollout delay calculated"
+            );
+            info!(
+                "Node will stop/restart for upgrade at {}",
+                restart_time.to_rfc3339()
             );
         }
 
@@ -562,7 +612,7 @@ mod tests {
     #[test]
     fn test_stable_channel_filters_beta() {
         let monitor = UpgradeMonitor::new(
-            "dirvine/saorsa-node".to_string(),
+            "saorsa-labs/saorsa-node".to_string(),
             UpgradeChannel::Stable,
             24,
         );
@@ -578,7 +628,7 @@ mod tests {
     #[test]
     fn test_beta_channel_accepts_beta() {
         let monitor =
-            UpgradeMonitor::new("dirvine/saorsa-node".to_string(), UpgradeChannel::Beta, 24);
+            UpgradeMonitor::new("saorsa-labs/saorsa-node".to_string(), UpgradeChannel::Beta, 24);
 
         let beta_version = Version::parse("1.0.0-beta.1").unwrap();
         assert!(monitor.version_matches_channel(&beta_version));
@@ -824,11 +874,11 @@ mod tests {
     #[test]
     fn test_monitor_repo() {
         let monitor = UpgradeMonitor::new(
-            "dirvine/saorsa-node".to_string(),
+            "saorsa-labs/saorsa-node".to_string(),
             UpgradeChannel::Stable,
             24,
         );
-        assert_eq!(monitor.repo(), "dirvine/saorsa-node");
+        assert_eq!(monitor.repo(), "saorsa-labs/saorsa-node");
     }
 
     /// Test 16: Current version getter

--- a/src/upgrade/monitor.rs
+++ b/src/upgrade/monitor.rs
@@ -195,7 +195,7 @@ impl UpgradeMonitor {
     ///
     /// Returns an error if the GitHub API request fails.
     pub async fn check_for_updates(&self) -> Result<Option<UpgradeInfo>> {
-        // Try the shared disk cache first
+        // Try the shared disk cache first (lock-free fast path)
         if let Some(ref cache) = self.release_cache {
             if let Some(cached_releases) = cache.read_if_valid(&self.repo) {
                 info!(
@@ -208,40 +208,47 @@ impl UpgradeMonitor {
                     self.channel,
                 ));
             }
-            info!("No valid cache, fetching from API");
-        }
 
-        let api_url = format!("https://api.github.com/repos/{}/releases", self.repo);
+            // Cache stale/missing — acquire lock and re-check so only one
+            // node actually hits the GitHub API while the rest wait.
+            let cache_clone = cache.clone();
+            let repo_clone = self.repo.clone();
+            let (lock_guard, rechecked) =
+                tokio::task::spawn_blocking(move || cache_clone.lock_and_recheck(&repo_clone))
+                    .await
+                    .map_err(|e| Error::Upgrade(format!("Cache lock task failed: {e}")))??;
 
-        debug!("Checking for updates from: {}", api_url);
+            if let Some(cached_releases) = rechecked {
+                info!(
+                    "Using cached release info after lock ({} releases)",
+                    cached_releases.len()
+                );
+                return Ok(select_upgrade_from_releases(
+                    &cached_releases,
+                    &self.current_version,
+                    self.channel,
+                ));
+            }
 
-        let response = self
-            .client
-            .get(&api_url)
-            .header("Accept", "application/vnd.github+json")
-            .send()
-            .await
-            .map_err(|e| Error::Network(format!("GitHub API request failed: {e}")))?;
+            info!("No valid cache under lock, fetching from API");
 
-        if !response.status().is_success() {
-            return Err(Error::Network(format!(
-                "GitHub API returned status: {}",
-                response.status()
-            )));
-        }
+            // Fetch from API while holding the lock
+            let releases = self.fetch_releases_from_api().await?;
 
-        let releases: Vec<GitHubRelease> = response
-            .json()
-            .await
-            .map_err(|e| Error::Network(format!("Failed to parse releases: {e}")))?;
-
-        // Write fresh results to the shared cache for other nodes
-        if let Some(ref cache) = self.release_cache {
-            if let Err(e) = cache.write(&self.repo, &releases) {
+            // Write fresh results under the lock for other nodes
+            if let Err(e) = cache.write_under_lock(lock_guard, &self.repo, &releases) {
                 warn!("Failed to write release cache: {e}");
             }
+
+            return Ok(select_upgrade_from_releases(
+                &releases,
+                &self.current_version,
+                self.channel,
+            ));
         }
 
+        // No cache configured — fetch directly
+        let releases = self.fetch_releases_from_api().await?;
         Ok(select_upgrade_from_releases(
             &releases,
             &self.current_version,
@@ -333,6 +340,32 @@ impl UpgradeMonitor {
             );
             Ok(None)
         }
+    }
+
+    /// Fetch releases from the GitHub API.
+    async fn fetch_releases_from_api(&self) -> Result<Vec<GitHubRelease>> {
+        let api_url = format!("https://api.github.com/repos/{}/releases", self.repo);
+        debug!("Checking for updates from: {}", api_url);
+
+        let response = self
+            .client
+            .get(&api_url)
+            .header("Accept", "application/vnd.github+json")
+            .send()
+            .await
+            .map_err(|e| Error::Network(format!("GitHub API request failed: {e}")))?;
+
+        if !response.status().is_success() {
+            return Err(Error::Network(format!(
+                "GitHub API returned status: {}",
+                response.status()
+            )));
+        }
+
+        response
+            .json()
+            .await
+            .map_err(|e| Error::Network(format!("Failed to parse releases: {e}")))
     }
 
     /// Get the remaining time until this node should upgrade.

--- a/src/upgrade/monitor.rs
+++ b/src/upgrade/monitor.rs
@@ -627,8 +627,11 @@ mod tests {
     /// Test 6: Channel filtering - beta includes beta
     #[test]
     fn test_beta_channel_accepts_beta() {
-        let monitor =
-            UpgradeMonitor::new("saorsa-labs/saorsa-node".to_string(), UpgradeChannel::Beta, 24);
+        let monitor = UpgradeMonitor::new(
+            "saorsa-labs/saorsa-node".to_string(),
+            UpgradeChannel::Beta,
+            24,
+        );
 
         let beta_version = Version::parse("1.0.0-beta.1").unwrap();
         assert!(monitor.version_matches_channel(&beta_version));

--- a/src/upgrade/release_cache.rs
+++ b/src/upgrade/release_cache.rs
@@ -1,0 +1,285 @@
+//! Disk cache for GitHub release metadata.
+//!
+//! When multiple saorsa-node instances run on the same machine, each would
+//! otherwise poll the GitHub API independently.  `ReleaseCache` stores the
+//! most recent API response on disk with a configurable TTL so that only the
+//! first node to hit a stale cache actually contacts GitHub.
+
+use crate::error::{Error, Result};
+use crate::upgrade::monitor::{Asset, GitHubRelease};
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tracing::debug;
+
+/// On-disk cache for GitHub release metadata.
+pub struct ReleaseCache {
+    /// Directory that holds the cache file and its lock.
+    cache_dir: PathBuf,
+    /// How long a cached response is considered fresh.
+    ttl: Duration,
+}
+
+/// Serialized container written to disk.
+#[derive(Serialize, Deserialize)]
+struct CachedReleases {
+    /// The GitHub repo these releases belong to (e.g. "owner/repo").
+    repo: String,
+    /// When the releases were fetched (seconds since UNIX epoch).
+    fetched_at_epoch_secs: u64,
+    /// The cached release objects.
+    releases: Vec<CachedRelease>,
+}
+
+/// Serialized mirror of [`GitHubRelease`].
+#[derive(Serialize, Deserialize)]
+struct CachedRelease {
+    tag_name: String,
+    name: String,
+    body: String,
+    prerelease: bool,
+    assets: Vec<CachedAsset>,
+}
+
+/// Serialized mirror of [`Asset`].
+#[derive(Serialize, Deserialize)]
+struct CachedAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+// ---------------------------------------------------------------------------
+// Conversions
+// ---------------------------------------------------------------------------
+
+impl From<&GitHubRelease> for CachedRelease {
+    fn from(r: &GitHubRelease) -> Self {
+        Self {
+            tag_name: r.tag_name.clone(),
+            name: r.name.clone(),
+            body: r.body.clone(),
+            prerelease: r.prerelease,
+            assets: r.assets.iter().map(CachedAsset::from).collect(),
+        }
+    }
+}
+
+impl From<CachedRelease> for GitHubRelease {
+    fn from(c: CachedRelease) -> Self {
+        Self {
+            tag_name: c.tag_name,
+            name: c.name,
+            body: c.body,
+            prerelease: c.prerelease,
+            assets: c.assets.into_iter().map(Asset::from).collect(),
+        }
+    }
+}
+
+impl From<&Asset> for CachedAsset {
+    fn from(a: &Asset) -> Self {
+        Self {
+            name: a.name.clone(),
+            browser_download_url: a.browser_download_url.clone(),
+        }
+    }
+}
+
+impl From<CachedAsset> for Asset {
+    fn from(c: CachedAsset) -> Self {
+        Self {
+            name: c.name,
+            browser_download_url: c.browser_download_url,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ReleaseCache implementation
+// ---------------------------------------------------------------------------
+
+impl ReleaseCache {
+    /// Create a new release cache backed by the given directory.
+    #[must_use]
+    pub fn new(cache_dir: PathBuf, ttl: Duration) -> Self {
+        Self { cache_dir, ttl }
+    }
+
+    /// Return the cached releases if the cache file exists, belongs to the
+    /// same repo, and has not expired.  Returns `None` on any error (missing,
+    /// corrupted, expired, wrong repo) — callers should fall back to the
+    /// network in that case.
+    #[must_use]
+    pub fn read_if_valid(&self, repo: &str) -> Option<Vec<GitHubRelease>> {
+        let data = fs::read_to_string(self.cache_file()).ok()?;
+        let cached: CachedReleases = serde_json::from_str(&data).ok()?;
+
+        if cached.repo != repo {
+            debug!(
+                "Release cache repo mismatch: cached={}, wanted={}",
+                cached.repo, repo
+            );
+            return None;
+        }
+
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+        let age_secs = now.saturating_sub(cached.fetched_at_epoch_secs);
+        if age_secs >= self.ttl.as_secs() {
+            debug!(
+                "Release cache expired (age={}s, ttl={}s)",
+                age_secs,
+                self.ttl.as_secs()
+            );
+            return None;
+        }
+
+        Some(
+            cached
+                .releases
+                .into_iter()
+                .map(GitHubRelease::from)
+                .collect(),
+        )
+    }
+
+    /// Write releases to the cache, using an exclusive file lock to
+    /// coordinate with other nodes on the same machine.
+    ///
+    /// The write is atomic: data goes to a temp file first, then is renamed
+    /// over the cache file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the lock cannot be acquired or the file cannot be
+    /// written.
+    pub fn write(&self, repo: &str, releases: &[GitHubRelease]) -> Result<()> {
+        let lock_path = self.lock_file();
+        let lock = File::create(&lock_path)
+            .map_err(|e| Error::Upgrade(format!("Failed to create release cache lock: {e}")))?;
+        lock.lock_exclusive()
+            .map_err(|e| Error::Upgrade(format!("Failed to acquire release cache lock: {e}")))?;
+
+        let result = self.write_inner(repo, releases);
+
+        drop(lock); // Dropping the file releases the exclusive lock
+        result
+    }
+
+    // -- private helpers -----------------------------------------------------
+
+    fn write_inner(&self, repo: &str, releases: &[GitHubRelease]) -> Result<()> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| Error::Upgrade(format!("System clock error: {e}")))?
+            .as_secs();
+
+        let cached = CachedReleases {
+            repo: repo.to_string(),
+            fetched_at_epoch_secs: now,
+            releases: releases.iter().map(CachedRelease::from).collect(),
+        };
+
+        let json = serde_json::to_string(&cached)
+            .map_err(|e| Error::Upgrade(format!("Failed to serialize release cache: {e}")))?;
+
+        // Atomic write: temp file + rename
+        let tmp_path = self.cache_dir.join("releases.json.tmp");
+        {
+            let mut f = File::create(&tmp_path)?;
+            f.write_all(json.as_bytes())?;
+            f.sync_all()?;
+        }
+        fs::rename(&tmp_path, self.cache_file())?;
+
+        debug!("Wrote release cache ({} releases)", releases.len());
+        Ok(())
+    }
+
+    fn cache_file(&self) -> PathBuf {
+        self.cache_dir.join("releases.json")
+    }
+
+    fn lock_file(&self) -> PathBuf {
+        self.cache_dir.join("releases.lock")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn sample_releases() -> Vec<GitHubRelease> {
+        vec![GitHubRelease {
+            tag_name: "v1.2.0".to_string(),
+            name: "Release 1.2.0".to_string(),
+            body: "Notes".to_string(),
+            prerelease: false,
+            assets: vec![Asset {
+                name: "saorsa-node-x86_64-linux.tar.gz".to_string(),
+                browser_download_url: "https://example.com/bin".to_string(),
+            }],
+        }]
+    }
+
+    #[test]
+    fn test_write_read_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let cache = ReleaseCache::new(tmp.path().to_path_buf(), Duration::from_secs(300));
+
+        cache.write("owner/repo", &sample_releases()).unwrap();
+
+        let loaded = cache.read_if_valid("owner/repo").unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].tag_name, "v1.2.0");
+        assert_eq!(loaded[0].assets.len(), 1);
+        assert_eq!(loaded[0].assets[0].name, "saorsa-node-x86_64-linux.tar.gz");
+    }
+
+    #[test]
+    fn test_ttl_expiry_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        // TTL of 0 seconds — anything written is immediately expired
+        let cache = ReleaseCache::new(tmp.path().to_path_buf(), Duration::from_secs(0));
+
+        cache.write("owner/repo", &sample_releases()).unwrap();
+
+        assert!(cache.read_if_valid("owner/repo").is_none());
+    }
+
+    #[test]
+    fn test_wrong_repo_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let cache = ReleaseCache::new(tmp.path().to_path_buf(), Duration::from_secs(300));
+
+        cache.write("owner/repo", &sample_releases()).unwrap();
+
+        assert!(cache.read_if_valid("other/repo").is_none());
+    }
+
+    #[test]
+    fn test_corrupted_file_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let cache = ReleaseCache::new(tmp.path().to_path_buf(), Duration::from_secs(300));
+
+        fs::write(cache.cache_file(), "not valid json!!!").unwrap();
+
+        assert!(cache.read_if_valid("owner/repo").is_none());
+    }
+
+    #[test]
+    fn test_missing_file_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let cache = ReleaseCache::new(tmp.path().to_path_buf(), Duration::from_secs(300));
+
+        assert!(cache.read_if_valid("owner/repo").is_none());
+    }
+}

--- a/src/upgrade/release_cache.rs
+++ b/src/upgrade/release_cache.rs
@@ -16,6 +16,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tracing::debug;
 
 /// On-disk cache for GitHub release metadata.
+#[derive(Clone)]
 pub struct ReleaseCache {
     /// Directory that holds the cache file and its lock.
     cache_dir: PathBuf,
@@ -145,6 +146,35 @@ impl ReleaseCache {
         )
     }
 
+    /// Acquire the exclusive cache lock, re-check the cache, and return
+    /// valid cached releases if another node populated them while we waited.
+    ///
+    /// Returns `Ok(Some(releases))` if a valid cache was found under the
+    /// lock, or `Ok(None)` if the cache is still stale/missing and the
+    /// caller should fetch from the network.  The returned
+    /// The returned lock guard must be held until after writing the fresh
+    /// data so that other nodes block rather than all hitting the API.
+    ///
+    /// **Note:** `lock_exclusive()` blocks the calling thread.  Callers in
+    /// async contexts should wrap this in `tokio::task::spawn_blocking`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the lock file cannot be created or acquired.
+    pub fn lock_and_recheck(
+        &self,
+        repo: &str,
+    ) -> Result<(ReleaseCacheLockGuard, Option<Vec<GitHubRelease>>)> {
+        let lock_path = self.lock_file();
+        let lock = File::create(&lock_path)
+            .map_err(|e| Error::Upgrade(format!("Failed to create release cache lock: {e}")))?;
+        lock.lock_exclusive()
+            .map_err(|e| Error::Upgrade(format!("Failed to acquire release cache lock: {e}")))?;
+
+        let cached = self.read_if_valid(repo);
+        Ok((ReleaseCacheLockGuard { _file: lock }, cached))
+    }
+
     /// Write releases to the cache, using an exclusive file lock to
     /// coordinate with other nodes on the same machine.
     ///
@@ -168,6 +198,22 @@ impl ReleaseCache {
         result
     }
 
+    /// Write releases to the cache while the caller already holds the
+    /// lock guard.  The guard is consumed to ensure the lock is released
+    /// after writing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be written.
+    pub fn write_under_lock(
+        &self,
+        _guard: ReleaseCacheLockGuard,
+        repo: &str,
+        releases: &[GitHubRelease],
+    ) -> Result<()> {
+        self.write_inner(repo, releases)
+    }
+
     // -- private helpers -----------------------------------------------------
 
     fn write_inner(&self, repo: &str, releases: &[GitHubRelease]) -> Result<()> {
@@ -185,14 +231,17 @@ impl ReleaseCache {
         let json = serde_json::to_string(&cached)
             .map_err(|e| Error::Upgrade(format!("Failed to serialize release cache: {e}")))?;
 
-        // Atomic write: temp file + rename
+        // Write to temp file then rename into place.
+        // Remove dest first on Windows where rename fails if it exists.
         let tmp_path = self.cache_dir.join("releases.json.tmp");
         {
             let mut f = File::create(&tmp_path)?;
             f.write_all(json.as_bytes())?;
             f.sync_all()?;
         }
-        fs::rename(&tmp_path, self.cache_file())?;
+        let cache_file = self.cache_file();
+        let _ = fs::remove_file(&cache_file);
+        fs::rename(&tmp_path, &cache_file)?;
 
         debug!("Wrote release cache ({} releases)", releases.len());
         Ok(())
@@ -205,6 +254,13 @@ impl ReleaseCache {
     fn lock_file(&self) -> PathBuf {
         self.cache_dir.join("releases.lock")
     }
+}
+
+/// RAII guard that holds an exclusive release cache lock.
+///
+/// The underlying file lock is released when this guard is dropped.
+pub struct ReleaseCacheLockGuard {
+    _file: File,
 }
 
 // ---------------------------------------------------------------------------

--- a/systemd/saorsa-node.service
+++ b/systemd/saorsa-node.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Saorsa Node - Quantum-proof decentralized network node
-Documentation=https://github.com/dirvine/saorsa-node
+Documentation=https://github.com/saorsa-labs/saorsa-node
 After=network-online.target
 Wants=network-online.target
 

--- a/systemd/saorsa-node.service
+++ b/systemd/saorsa-node.service
@@ -8,9 +8,9 @@ Wants=network-online.target
 Type=simple
 User=saorsa
 Group=saorsa
-ExecStart=/usr/bin/saorsa-node --config /etc/saorsa/config.toml
+ExecStart=/usr/bin/saorsa-node --config /etc/saorsa/config.toml --stop-on-upgrade
 ExecReload=/bin/kill -HUP $MAINPID
-Restart=on-failure
+Restart=always
 RestartSec=5s
 TimeoutStopSec=30s
 

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -23,8 +23,8 @@
 
         <Icon Id="SaorsaIcon" SourceFile="wix\saorsa.ico"/>
         <Property Id="ARPPRODUCTICON" Value="SaorsaIcon"/>
-        <Property Id="ARPHELPLINK" Value="https://github.com/dirvine/saorsa-node"/>
-        <Property Id="ARPURLINFOABOUT" Value="https://github.com/dirvine/saorsa-node"/>
+        <Property Id="ARPHELPLINK" Value="https://github.com/saorsa-labs/saorsa-node"/>
+        <Property Id="ARPURLINFOABOUT" Value="https://github.com/saorsa-labs/saorsa-node"/>
 
         <Feature Id="MainFeature" Title="Saorsa Node" Level="1">
             <ComponentGroupRef Id="BinariesGroup"/>


### PR DESCRIPTION
## Summary

Extends the automatic upgrade system with production-ready features for multi-node deployments across all platforms:

- **Always-on upgrades**: Removed the `--auto-upgrade` flag; upgrades are now always enabled, simplifying deployment configuration
- **Release metadata cache**: Shared disk cache with configurable TTL so multiple nodes on the same machine don't each poll the GitHub API independently
- **Binary cache**: Downloaded and verified binaries are cached on disk (with SHA-256 integrity checks) so only the first node needs to download; subsequent nodes copy from cache
- **Clean process restart**: Replaced Unix `exec()` with a spawn-and-exit model that works cross-platform. Added `--stop-on-upgrade` flag for service manager environments (systemd, launchd, Windows Service) where the manager handles restarts
- **Windows support**: Added zip archive extraction alongside tar.gz, enabling auto-upgrades on Windows nodes
- **Staggered upgrade checks**: Nodes randomise their check intervals (±5%) to avoid thundering-herd API calls
- **Robustness fixes**: Handle deleted binary paths, improve error context in download/extraction, fix staged rollout check integration in the node loop

## Validation

Three separate testnet deployments were used to validate the changes:

- **100-node Linux testnet**: All nodes successfully auto-upgraded to the fake 0.3.12-rc.1 release
- **100-node Linux testnet + standalone Windows node**: All Linux nodes upgraded successfully, and the standalone Windows node also upgraded correctly (zip extraction path)
- **100-node Linux testnet + standalone macOS node**: All Linux nodes upgraded successfully, and the standalone macOS node also upgraded correctly

## Test plan

- [x] 100-node Linux-only testnet upgrade validated
- [x] 100-node Linux testnet + Windows standalone node upgrade validated
- [x] 100-node Linux testnet + macOS standalone node upgrade validated


🤖 Generated with [Claude Code](https://claude.com/claude-code)