### PR TITLE
fix: update to saorsa-core 0.17.2 with peer_addrs API change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saorsa-node"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Saorsa decentralized network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ path = "src/bin/saorsa-devnet/main.rs"
 
 [dependencies]
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
-saorsa-core = "0.17"
+saorsa-core = "0.17.2"
 saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment

--- a/src/client/chunk_protocol.rs
+++ b/src/client/chunk_protocol.rs
@@ -5,7 +5,7 @@
 
 use crate::ant_protocol::{ChunkMessage, ChunkMessageBody, CHUNK_PROTOCOL_ID};
 use saorsa_core::identity::PeerId;
-use saorsa_core::{P2PEvent, P2PNode};
+use saorsa_core::{MultiAddr, P2PEvent, P2PNode};
 use std::time::Duration;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::time::Instant;
@@ -34,6 +34,7 @@ pub async fn send_and_await_chunk_response<T, E>(
     message_bytes: Vec<u8>,
     request_id: u64,
     timeout: Duration,
+    peer_addrs: &[MultiAddr],
     response_handler: impl Fn(ChunkMessageBody) -> Option<Result<T, E>>,
     send_error: impl FnOnce(String) -> E,
     timeout_error: impl FnOnce() -> E,
@@ -41,7 +42,7 @@ pub async fn send_and_await_chunk_response<T, E>(
     // Subscribe before sending so we don't miss the response
     let mut events = node.subscribe_events();
 
-    node.send_message(target_peer, CHUNK_PROTOCOL_ID, message_bytes)
+    node.send_message(target_peer, CHUNK_PROTOCOL_ID, message_bytes, peer_addrs)
         .await
         .map_err(|e| send_error(e.to_string()))?;
 

--- a/src/devnet.rs
+++ b/src/devnet.rs
@@ -666,6 +666,7 @@ impl Devnet {
                                                 &source,
                                                 CHUNK_PROTOCOL_ID,
                                                 response.to_vec(),
+                                                &[],
                                             )
                                             .await
                                         {

--- a/src/node.rs
+++ b/src/node.rs
@@ -653,7 +653,12 @@ impl RunningNode {
                             match result {
                                 Ok(response) => {
                                     if let Err(e) = p2p
-                                        .send_message(&source, response_topic, response.to_vec())
+                                        .send_message(
+                                            &source,
+                                            response_topic,
+                                            response.to_vec(),
+                                            &[],
+                                        )
                                         .await
                                     {
                                         warn!("Failed to send {data_type} protocol response to {source}: {e}");

--- a/tests/e2e/integration_tests.rs
+++ b/tests/e2e/integration_tests.rs
@@ -218,7 +218,7 @@ async fn test_node_to_node_messaging() {
     let sender_p2p = sender.p2p_node.as_ref().expect("Node 3 should be running");
 
     sender_p2p
-        .send_message(&target_peer_id, TEST_TOPIC, PAYLOAD.to_vec())
+        .send_message(&target_peer_id, TEST_TOPIC, PAYLOAD.to_vec(), &[])
         .await
         .expect("Failed to send message to connected peer");
 

--- a/tests/e2e/testnet.rs
+++ b/tests/e2e/testnet.rs
@@ -651,6 +651,7 @@ impl TestNode {
             message_bytes,
             request_id,
             timeout,
+            &[],
             |body| match body {
                 ChunkMessageBody::PutResponse(ChunkPutResponse::Success { address: addr }) => {
                     debug!(
@@ -747,6 +748,7 @@ impl TestNode {
             message_bytes,
             request_id,
             timeout,
+            &[],
             |body| match body {
                 ChunkMessageBody::GetResponse(ChunkGetResponse::Success {
                     address: addr,
@@ -1164,6 +1166,7 @@ impl TestNetwork {
                                                 &source,
                                                 CHUNK_PROTOCOL_ID,
                                                 response.to_vec(),
+                                                &[],
                                             )
                                             .await
                                         {


### PR DESCRIPTION
## Summary
- Pin `saorsa-core` dependency to `0.17.2` (from `0.17`)
- Update all `send_message` calls to include the new `peer_addrs` parameter added in saorsa-core 0.17.2
- Bump saorsa-node version to `0.4.1`

## Test plan
- [ ] CI passes (build + tests)
- [ ] Verify node connects to bootstrap peers correctly with new `send_message` signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)