### PR TITLE
fix: verify only paid quotes in SingleNode payment model

### DIFF
--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -9,8 +9,6 @@ use crate::payment::proof::deserialize_proof;
 use crate::payment::quote::{verify_quote_content, verify_quote_signature};
 use crate::payment::single_node::REQUIRED_QUOTES;
 use ant_evm::{ProofOfPayment, RewardsAddress};
-use evmlib::contract::payment_vault::error::Error as PaymentVaultError;
-use evmlib::contract::payment_vault::verify_data_payment;
 use evmlib::Network as EvmNetwork;
 use saorsa_core::identity::node_identity::peer_id_from_public_key_bytes;
 use std::time::SystemTime;
@@ -292,31 +290,60 @@ impl PaymentVerifier {
         .await
         .map_err(|e| Error::Payment(format!("Signature verification task failed: {e}")))??;
 
-        // Verify on-chain payment
+        // Verify on-chain payment.
+        //
+        // The SingleNode payment model pays only the median-priced quote (3x)
+        // and sends Amount::ZERO for the other 4. evmlib's pay_for_quotes()
+        // filters out zero-amount payments, so only 1 quote has an on-chain
+        // record. The contract's verifyPayment() returns isValid=false for
+        // unpaid quotes, which is expected — we only require that at least
+        // one result is valid (the paid quote).
         let payment_digest = payment.digest();
         if payment_digest.is_empty() {
             return Err(Error::Payment("Payment has no quotes".to_string()));
         }
 
-        let owned_quote_hashes = vec![];
-        match verify_data_payment(&self.config.evm.network, owned_quote_hashes, payment_digest)
+        let payment_verifications: Vec<_> = payment_digest
+            .into_iter()
+            .map(
+                evmlib::contract::payment_vault::interface::IPaymentVault::PaymentVerification::from,
+            )
+            .collect();
+
+        let provider =
+            evmlib::utils::http_provider(self.config.evm.network.rpc_url().clone());
+        let handler = evmlib::contract::payment_vault::handler::PaymentVaultHandler::new(
+            *self.config.evm.network.data_payments_address(),
+            provider,
+        );
+
+        let results = handler
+            .verify_payment(payment_verifications)
             .await
-        {
-            Ok(_amount) => {
-                if tracing::enabled!(tracing::Level::INFO) {
-                    info!("EVM payment verified for {}", hex::encode(xorname));
-                }
-                Ok(())
-            }
-            Err(PaymentVaultError::PaymentInvalid) => Err(Error::Payment(format!(
-                "Payment verification failed on-chain for {}",
+            .map_err(|e| {
+                Error::Payment(format!(
+                    "EVM verification error for {}: {e}",
+                    hex::encode(xorname)
+                ))
+            })?;
+
+        let any_valid = results.iter().any(|r| r.isValid);
+        if !any_valid {
+            return Err(Error::Payment(format!(
+                "Payment verification failed on-chain for {} (no valid payments found)",
                 hex::encode(xorname)
-            ))),
-            Err(e) => Err(Error::Payment(format!(
-                "EVM verification error for {}: {e}",
-                hex::encode(xorname)
-            ))),
+            )));
         }
+
+        if tracing::enabled!(tracing::Level::INFO) {
+            let valid_count = results.iter().filter(|r| r.isValid).count();
+            info!(
+                "EVM payment verified for {} ({valid_count}/{} quotes paid)",
+                hex::encode(xorname),
+                results.len()
+            );
+        }
+        Ok(())
     }
 
     /// Validate quote count, uniqueness, and basic structure.

--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -292,12 +292,19 @@ impl PaymentVerifier {
 
         // Verify on-chain payment.
         //
-        // The SingleNode payment model pays only the median-priced quote (3x)
+        // The SingleNode payment model pays only the median-priced quote (at 3x)
         // and sends Amount::ZERO for the other 4. evmlib's pay_for_quotes()
         // filters out zero-amount payments, so only 1 quote has an on-chain
-        // record. The contract's verifyPayment() returns isValid=false for
-        // unpaid quotes, which is expected — we only require that at least
-        // one result is valid (the paid quote).
+        // record. The contract's verifyPayment() returns amountPaid=0 and
+        // isValid=false for unpaid quotes, which is expected.
+        //
+        // We use the amountPaid field to distinguish paid from unpaid results:
+        // - At least one quote must have been paid (amountPaid > 0)
+        // - ALL paid quotes must be valid (isValid=true)
+        // - Unpaid quotes (amountPaid=0) are allowed to be invalid
+        //
+        // This matches autonomi's strict verification model (all paid must be
+        // valid) while accommodating payment models that don't pay every quote.
         let payment_digest = payment.digest();
         if payment_digest.is_empty() {
             return Err(Error::Payment("Payment has no quotes".to_string()));
@@ -310,8 +317,7 @@ impl PaymentVerifier {
             )
             .collect();
 
-        let provider =
-            evmlib::utils::http_provider(self.config.evm.network.rpc_url().clone());
+        let provider = evmlib::utils::http_provider(self.config.evm.network.rpc_url().clone());
         let handler = evmlib::contract::payment_vault::handler::PaymentVaultHandler::new(
             *self.config.evm.network.data_payments_address(),
             provider,
@@ -327,18 +333,31 @@ impl PaymentVerifier {
                 ))
             })?;
 
-        let any_valid = results.iter().any(|r| r.isValid);
-        if !any_valid {
+        let paid_results: Vec<_> = results
+            .iter()
+            .filter(|r| r.amountPaid > evmlib::common::U256::ZERO)
+            .collect();
+
+        if paid_results.is_empty() {
             return Err(Error::Payment(format!(
-                "Payment verification failed on-chain for {} (no valid payments found)",
+                "Payment verification failed on-chain for {} (no paid quotes found)",
                 hex::encode(xorname)
             )));
         }
 
+        for result in &paid_results {
+            if !result.isValid {
+                return Err(Error::Payment(format!(
+                    "Payment verification failed on-chain for {} (paid quote is invalid)",
+                    hex::encode(xorname)
+                )));
+            }
+        }
+
         if tracing::enabled!(tracing::Level::INFO) {
-            let valid_count = results.iter().filter(|r| r.isValid).count();
+            let valid_count = paid_results.len();
             info!(
-                "EVM payment verified for {} ({valid_count}/{} quotes paid)",
+                "EVM payment verified for {} ({valid_count} paid and valid, {} total results)",
                 hex::encode(xorname),
                 results.len()
             );


### PR DESCRIPTION
## Summary

- The SingleNode payment model pays only the median-priced quote (3x) and sends `Amount::ZERO` for the other 4
- `evmlib::pay_for_quotes()` filters out zero-amount payments, so only 1 quote has an on-chain record
- The verifier was using `verify_data_payment()` which fails if ANY result is `isValid=false`, causing every upload to fail because the 4 unpaid quotes have no on-chain record
- Fix: call the contract's `verifyPayment()` directly and require that at least one result is valid (the paid quote), rather than requiring all results to be valid

## Test plan

- [x] Verified on 74-node testnet: uploads that previously failed with "Payment verification failed on-chain" now succeed
- [x] Existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)