### PR TITLE
feat: integrate merkle batch payments with ML-DSA-65

### DIFF
--- a/src/ant_protocol/chunk.rs
+++ b/src/ant_protocol/chunk.rs
@@ -47,6 +47,10 @@ pub enum ChunkMessageBody {
     QuoteRequest(ChunkQuoteRequest),
     /// Response with a storage quote.
     QuoteResponse(ChunkQuoteResponse),
+    /// Request a merkle candidate quote for batch payments.
+    MerkleCandidateQuoteRequest(MerkleCandidateQuoteRequest),
+    /// Response with a merkle candidate quote.
+    MerkleCandidateQuoteResponse(MerkleCandidateQuoteResponse),
 }
 
 /// Wire-format wrapper that pairs a sender-assigned `request_id` with
@@ -236,6 +240,49 @@ pub enum ChunkQuoteResponse {
     /// Quote generation failed.
     Error(ProtocolError),
 }
+
+// =============================================================================
+// Merkle Candidate Quote Request/Response
+// =============================================================================
+
+/// Request a merkle candidate quote for batch payments.
+///
+/// Part of the merkle batch payment system where clients collect
+/// signed candidate quotes from 16 closest peers per pool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MerkleCandidateQuoteRequest {
+    /// The candidate pool address (hash of midpoint || root || timestamp).
+    pub address: XorName,
+    /// Data type identifier (0 for chunks).
+    pub data_type: u32,
+    /// Size of the data in bytes.
+    pub data_size: u64,
+    /// Client-provided merkle payment timestamp (unix seconds).
+    pub merkle_payment_timestamp: u64,
+}
+
+/// Response with a merkle candidate quote.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum MerkleCandidateQuoteResponse {
+    /// Candidate quote generated successfully.
+    /// Contains the serialized `MerklePaymentCandidateNode`.
+    Success {
+        /// Serialized `MerklePaymentCandidateNode`.
+        candidate_node: Vec<u8>,
+    },
+    /// Quote generation failed.
+    Error(ProtocolError),
+}
+
+// =============================================================================
+// Payment Proof Type Tags
+// =============================================================================
+
+/// Version byte prefix for payment proof serialization.
+/// Allows the verifier to detect proof type before deserialization.
+pub const PROOF_TAG_SINGLE_NODE: u8 = 0x01;
+/// Version byte prefix for merkle payment proofs.
+pub const PROOF_TAG_MERKLE: u8 = 0x02;
 
 // =============================================================================
 // Protocol Errors
@@ -476,5 +523,91 @@ mod tests {
         assert_eq!(PROTOCOL_VERSION, 1);
         assert_eq!(MAX_CHUNK_SIZE, 4 * 1024 * 1024);
         assert_eq!(DATA_TYPE_CHUNK, 0);
+    }
+
+    #[test]
+    fn test_proof_tag_constants() {
+        // Tags must be distinct non-zero bytes
+        assert_ne!(PROOF_TAG_SINGLE_NODE, PROOF_TAG_MERKLE);
+        assert_ne!(PROOF_TAG_SINGLE_NODE, 0x00);
+        assert_ne!(PROOF_TAG_MERKLE, 0x00);
+        assert_eq!(PROOF_TAG_SINGLE_NODE, 0x01);
+        assert_eq!(PROOF_TAG_MERKLE, 0x02);
+    }
+
+    #[test]
+    fn test_merkle_candidate_quote_request_encode_decode() {
+        let address = [0x56; 32];
+        let request = MerkleCandidateQuoteRequest {
+            address,
+            data_type: DATA_TYPE_CHUNK,
+            data_size: 2048,
+            merkle_payment_timestamp: 1_700_000_000,
+        };
+        let msg = ChunkMessage {
+            request_id: 500,
+            body: ChunkMessageBody::MerkleCandidateQuoteRequest(request),
+        };
+
+        let encoded = msg.encode().expect("encode should succeed");
+        let decoded = ChunkMessage::decode(&encoded).expect("decode should succeed");
+
+        assert_eq!(decoded.request_id, 500);
+        if let ChunkMessageBody::MerkleCandidateQuoteRequest(req) = decoded.body {
+            assert_eq!(req.address, address);
+            assert_eq!(req.data_type, DATA_TYPE_CHUNK);
+            assert_eq!(req.data_size, 2048);
+            assert_eq!(req.merkle_payment_timestamp, 1_700_000_000);
+        } else {
+            panic!("expected MerkleCandidateQuoteRequest");
+        }
+    }
+
+    #[test]
+    fn test_merkle_candidate_quote_response_success_encode_decode() {
+        let candidate_node_bytes = vec![0xAA, 0xBB, 0xCC, 0xDD];
+        let response = MerkleCandidateQuoteResponse::Success {
+            candidate_node: candidate_node_bytes.clone(),
+        };
+        let msg = ChunkMessage {
+            request_id: 501,
+            body: ChunkMessageBody::MerkleCandidateQuoteResponse(response),
+        };
+
+        let encoded = msg.encode().expect("encode should succeed");
+        let decoded = ChunkMessage::decode(&encoded).expect("decode should succeed");
+
+        assert_eq!(decoded.request_id, 501);
+        if let ChunkMessageBody::MerkleCandidateQuoteResponse(
+            MerkleCandidateQuoteResponse::Success { candidate_node },
+        ) = decoded.body
+        {
+            assert_eq!(candidate_node, candidate_node_bytes);
+        } else {
+            panic!("expected MerkleCandidateQuoteResponse::Success");
+        }
+    }
+
+    #[test]
+    fn test_merkle_candidate_quote_response_error_encode_decode() {
+        let error = ProtocolError::QuoteFailed("no libp2p keypair".to_string());
+        let response = MerkleCandidateQuoteResponse::Error(error.clone());
+        let msg = ChunkMessage {
+            request_id: 502,
+            body: ChunkMessageBody::MerkleCandidateQuoteResponse(response),
+        };
+
+        let encoded = msg.encode().expect("encode should succeed");
+        let decoded = ChunkMessage::decode(&encoded).expect("decode should succeed");
+
+        assert_eq!(decoded.request_id, 502);
+        if let ChunkMessageBody::MerkleCandidateQuoteResponse(
+            MerkleCandidateQuoteResponse::Error(err),
+        ) = decoded.body
+        {
+            assert_eq!(err, error);
+        } else {
+            panic!("expected MerkleCandidateQuoteResponse::Error");
+        }
     }
 }

--- a/src/ant_protocol/mod.rs
+++ b/src/ant_protocol/mod.rs
@@ -48,6 +48,8 @@ pub mod chunk;
 // Re-export chunk types for convenience
 pub use chunk::{
     ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkMessageBody, ChunkPutRequest,
-    ChunkPutResponse, ChunkQuoteRequest, ChunkQuoteResponse, ProtocolError, XorName,
-    CHUNK_PROTOCOL_ID, DATA_TYPE_CHUNK, MAX_CHUNK_SIZE, MAX_WIRE_MESSAGE_SIZE, PROTOCOL_VERSION,
+    ChunkPutResponse, ChunkQuoteRequest, ChunkQuoteResponse, MerkleCandidateQuoteRequest,
+    MerkleCandidateQuoteResponse, ProtocolError, XorName, CHUNK_PROTOCOL_ID, DATA_TYPE_CHUNK,
+    MAX_CHUNK_SIZE, MAX_WIRE_MESSAGE_SIZE, PROOF_TAG_MERKLE, PROOF_TAG_SINGLE_NODE,
+    PROTOCOL_VERSION,
 };

--- a/src/bin/saorsa-devnet/main.rs
+++ b/src/bin/saorsa-devnet/main.rs
@@ -60,11 +60,14 @@ async fn main() -> color_eyre::Result<()> {
         let network = testnet.to_network();
         let wallet_key = testnet.default_wallet_private_key();
 
-        let (rpc_url, token_addr, payments_addr) = match &network {
+        let (rpc_url, token_addr, payments_addr, merkle_addr) = match &network {
             evmlib::Network::Custom(custom) => (
                 custom.rpc_url_http.to_string(),
                 format!("{:?}", custom.payment_token_address),
                 format!("{:?}", custom.data_payments_address),
+                custom
+                    .merkle_payments_address
+                    .map(|addr| format!("{addr:?}")),
             ),
             _ => {
                 return Err(color_eyre::eyre::eyre!(
@@ -87,6 +90,7 @@ async fn main() -> color_eyre::Result<()> {
             wallet_private_key: wallet_key,
             payment_token_address: token_addr,
             data_payments_address: payments_addr,
+            merkle_payments_address: merkle_addr,
         })
     } else {
         None

--- a/src/devnet.rs
+++ b/src/devnet.rs
@@ -246,6 +246,8 @@ pub struct DevnetEvmInfo {
     pub payment_token_address: String,
     /// Data payments contract address.
     pub data_payments_address: String,
+    /// Merkle payments contract address (for batch payments).
+    pub merkle_payments_address: Option<String>,
 }
 
 /// Network state for devnet startup lifecycle.

--- a/src/devnet.rs
+++ b/src/devnet.rs
@@ -247,6 +247,7 @@ pub struct DevnetEvmInfo {
     /// Data payments contract address.
     pub data_payments_address: String,
     /// Merkle payments contract address (for batch payments).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub merkle_payments_address: Option<String>,
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -371,19 +371,21 @@ impl NodeBuilder {
         let metrics_tracker = QuotingMetricsTracker::new(max_records, 0);
         let mut quote_generator = QuoteGenerator::new(rewards_address, metrics_tracker);
 
-        // Wire ML-DSA-65 signing from node identity
+        // Wire ML-DSA-65 signing from node identity.
+        // This same signer is used for both regular quotes and merkle candidate quotes.
         crate::payment::wire_ml_dsa_signer(&mut quote_generator, identity)?;
 
-        info!(
-            "ANT protocol handler initialized with ML-DSA-65 signing (protocol={})",
-            CHUNK_PROTOCOL_ID
-        );
-
-        Ok(AntProtocol::new(
+        let protocol = AntProtocol::new(
             Arc::new(storage),
             Arc::new(payment_verifier),
             Arc::new(quote_generator),
-        ))
+        );
+
+        info!(
+            "ANT protocol handler initialized with ML-DSA-65 signing (protocol={CHUNK_PROTOCOL_ID})"
+        );
+
+        Ok(protocol)
     }
 
     /// Build the bootstrap cache manager from config.

--- a/src/payment/mod.rs
+++ b/src/payment/mod.rs
@@ -50,8 +50,14 @@ pub mod wallet;
 pub use cache::{CacheStats, VerifiedCache};
 pub use metrics::QuotingMetricsTracker;
 pub use pricing::calculate_price;
-pub use proof::{deserialize_proof, PaymentProof};
-pub use quote::{verify_quote_content, wire_ml_dsa_signer, QuoteGenerator, XorName};
+pub use proof::{
+    deserialize_merkle_proof, deserialize_proof, detect_proof_type, serialize_merkle_proof,
+    serialize_single_node_proof, PaymentProof, ProofType,
+};
+pub use quote::{
+    verify_merkle_candidate_signature, verify_quote_content, wire_ml_dsa_signer, QuoteGenerator,
+    XorName,
+};
 pub use single_node::SingleNodePayment;
 pub use verifier::{EvmVerifierConfig, PaymentStatus, PaymentVerifier, PaymentVerifierConfig};
 pub use wallet::{is_valid_address, parse_rewards_address, WalletConfig};

--- a/src/payment/proof.rs
+++ b/src/payment/proof.rs
@@ -3,6 +3,8 @@
 //! `PaymentProof` bundles a `ProofOfPayment` (quotes + peer IDs) with the
 //! on-chain transaction hashes returned by the wallet after payment.
 
+use crate::ant_protocol::{PROOF_TAG_MERKLE, PROOF_TAG_SINGLE_NODE};
+use ant_evm::merkle_payments::MerklePaymentProof;
 use ant_evm::ProofOfPayment;
 use evmlib::common::TxHash;
 use serde::{Deserialize, Serialize};
@@ -20,25 +22,104 @@ pub struct PaymentProof {
     pub tx_hashes: Vec<TxHash>,
 }
 
-/// Deserialize proof bytes from the `PaymentProof` format.
+/// The detected type of a payment proof.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProofType {
+    /// `SingleNode` payment (5 quotes, median-paid).
+    SingleNode,
+    /// Merkle batch payment (one tx for many chunks).
+    Merkle,
+}
+
+/// Detect the proof type from the first byte (version tag).
 ///
+/// Returns `None` if the tag byte is unrecognized or the slice is empty.
+#[must_use]
+pub fn detect_proof_type(bytes: &[u8]) -> Option<ProofType> {
+    match bytes.first() {
+        Some(&PROOF_TAG_SINGLE_NODE) => Some(ProofType::SingleNode),
+        Some(&PROOF_TAG_MERKLE) => Some(ProofType::Merkle),
+        _ => None,
+    }
+}
+
+/// Serialize a `PaymentProof` (single-node) with the version tag prefix.
+///
+/// # Errors
+///
+/// Returns an error if serialization fails.
+pub fn serialize_single_node_proof(
+    proof: &PaymentProof,
+) -> std::result::Result<Vec<u8>, rmp_serde::encode::Error> {
+    let body = rmp_serde::to_vec(proof)?;
+    let mut tagged = Vec::with_capacity(1 + body.len());
+    tagged.push(PROOF_TAG_SINGLE_NODE);
+    tagged.extend_from_slice(&body);
+    Ok(tagged)
+}
+
+/// Serialize a `MerklePaymentProof` with the version tag prefix.
+///
+/// # Errors
+///
+/// Returns an error if serialization fails.
+pub fn serialize_merkle_proof(
+    proof: &MerklePaymentProof,
+) -> std::result::Result<Vec<u8>, rmp_serde::encode::Error> {
+    let body = rmp_serde::to_vec(proof)?;
+    let mut tagged = Vec::with_capacity(1 + body.len());
+    tagged.push(PROOF_TAG_MERKLE);
+    tagged.extend_from_slice(&body);
+    Ok(tagged)
+}
+
+/// Deserialize proof bytes from the `PaymentProof` format (single-node).
+///
+/// Expects the first byte to be `PROOF_TAG_SINGLE_NODE`.
 /// Returns `(ProofOfPayment, Vec<TxHash>)`.
 ///
 /// # Errors
 ///
-/// Returns an error if the bytes cannot be deserialized.
-pub fn deserialize_proof(
-    bytes: &[u8],
-) -> std::result::Result<(ProofOfPayment, Vec<TxHash>), rmp_serde::decode::Error> {
-    let proof = rmp_serde::from_slice::<PaymentProof>(bytes)?;
+/// Returns an error if the tag is missing or the bytes cannot be deserialized.
+pub fn deserialize_proof(bytes: &[u8]) -> Result<(ProofOfPayment, Vec<TxHash>), String> {
+    if bytes.first() != Some(&PROOF_TAG_SINGLE_NODE) {
+        return Err("Missing single-node proof tag byte".to_string());
+    }
+    let payload = bytes
+        .get(1..)
+        .ok_or_else(|| "Single-node proof tag present but no payload".to_string())?;
+    let proof = rmp_serde::from_slice::<PaymentProof>(payload)
+        .map_err(|e| format!("Failed to deserialize single-node proof: {e}"))?;
     Ok((proof.proof_of_payment, proof.tx_hashes))
 }
 
+/// Deserialize proof bytes as a `MerklePaymentProof`.
+///
+/// Expects the first byte to be `PROOF_TAG_MERKLE`.
+///
+/// # Errors
+///
+/// Returns an error if the bytes cannot be deserialized or the tag is wrong.
+pub fn deserialize_merkle_proof(bytes: &[u8]) -> std::result::Result<MerklePaymentProof, String> {
+    if bytes.first() != Some(&PROOF_TAG_MERKLE) {
+        return Err("Missing merkle proof tag byte".to_string());
+    }
+    let payload = bytes
+        .get(1..)
+        .ok_or_else(|| "Merkle proof tag present but no payload".to_string())?;
+    rmp_serde::from_slice::<MerklePaymentProof>(payload)
+        .map_err(|e| format!("Failed to deserialize merkle proof: {e}"))
+}
+
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
     use alloy::primitives::FixedBytes;
+    use ant_evm::merkle_payments::{
+        MerklePaymentCandidateNode, MerklePaymentCandidatePool, MerklePaymentProof, MerkleTree,
+        CANDIDATES_PER_POOL,
+    };
     use ant_evm::RewardsAddress;
     use ant_evm::{EncodedPeerId, PaymentQuote};
     use evmlib::quoting_metrics::QuotingMetrics;
@@ -84,7 +165,7 @@ mod tests {
             tx_hashes: vec![tx_hash],
         };
 
-        let bytes = rmp_serde::to_vec(&proof).unwrap();
+        let bytes = serialize_single_node_proof(&proof).unwrap();
         let (pop, hashes) = deserialize_proof(&bytes).unwrap();
 
         assert_eq!(pop.peer_quotes.len(), 1);
@@ -99,7 +180,7 @@ mod tests {
             tx_hashes: vec![],
         };
 
-        let bytes = rmp_serde::to_vec(&proof).unwrap();
+        let bytes = serialize_single_node_proof(&proof).unwrap();
         let (pop, hashes) = deserialize_proof(&bytes).unwrap();
 
         assert_eq!(pop.peer_quotes.len(), 1);
@@ -114,6 +195,18 @@ mod tests {
     }
 
     #[test]
+    fn test_deserialize_proof_rejects_untagged() {
+        // Raw msgpack without tag byte must be rejected
+        let proof = PaymentProof {
+            proof_of_payment: make_proof_of_payment(),
+            tx_hashes: vec![],
+        };
+        let raw_bytes = rmp_serde::to_vec(&proof).unwrap();
+        let result = deserialize_proof(&raw_bytes);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_payment_proof_multiple_tx_hashes() {
         let tx1 = FixedBytes::from([0x11u8; 32]);
         let tx2 = FixedBytes::from([0x22u8; 32]);
@@ -122,11 +215,182 @@ mod tests {
             tx_hashes: vec![tx1, tx2],
         };
 
-        let bytes = rmp_serde::to_vec(&proof).unwrap();
+        let bytes = serialize_single_node_proof(&proof).unwrap();
         let (_, hashes) = deserialize_proof(&bytes).unwrap();
 
         assert_eq!(hashes.len(), 2);
         assert_eq!(hashes.first().unwrap(), &tx1);
         assert_eq!(hashes.get(1).unwrap(), &tx2);
+    }
+
+    // =========================================================================
+    // detect_proof_type tests
+    // =========================================================================
+
+    #[test]
+    fn test_detect_proof_type_single_node() {
+        let bytes = [PROOF_TAG_SINGLE_NODE, 0x00, 0x01];
+        let result = detect_proof_type(&bytes);
+        assert_eq!(result, Some(ProofType::SingleNode));
+    }
+
+    #[test]
+    fn test_detect_proof_type_merkle() {
+        let bytes = [PROOF_TAG_MERKLE, 0x00, 0x01];
+        let result = detect_proof_type(&bytes);
+        assert_eq!(result, Some(ProofType::Merkle));
+    }
+
+    #[test]
+    fn test_detect_proof_type_unknown_tag() {
+        let bytes = [0xFF, 0x00, 0x01];
+        let result = detect_proof_type(&bytes);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_detect_proof_type_empty_bytes() {
+        let bytes: &[u8] = &[];
+        let result = detect_proof_type(bytes);
+        assert_eq!(result, None);
+    }
+
+    // =========================================================================
+    // Tagged serialize/deserialize round-trip tests
+    // =========================================================================
+
+    #[test]
+    fn test_serialize_single_node_proof_roundtrip_with_tag() {
+        let tx_hash = FixedBytes::from([0xCCu8; 32]);
+        let proof = PaymentProof {
+            proof_of_payment: make_proof_of_payment(),
+            tx_hashes: vec![tx_hash],
+        };
+
+        let tagged_bytes = serialize_single_node_proof(&proof).unwrap();
+
+        // First byte must be the single-node tag
+        assert_eq!(
+            tagged_bytes.first().copied(),
+            Some(PROOF_TAG_SINGLE_NODE),
+            "Tagged proof must start with PROOF_TAG_SINGLE_NODE"
+        );
+
+        // detect_proof_type should identify it
+        assert_eq!(
+            detect_proof_type(&tagged_bytes),
+            Some(ProofType::SingleNode)
+        );
+
+        // deserialize_proof handles the tag transparently
+        let (pop, hashes) = deserialize_proof(&tagged_bytes).unwrap();
+        assert_eq!(pop.peer_quotes.len(), 1);
+        assert_eq!(hashes.len(), 1);
+        assert_eq!(hashes.first().unwrap(), &tx_hash);
+    }
+
+    // =========================================================================
+    // Merkle proof serialize/deserialize round-trip tests
+    // =========================================================================
+
+    /// Create a minimal valid `MerklePaymentProof` from a small merkle tree.
+    fn make_test_merkle_proof() -> MerklePaymentProof {
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        // Build a tree with 4 addresses (minimal depth)
+        let addresses: Vec<xor_name::XorName> = (0..4u8)
+            .map(|i| xor_name::XorName::from_content(&[i]))
+            .collect();
+        let tree = MerkleTree::from_xornames(addresses.clone()).unwrap();
+
+        // Build candidate nodes
+        let candidate_nodes: [MerklePaymentCandidateNode; CANDIDATES_PER_POOL] =
+            std::array::from_fn(|i| {
+                let kp = Keypair::generate_ed25519();
+                MerklePaymentCandidateNode::new(
+                    &kp,
+                    QuotingMetrics {
+                        data_size: 1024,
+                        data_type: 0,
+                        close_records_stored: i * 10,
+                        records_per_type: vec![],
+                        max_records: 500,
+                        received_payment_count: 0,
+                        live_time: 100,
+                        network_density: None,
+                        network_size: None,
+                    },
+                    #[allow(clippy::cast_possible_truncation)]
+                    RewardsAddress::new([i as u8; 20]),
+                    timestamp,
+                )
+                .expect("candidate node creation should succeed")
+            });
+
+        let reward_candidates = tree.reward_candidates(timestamp).unwrap();
+        let midpoint_proof = reward_candidates.first().unwrap().clone();
+
+        let pool = MerklePaymentCandidatePool {
+            midpoint_proof,
+            candidate_nodes,
+        };
+
+        let first_address = *addresses.first().unwrap();
+        let address_proof = tree.generate_address_proof(0, first_address).unwrap();
+
+        MerklePaymentProof::new(first_address, address_proof, pool)
+    }
+
+    #[test]
+    fn test_serialize_merkle_proof_roundtrip() {
+        let merkle_proof = make_test_merkle_proof();
+
+        let tagged_bytes = serialize_merkle_proof(&merkle_proof).unwrap();
+
+        // First byte must be the merkle tag
+        assert_eq!(
+            tagged_bytes.first().copied(),
+            Some(PROOF_TAG_MERKLE),
+            "Tagged merkle proof must start with PROOF_TAG_MERKLE"
+        );
+
+        // detect_proof_type should identify it as merkle
+        assert_eq!(detect_proof_type(&tagged_bytes), Some(ProofType::Merkle));
+
+        // deserialize_merkle_proof should recover the original proof
+        let recovered = deserialize_merkle_proof(&tagged_bytes).unwrap();
+        assert_eq!(recovered.address, merkle_proof.address);
+        assert_eq!(
+            recovered.winner_pool.candidate_nodes.len(),
+            CANDIDATES_PER_POOL
+        );
+    }
+
+    #[test]
+    fn test_deserialize_merkle_proof_rejects_wrong_tag() {
+        let merkle_proof = make_test_merkle_proof();
+        let mut tagged_bytes = serialize_merkle_proof(&merkle_proof).unwrap();
+
+        // Replace the tag with the single-node tag
+        if let Some(first) = tagged_bytes.first_mut() {
+            *first = PROOF_TAG_SINGLE_NODE;
+        }
+
+        let result = deserialize_merkle_proof(&tagged_bytes);
+        assert!(result.is_err(), "Should reject wrong tag byte");
+        let err_msg = result.unwrap_err();
+        assert!(
+            err_msg.contains("Missing merkle proof tag"),
+            "Error should mention missing tag: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_merkle_proof_rejects_empty() {
+        let result = deserialize_merkle_proof(&[]);
+        assert!(result.is_err());
     }
 }

--- a/src/payment/proof.rs
+++ b/src/payment/proof.rs
@@ -125,6 +125,9 @@ mod tests {
     use evmlib::quoting_metrics::QuotingMetrics;
     use libp2p::identity::Keypair;
     use libp2p::PeerId;
+    use saorsa_core::MlDsa65;
+    use saorsa_pqc::pqc::types::MlDsaSecretKey;
+    use saorsa_pqc::pqc::MlDsaOperations;
     use std::time::SystemTime;
     use xor_name::XorName;
 
@@ -306,28 +309,36 @@ mod tests {
             .collect();
         let tree = MerkleTree::from_xornames(addresses.clone()).unwrap();
 
-        // Build candidate nodes
+        // Build candidate nodes with ML-DSA-65 signing (matching production)
         let candidate_nodes: [MerklePaymentCandidateNode; CANDIDATES_PER_POOL] =
             std::array::from_fn(|i| {
-                let kp = Keypair::generate_ed25519();
-                MerklePaymentCandidateNode::new(
-                    &kp,
-                    QuotingMetrics {
-                        data_size: 1024,
-                        data_type: 0,
-                        close_records_stored: i * 10,
-                        records_per_type: vec![],
-                        max_records: 500,
-                        received_payment_count: 0,
-                        live_time: 100,
-                        network_density: None,
-                        network_size: None,
-                    },
-                    #[allow(clippy::cast_possible_truncation)]
-                    RewardsAddress::new([i as u8; 20]),
-                    timestamp,
-                )
-                .expect("candidate node creation should succeed")
+                let ml_dsa = MlDsa65::new();
+                let (pub_key, secret_key) = ml_dsa.generate_keypair().expect("keygen");
+                let metrics = QuotingMetrics {
+                    data_size: 1024,
+                    data_type: 0,
+                    close_records_stored: i * 10,
+                    records_per_type: vec![],
+                    max_records: 500,
+                    received_payment_count: 0,
+                    live_time: 100,
+                    network_density: None,
+                    network_size: None,
+                };
+                #[allow(clippy::cast_possible_truncation)]
+                let reward_address = RewardsAddress::new([i as u8; 20]);
+                let msg =
+                    MerklePaymentCandidateNode::bytes_to_sign(&metrics, &reward_address, timestamp);
+                let sk = MlDsaSecretKey::from_bytes(secret_key.as_bytes()).expect("sk");
+                let signature = ml_dsa.sign(&sk, &msg).expect("sign").as_bytes().to_vec();
+
+                MerklePaymentCandidateNode {
+                    pub_key: pub_key.as_bytes().to_vec(),
+                    quoting_metrics: metrics,
+                    reward_address,
+                    merkle_payment_timestamp: timestamp,
+                    signature,
+                }
             });
 
         let reward_candidates = tree.reward_candidates(timestamp).unwrap();

--- a/src/payment/quote.rs
+++ b/src/payment/quote.rs
@@ -9,6 +9,7 @@
 
 use crate::error::{Error, Result};
 use crate::payment::metrics::QuotingMetricsTracker;
+use ant_evm::merkle_payments::MerklePaymentCandidateNode;
 use ant_evm::{PaymentQuote, QuotingMetrics, RewardsAddress};
 use saorsa_core::MlDsa65;
 use saorsa_pqc::pqc::types::{MlDsaPublicKey, MlDsaSecretKey, MlDsaSignature};
@@ -185,6 +186,65 @@ impl QuoteGenerator {
     pub fn record_store(&self, data_type: u32) {
         self.metrics_tracker.record_store(data_type);
     }
+
+    /// Create a merkle candidate quote for batch payment using ML-DSA-65.
+    ///
+    /// Returns a `MerklePaymentCandidateNode` constructed with the node's
+    /// ML-DSA-65 public key and signature. This uses the same post-quantum
+    /// signing stack as regular payment quotes, rather than the ed25519
+    /// signing that the upstream `ant-evm` library assumes.
+    ///
+    /// The `pub_key` field stores the raw ML-DSA-65 public key bytes,
+    /// and `signature` stores the ML-DSA-65 signature over `bytes_to_sign()`.
+    /// Clients verify these using `verify_merkle_candidate_signature()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if signing is not configured.
+    pub fn create_merkle_candidate_quote(
+        &self,
+        data_size: usize,
+        data_type: u32,
+        merkle_payment_timestamp: u64,
+    ) -> Result<MerklePaymentCandidateNode> {
+        let sign_fn = self
+            .sign_fn
+            .as_ref()
+            .ok_or_else(|| Error::Payment("Quote signing not configured".to_string()))?;
+
+        let quoting_metrics = self.metrics_tracker.get_metrics(data_size, data_type);
+
+        // Compute the same bytes_to_sign used by the upstream library
+        let msg = MerklePaymentCandidateNode::bytes_to_sign(
+            &quoting_metrics,
+            &self.rewards_address,
+            merkle_payment_timestamp,
+        );
+
+        // Sign with ML-DSA-65
+        let signature = sign_fn(&msg);
+        if signature.is_empty() {
+            return Err(Error::Payment(
+                "ML-DSA-65 signing produced empty signature for merkle candidate".to_string(),
+            ));
+        }
+
+        let candidate = MerklePaymentCandidateNode {
+            pub_key: self.pub_key.clone(),
+            quoting_metrics,
+            reward_address: self.rewards_address,
+            merkle_payment_timestamp,
+            signature,
+        };
+
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            debug!(
+                "Generated ML-DSA-65 merkle candidate quote (size: {data_size}, type: {data_type}, ts: {merkle_payment_timestamp})"
+            );
+        }
+
+        Ok(candidate)
+    }
 }
 
 /// Verify a payment quote's content address and ML-DSA-65 signature.
@@ -260,6 +320,54 @@ pub fn verify_quote_signature(quote: &PaymentQuote) -> bool {
         }
         Err(e) => {
             debug!("ML-DSA-65 verification error: {e}");
+            false
+        }
+    }
+}
+
+/// Verify a `MerklePaymentCandidateNode` signature using ML-DSA-65.
+///
+/// Saorsa uses ML-DSA-65 post-quantum signatures for merkle candidate signing,
+/// rather than the ed25519 signatures used by the upstream `ant-evm` library.
+/// The `pub_key` field contains the raw ML-DSA-65 public key bytes, and
+/// `signature` contains the ML-DSA-65 signature over `bytes_to_sign()`.
+///
+/// This replaces `MerklePaymentCandidateNode::verify_signature()` which
+/// expects libp2p ed25519 keys.
+#[must_use]
+pub fn verify_merkle_candidate_signature(candidate: &MerklePaymentCandidateNode) -> bool {
+    let pub_key = match MlDsaPublicKey::from_bytes(&candidate.pub_key) {
+        Ok(pk) => pk,
+        Err(e) => {
+            debug!("Failed to parse ML-DSA-65 public key from merkle candidate: {e}");
+            return false;
+        }
+    };
+
+    let signature = match MlDsaSignature::from_bytes(&candidate.signature) {
+        Ok(sig) => sig,
+        Err(e) => {
+            debug!("Failed to parse ML-DSA-65 signature from merkle candidate: {e}");
+            return false;
+        }
+    };
+
+    let msg = MerklePaymentCandidateNode::bytes_to_sign(
+        &candidate.quoting_metrics,
+        &candidate.reward_address,
+        candidate.merkle_payment_timestamp,
+    );
+
+    let ml_dsa = MlDsa65::new();
+    match ml_dsa.verify(&pub_key, &msg, &signature) {
+        Ok(valid) => {
+            if !valid {
+                debug!("ML-DSA-65 merkle candidate signature verification failed");
+            }
+            valid
+        }
+        Err(e) => {
+            debug!("ML-DSA-65 merkle candidate verification error: {e}");
             false
         }
     }
@@ -572,5 +680,70 @@ mod tests {
 
         let result = generator.probe_signer();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_create_merkle_candidate_quote_with_ml_dsa() {
+        let ml_dsa = MlDsa65::new();
+        let (public_key, secret_key) = ml_dsa.generate_keypair().expect("keypair generation");
+
+        let rewards_address = RewardsAddress::new([0x42u8; 20]);
+        let metrics_tracker = QuotingMetricsTracker::new(800, 50);
+        let mut generator = QuoteGenerator::new(rewards_address, metrics_tracker);
+
+        // Wire ML-DSA-65 signing (same as production nodes)
+        let pub_key_bytes = public_key.as_bytes().to_vec();
+        let sk_bytes = secret_key.as_bytes().to_vec();
+        generator.set_signer(pub_key_bytes.clone(), move |msg| {
+            let sk = MlDsaSecretKey::from_bytes(&sk_bytes).expect("sk parse");
+            let ml_dsa = MlDsa65::new();
+            ml_dsa.sign(&sk, msg).expect("sign").as_bytes().to_vec()
+        });
+
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_secs();
+
+        let result = generator.create_merkle_candidate_quote(2048, 0, timestamp);
+
+        assert!(
+            result.is_ok(),
+            "create_merkle_candidate_quote should succeed: {result:?}"
+        );
+
+        let candidate = result.expect("valid candidate");
+
+        // Verify the returned node has the correct reward address
+        assert_eq!(candidate.reward_address, rewards_address);
+
+        // Verify the timestamp was set correctly
+        assert_eq!(candidate.merkle_payment_timestamp, timestamp);
+
+        // Verify metrics match what the tracker would produce
+        assert_eq!(candidate.quoting_metrics.data_size, 2048);
+        assert_eq!(candidate.quoting_metrics.data_type, 0);
+        assert_eq!(candidate.quoting_metrics.max_records, 800);
+        assert_eq!(candidate.quoting_metrics.close_records_stored, 50);
+
+        // Verify the public key is the ML-DSA-65 public key (not ed25519)
+        assert_eq!(
+            candidate.pub_key, pub_key_bytes,
+            "Public key should be raw ML-DSA-65 bytes"
+        );
+
+        // Verify ML-DSA-65 signature is valid using our verifier
+        assert!(
+            verify_merkle_candidate_signature(&candidate),
+            "ML-DSA-65 merkle candidate signature must be valid"
+        );
+
+        // Verify tampered timestamp invalidates ML-DSA signature
+        let mut tampered = candidate;
+        tampered.merkle_payment_timestamp = timestamp + 1;
+        assert!(
+            !verify_merkle_candidate_signature(&tampered),
+            "Tampered timestamp should invalidate the ML-DSA-65 signature"
+        );
     }
 }

--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -13,8 +13,6 @@ use crate::payment::single_node::REQUIRED_QUOTES;
 use ant_evm::merkle_payments::OnChainPaymentInfo;
 use ant_evm::{ProofOfPayment, RewardsAddress};
 use evmlib::contract::merkle_payment_vault;
-use evmlib::contract::payment_vault::error::Error as PaymentVaultError;
-use evmlib::contract::payment_vault::verify_data_payment;
 use evmlib::merkle_batch_payment::PoolHash;
 use evmlib::Network as EvmNetwork;
 use lru::LruCache;

--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -5,12 +5,22 @@
 
 use crate::error::{Error, Result};
 use crate::payment::cache::{CacheStats, VerifiedCache, XorName};
-use crate::payment::proof::deserialize_proof;
+use crate::payment::proof::{
+    deserialize_merkle_proof, deserialize_proof, detect_proof_type, ProofType,
+};
 use crate::payment::quote::{verify_quote_content, verify_quote_signature};
 use crate::payment::single_node::REQUIRED_QUOTES;
+use ant_evm::merkle_payments::OnChainPaymentInfo;
 use ant_evm::{ProofOfPayment, RewardsAddress};
+use evmlib::contract::merkle_payment_vault;
+use evmlib::contract::payment_vault::error::Error as PaymentVaultError;
+use evmlib::contract::payment_vault::verify_data_payment;
+use evmlib::merkle_batch_payment::PoolHash;
 use evmlib::Network as EvmNetwork;
+use lru::LruCache;
+use parking_lot::Mutex;
 use saorsa_core::identity::node_identity::peer_id_from_public_key_bytes;
+use std::num::NonZeroUsize;
 use std::time::SystemTime;
 use tracing::{debug, info};
 
@@ -20,12 +30,13 @@ use tracing::{debug, info};
 /// Proofs smaller than this are rejected as they cannot contain sufficient payment information.
 const MIN_PAYMENT_PROOF_SIZE_BYTES: usize = 32;
 
-/// Maximum allowed size for a payment proof in bytes (100 KB).
+/// Maximum allowed size for a payment proof in bytes (256 KB).
 ///
-/// A `ProofOfPayment` with 5 ML-DSA-65 quotes can reach ~30 KB (each quote carries a
-/// ~1,952-byte public key and a 3,309-byte signature plus metadata). 100 KB provides
-/// headroom for future fields while still capping memory during verification.
-const MAX_PAYMENT_PROOF_SIZE_BYTES: usize = 102_400;
+/// Single-node proofs with 5 ML-DSA-65 quotes reach ~30 KB.
+/// Merkle proofs include 16 candidate nodes (each with ~1,952-byte ML-DSA pub key
+/// and ~3,309-byte signature) plus merkle branch hashes, totaling ~130 KB.
+/// 256 KB provides headroom while still capping memory during verification.
+const MAX_PAYMENT_PROOF_SIZE_BYTES: usize = 262_144;
 
 /// Maximum age of a payment quote before it's considered expired (24 hours).
 /// Prevents replaying old cheap quotes against nearly-full nodes.
@@ -93,14 +104,20 @@ impl PaymentStatus {
     }
 }
 
+/// Default capacity for the merkle pool cache (number of pool hashes to cache).
+const DEFAULT_POOL_CACHE_CAPACITY: usize = 1_000;
+
 /// Main payment verifier for saorsa-node.
 ///
 /// Uses:
 /// 1. LRU cache for fast lookups of previously verified `XorName` values
 /// 2. EVM payment verification for new data (always required)
+/// 3. Pool-level cache for merkle batch payments (avoids repeated on-chain queries)
 pub struct PaymentVerifier {
     /// LRU cache of verified `XorName` values.
     cache: VerifiedCache,
+    /// LRU cache of verified merkle pool hashes → on-chain payment info.
+    pool_cache: Mutex<LruCache<PoolHash, OnChainPaymentInfo>>,
     /// Configuration.
     config: PaymentVerifierConfig,
 }
@@ -110,11 +127,19 @@ impl PaymentVerifier {
     #[must_use]
     pub fn new(config: PaymentVerifierConfig) -> Self {
         let cache = VerifiedCache::with_capacity(config.cache_capacity);
+        // SAFETY: DEFAULT_POOL_CACHE_CAPACITY is a const > 0, so this is always Some
+        let pool_cache_size =
+            NonZeroUsize::new(DEFAULT_POOL_CACHE_CAPACITY).unwrap_or(NonZeroUsize::MIN);
+        let pool_cache = Mutex::new(LruCache::new(pool_cache_size));
 
         let cache_capacity = config.cache_capacity;
-        info!("Payment verifier initialized (cache_capacity={cache_capacity}, evm=always-on)");
+        info!("Payment verifier initialized (cache_capacity={cache_capacity}, evm=always-on, pool_cache={DEFAULT_POOL_CACHE_CAPACITY})");
 
-        Self { cache, config }
+        Self {
+            cache,
+            pool_cache,
+            config,
+        }
     }
 
     /// Check if payment is required for the given `XorName`.
@@ -197,17 +222,29 @@ impl PaymentVerifier {
                         )));
                     }
 
-                    // Deserialize the proof (supports both new PaymentProof and legacy ProofOfPayment)
-                    let (payment, tx_hashes) = deserialize_proof(proof).map_err(|e| {
-                        Error::Payment(format!("Failed to deserialize payment proof: {e}"))
-                    })?;
+                    // Detect proof type from version tag byte
+                    match detect_proof_type(proof) {
+                        Some(ProofType::Merkle) => {
+                            self.verify_merkle_payment(xorname, proof).await?;
+                        }
+                        Some(ProofType::SingleNode) => {
+                            let (payment, tx_hashes) = deserialize_proof(proof).map_err(|e| {
+                                Error::Payment(format!("Failed to deserialize payment proof: {e}"))
+                            })?;
 
-                    if !tx_hashes.is_empty() {
-                        debug!("Proof includes {} transaction hash(es)", tx_hashes.len());
+                            if !tx_hashes.is_empty() {
+                                debug!("Proof includes {} transaction hash(es)", tx_hashes.len());
+                            }
+
+                            self.verify_evm_payment(xorname, &payment).await?;
+                        }
+                        None => {
+                            return Err(Error::Payment(format!(
+                                "Unknown payment proof type tag: {:?}",
+                                proof.first()
+                            )));
+                        }
                     }
-
-                    // Verify the payment using EVM
-                    self.verify_evm_payment(xorname, &payment).await?;
 
                     // Cache the verified xorname
                     self.cache.insert(*xorname);
@@ -469,6 +506,168 @@ impl PaymentVerifier {
         Ok(())
     }
 
+    /// Verify a merkle batch payment proof.
+    ///
+    /// This verification flow:
+    /// 1. Deserialize the `MerklePaymentProof`
+    /// 2. Check pool cache for previously verified pool hash
+    /// 3. If not cached, query on-chain for payment info
+    /// 4. Validate the proof against on-chain data
+    /// 5. Cache the pool hash for subsequent chunk verifications in the same batch
+    #[allow(clippy::too_many_lines)]
+    async fn verify_merkle_payment(&self, xorname: &XorName, proof_bytes: &[u8]) -> Result<()> {
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            debug!("Verifying merkle payment for {}", hex::encode(xorname));
+        }
+
+        // Deserialize the merkle proof
+        let merkle_proof = deserialize_merkle_proof(proof_bytes)
+            .map_err(|e| Error::Payment(format!("Failed to deserialize merkle proof: {e}")))?;
+
+        // Verify the address in the proof matches the xorname being stored
+        if merkle_proof.address.0 != *xorname {
+            return Err(Error::Payment(format!(
+                "Merkle proof address mismatch: proof is for {}, but storing {}",
+                hex::encode(merkle_proof.address.0),
+                hex::encode(xorname)
+            )));
+        }
+
+        let pool_hash = merkle_proof.winner_pool_hash();
+
+        // Check pool cache first
+        let cached_info = {
+            let mut pool_cache = self.pool_cache.lock();
+            pool_cache.get(&pool_hash).cloned()
+        };
+
+        let payment_info = if let Some(info) = cached_info {
+            debug!("Pool cache hit for hash {}", hex::encode(pool_hash));
+            info
+        } else {
+            // Query on-chain for payment info
+            let info =
+                merkle_payment_vault::get_merkle_payment_info(&self.config.evm.network, pool_hash)
+                    .await
+                    .map_err(|e| {
+                        Error::Payment(format!(
+                            "Failed to query merkle payment info for pool {}: {e}",
+                            hex::encode(pool_hash)
+                        ))
+                    })?;
+
+            let on_chain_info = OnChainPaymentInfo {
+                depth: info.depth,
+                merkle_payment_timestamp: info.merklePaymentTimestamp,
+                paid_node_addresses: info
+                    .paidNodeAddresses
+                    .iter()
+                    .map(|pna| (pna.rewardsAddress, pna.poolIndex as usize))
+                    .collect(),
+            };
+
+            // Cache the pool info for subsequent chunks in the same batch
+            {
+                let mut pool_cache = self.pool_cache.lock();
+                pool_cache.put(pool_hash, on_chain_info.clone());
+            }
+
+            debug!(
+                "Queried on-chain merkle payment info for pool {}: depth={}, timestamp={}, paid_nodes={}",
+                hex::encode(pool_hash),
+                on_chain_info.depth,
+                on_chain_info.merkle_payment_timestamp,
+                on_chain_info.paid_node_addresses.len()
+            );
+
+            on_chain_info
+        };
+
+        // pool_hash was derived from merkle_proof.winner_pool and used to query
+        // the contract. The contract only returns data if a payment exists for that
+        // hash. The ML-DSA signature check below ensures the pool contents are
+        // authentic (nodes actually signed their candidate quotes).
+
+        // Verify ML-DSA-65 signatures on all candidate nodes in the winner pool.
+        // Without this, a client could fabricate a pool with fake reward addresses
+        // since the contract only commits to the bytes the client submitted.
+        for candidate in &merkle_proof.winner_pool.candidate_nodes {
+            if !crate::payment::verify_merkle_candidate_signature(candidate) {
+                return Err(Error::Payment(format!(
+                    "Invalid ML-DSA-65 signature on merkle candidate node (reward: {})",
+                    candidate.reward_address
+                )));
+            }
+        }
+
+        // Get the root from the winner pool's midpoint proof
+        let smart_contract_root = merkle_proof.winner_pool.midpoint_proof.root();
+
+        // Verify the cryptographic merkle proofs (address belongs to tree,
+        // midpoint belongs to tree, roots match, timestamps valid).
+        ant_evm::merkle_payments::verify_merkle_proof(
+            &merkle_proof.address,
+            &merkle_proof.data_proof,
+            &merkle_proof.winner_pool.midpoint_proof,
+            payment_info.depth,
+            smart_contract_root,
+            payment_info.merkle_payment_timestamp,
+        )
+        .map_err(|e| {
+            Error::Payment(format!(
+                "Merkle proof verification failed for {}: {e}",
+                hex::encode(xorname)
+            ))
+        })?;
+
+        // Verify paid node count matches depth
+        if payment_info.paid_node_addresses.len() != payment_info.depth as usize {
+            return Err(Error::Payment(format!(
+                "Wrong number of paid nodes: expected {}, got {}",
+                payment_info.depth,
+                payment_info.paid_node_addresses.len()
+            )));
+        }
+
+        // Verify paid node indices are valid within the candidate pool.
+        //
+        // Note: unlike single-node payments, merkle proofs are NOT bound to a
+        // specific storing node. The contract pays `depth` random nodes from the
+        // winner pool; the storing node is whichever close-group peer the client
+        // routes the chunk to. There is no local-recipient check here because
+        // any node that can verify the merkle proof is allowed to store the chunk.
+        // Replay protection comes from the per-address proof binding (each proof
+        // is for a specific XorName in the paid tree).
+        for (addr, idx) in &payment_info.paid_node_addresses {
+            let node = merkle_proof
+                .winner_pool
+                .candidate_nodes
+                .get(*idx)
+                .ok_or_else(|| {
+                    Error::Payment(format!(
+                        "Paid node index {idx} out of bounds for pool size {}",
+                        merkle_proof.winner_pool.candidate_nodes.len()
+                    ))
+                })?;
+            if node.reward_address != *addr {
+                return Err(Error::Payment(format!(
+                    "Paid node address mismatch at index {idx}: expected {addr}, got {}",
+                    node.reward_address
+                )));
+            }
+        }
+
+        if tracing::enabled!(tracing::Level::INFO) {
+            info!(
+                "Merkle payment verified for {} (pool: {})",
+                hex::encode(xorname),
+                hex::encode(pool_hash)
+            );
+        }
+
+        Ok(())
+    }
+
     /// Verify this node is among the paid recipients.
     fn validate_local_recipient(&self, payment: &ProofOfPayment) -> Result<()> {
         let local_addr = &self.config.local_rewards_address;
@@ -619,54 +818,56 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_proof_at_min_boundary() {
+    async fn test_proof_at_min_boundary_unknown_tag() {
         let verifier = create_test_verifier();
         let xorname = [3u8; 32];
 
-        // Exactly MIN_PAYMENT_PROOF_SIZE_BYTES — passes size check, but
-        // will fail deserialization (not valid msgpack)
+        // Exactly MIN_PAYMENT_PROOF_SIZE_BYTES with unknown tag — rejected
         let boundary_proof = vec![0xFFu8; MIN_PAYMENT_PROOF_SIZE_BYTES];
         let result = verifier
             .verify_payment(&xorname, Some(&boundary_proof))
             .await;
         assert!(result.is_err());
-        let err_msg = format!("{}", result.expect_err("should fail deser"));
+        let err_msg = format!("{}", result.expect_err("should fail"));
         assert!(
-            err_msg.contains("deserialize"),
-            "Error should mention deserialization: {err_msg}"
+            err_msg.contains("Unknown payment proof type tag"),
+            "Error should mention unknown tag: {err_msg}"
         );
     }
 
     #[tokio::test]
-    async fn test_proof_at_max_boundary() {
+    async fn test_proof_at_max_boundary_unknown_tag() {
         let verifier = create_test_verifier();
         let xorname = [4u8; 32];
 
-        // Exactly MAX_PAYMENT_PROOF_SIZE_BYTES — passes size check, but
-        // will fail deserialization
+        // Exactly MAX_PAYMENT_PROOF_SIZE_BYTES with unknown tag — rejected
         let boundary_proof = vec![0xFFu8; MAX_PAYMENT_PROOF_SIZE_BYTES];
         let result = verifier
             .verify_payment(&xorname, Some(&boundary_proof))
             .await;
         assert!(result.is_err());
-        let err_msg = format!("{}", result.expect_err("should fail deser"));
+        let err_msg = format!("{}", result.expect_err("should fail"));
         assert!(
-            err_msg.contains("deserialize"),
-            "Error should mention deserialization: {err_msg}"
+            err_msg.contains("Unknown payment proof type tag"),
+            "Error should mention unknown tag: {err_msg}"
         );
     }
 
     #[tokio::test]
-    async fn test_malformed_msgpack_proof() {
+    async fn test_malformed_single_node_proof() {
         let verifier = create_test_verifier();
         let xorname = [5u8; 32];
 
-        // Valid size but garbage bytes — should fail deserialization
-        let garbage = vec![0xAB; 64];
+        // Valid tag (0x01) but garbage payload — should fail deserialization
+        let mut garbage = vec![crate::ant_protocol::PROOF_TAG_SINGLE_NODE];
+        garbage.extend_from_slice(&[0xAB; 63]);
         let result = verifier.verify_payment(&xorname, Some(&garbage)).await;
         assert!(result.is_err());
         let err_msg = format!("{}", result.expect_err("should fail"));
-        assert!(err_msg.contains("deserialize"));
+        assert!(
+            err_msg.contains("deserialize") || err_msg.contains("Failed"),
+            "Error should mention deserialization failure: {err_msg}"
+        );
     }
 
     #[test]
@@ -776,7 +977,8 @@ mod tests {
             tx_hashes: vec![FixedBytes::from([0xABu8; 32])],
         };
 
-        let proof_bytes = rmp_serde::to_vec(&proof).expect("serialize");
+        let proof_bytes =
+            crate::payment::proof::serialize_single_node_proof(&proof).expect("serialize");
 
         // 5 ML-DSA-65 quotes with ~1952-byte pub keys and ~3309-byte signatures
         // should produce a proof in the 20-60 KB range
@@ -795,7 +997,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_content_address_mismatch_rejected() {
-        use crate::payment::proof::PaymentProof;
+        use crate::payment::proof::{serialize_single_node_proof, PaymentProof};
         use ant_evm::{EncodedPeerId, PaymentQuote, QuotingMetrics, RewardsAddress};
         use libp2p::identity::Keypair;
         use libp2p::PeerId;
@@ -834,14 +1036,13 @@ mod tests {
             let peer_id = PeerId::from_public_key(&keypair.public());
             peer_quotes.push((EncodedPeerId::from(peer_id), quote.clone()));
         }
-        let payment = ProofOfPayment { peer_quotes };
 
         let proof = PaymentProof {
-            proof_of_payment: payment,
+            proof_of_payment: ProofOfPayment { peer_quotes },
             tx_hashes: vec![],
         };
 
-        let proof_bytes = rmp_serde::to_vec(&proof).expect("serialize proof");
+        let proof_bytes = serialize_single_node_proof(&proof).expect("serialize proof");
 
         let result = verifier
             .verify_payment(&target_xorname, Some(&proof_bytes))
@@ -883,17 +1084,17 @@ mod tests {
         }
     }
 
-    /// Helper: wrap quotes into a serialized `PaymentProof`.
+    /// Helper: wrap quotes into a tagged serialized `PaymentProof`.
     fn serialize_proof(
         peer_quotes: Vec<(ant_evm::EncodedPeerId, ant_evm::PaymentQuote)>,
     ) -> Vec<u8> {
-        use crate::payment::proof::PaymentProof;
+        use crate::payment::proof::{serialize_single_node_proof, PaymentProof};
 
         let proof = PaymentProof {
             proof_of_payment: ProofOfPayment { peer_quotes },
             tx_hashes: vec![],
         };
-        rmp_serde::to_vec(&proof).expect("serialize proof")
+        serialize_single_node_proof(&proof).expect("serialize proof")
     }
 
     #[tokio::test]
@@ -1152,5 +1353,131 @@ mod tests {
             err_msg.contains("pub_key does not belong to claimed peer"),
             "Error should mention binding mismatch: {err_msg}"
         );
+    }
+
+    // =========================================================================
+    // Merkle-tagged proof tests
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_merkle_tagged_proof_invalid_data_rejected() {
+        use crate::ant_protocol::PROOF_TAG_MERKLE;
+
+        let verifier = create_test_verifier();
+        let xorname = [0xA1u8; 32];
+
+        // Build a merkle-tagged proof with garbage body.
+        // The tag byte is correct but the body is not valid msgpack.
+        let mut merkle_garbage = Vec::with_capacity(64);
+        merkle_garbage.push(PROOF_TAG_MERKLE);
+        merkle_garbage.extend_from_slice(&[0xAB; 63]);
+
+        let result = verifier
+            .verify_payment(&xorname, Some(&merkle_garbage))
+            .await;
+
+        assert!(
+            result.is_err(),
+            "Should reject merkle proof with invalid body"
+        );
+        let err_msg = format!("{}", result.expect_err("should fail"));
+        assert!(
+            err_msg.contains("deserialize") || err_msg.contains("merkle proof"),
+            "Error should mention deserialization failure: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_single_node_tagged_proof_deserialization() {
+        use crate::payment::proof::serialize_single_node_proof;
+        use ant_evm::{EncodedPeerId, RewardsAddress};
+
+        let verifier = create_test_verifier();
+        let xorname = [0xA2u8; 32];
+        let rewards_addr = RewardsAddress::new([1u8; 20]);
+
+        // Build a valid tagged single-node proof
+        let quote = make_fake_quote(xorname, SystemTime::now(), rewards_addr);
+        let mut peer_quotes = Vec::new();
+        for _ in 0..5 {
+            let keypair = libp2p::identity::Keypair::generate_ed25519();
+            let peer_id = libp2p::PeerId::from_public_key(&keypair.public());
+            peer_quotes.push((EncodedPeerId::from(peer_id), quote.clone()));
+        }
+
+        let proof = crate::payment::proof::PaymentProof {
+            proof_of_payment: ProofOfPayment {
+                peer_quotes: peer_quotes.clone(),
+            },
+            tx_hashes: vec![],
+        };
+
+        let tagged_bytes = serialize_single_node_proof(&proof).expect("serialize tagged proof");
+
+        // detect_proof_type should identify it as SingleNode
+        assert_eq!(
+            crate::payment::proof::detect_proof_type(&tagged_bytes),
+            Some(crate::payment::proof::ProofType::SingleNode)
+        );
+
+        // verify_payment should process it through the single-node path.
+        // It will fail at quote validation (fake pub_key), but we verify
+        // it passes the deserialization stage by checking the error type.
+        let result = verifier.verify_payment(&xorname, Some(&tagged_bytes)).await;
+
+        assert!(result.is_err(), "Should fail at quote validation stage");
+        let err_msg = format!("{}", result.expect_err("should fail"));
+        // It should NOT be a deserialization error — it should get further
+        assert!(
+            !err_msg.contains("deserialize"),
+            "Should pass deserialization but fail later: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn test_pool_cache_same_hash_queries_once() {
+        use evmlib::merkle_batch_payment::PoolHash;
+
+        // Verify the pool_cache field exists and works correctly.
+        // Insert a pool hash, then verify it's present on lookup.
+        let verifier = create_test_verifier();
+
+        let pool_hash: PoolHash = [0xBBu8; 32];
+        let payment_info = ant_evm::merkle_payments::OnChainPaymentInfo {
+            depth: 4,
+            merkle_payment_timestamp: 1_700_000_000,
+            paid_node_addresses: vec![],
+        };
+
+        // Insert into pool cache
+        {
+            let mut cache = verifier.pool_cache.lock();
+            cache.put(pool_hash, payment_info);
+        }
+
+        // First lookup — should find it
+        {
+            let found = verifier.pool_cache.lock().get(&pool_hash).cloned();
+            assert!(found.is_some(), "Pool hash should be in cache after insert");
+            let info = found.expect("cached info");
+            assert_eq!(info.depth, 4);
+            assert_eq!(info.merkle_payment_timestamp, 1_700_000_000);
+        }
+
+        // Second lookup — same result (no double-query needed)
+        {
+            let found = verifier.pool_cache.lock().get(&pool_hash).cloned();
+            assert!(
+                found.is_some(),
+                "Pool hash should still be in cache on second lookup"
+            );
+        }
+
+        // Different pool hash — should NOT be found
+        let other_hash: PoolHash = [0xCCu8; 32];
+        {
+            let found = verifier.pool_cache.lock().get(&other_hash).cloned();
+            assert!(found.is_none(), "Unknown pool hash should not be in cache");
+        }
     }
 }

--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -593,13 +593,20 @@ impl PaymentVerifier {
         // hash. The ML-DSA signature check below ensures the pool contents are
         // authentic (nodes actually signed their candidate quotes).
 
-        // Verify ML-DSA-65 signatures on all candidate nodes in the winner pool.
-        // Without this, a client could fabricate a pool with fake reward addresses
-        // since the contract only commits to the bytes the client submitted.
+        // Verify ML-DSA-65 signatures and timestamp/data_type consistency
+        // on all candidate nodes in the winner pool.
         for candidate in &merkle_proof.winner_pool.candidate_nodes {
             if !crate::payment::verify_merkle_candidate_signature(candidate) {
                 return Err(Error::Payment(format!(
                     "Invalid ML-DSA-65 signature on merkle candidate node (reward: {})",
+                    candidate.reward_address
+                )));
+            }
+            if candidate.merkle_payment_timestamp != payment_info.merkle_payment_timestamp {
+                return Err(Error::Payment(format!(
+                    "Candidate timestamp mismatch: expected {}, got {} (reward: {})",
+                    payment_info.merkle_payment_timestamp,
+                    candidate.merkle_payment_timestamp,
                     candidate.reward_address
                 )));
             }

--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -126,8 +126,11 @@ impl PaymentVerifier {
     /// Create a new payment verifier.
     #[must_use]
     pub fn new(config: PaymentVerifierConfig) -> Self {
+        const _: () = assert!(
+            DEFAULT_POOL_CACHE_CAPACITY > 0,
+            "pool cache capacity must be > 0"
+        );
         let cache = VerifiedCache::with_capacity(config.cache_capacity);
-        // SAFETY: DEFAULT_POOL_CACHE_CAPACITY is a const > 0, so this is always Some
         let pool_cache_size =
             NonZeroUsize::new(DEFAULT_POOL_CACHE_CAPACITY).unwrap_or(NonZeroUsize::MIN);
         let pool_cache = Mutex::new(LruCache::new(pool_cache_size));
@@ -556,14 +559,16 @@ impl PaymentVerifier {
                         ))
                     })?;
 
+            let paid_node_addresses: Vec<_> = info
+                .paidNodeAddresses
+                .iter()
+                .map(|pna| (pna.rewardsAddress, usize::from(pna.poolIndex)))
+                .collect();
+
             let on_chain_info = OnChainPaymentInfo {
                 depth: info.depth,
                 merkle_payment_timestamp: info.merklePaymentTimestamp,
-                paid_node_addresses: info
-                    .paidNodeAddresses
-                    .iter()
-                    .map(|pna| (pna.rewardsAddress, pna.poolIndex as usize))
-                    .collect(),
+                paid_node_addresses,
             };
 
             // Cache the pool info for subsequent chunks in the same batch
@@ -1435,7 +1440,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pool_cache_same_hash_queries_once() {
+    fn test_pool_cache_insert_and_lookup() {
         use evmlib::merkle_batch_payment::PoolHash;
 
         // Verify the pool_cache field exists and works correctly.

--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -239,9 +239,9 @@ impl PaymentVerifier {
                             self.verify_evm_payment(xorname, &payment).await?;
                         }
                         None => {
+                            let tag = proof.first().copied().unwrap_or(0);
                             return Err(Error::Payment(format!(
-                                "Unknown payment proof type tag: {:?}",
-                                proof.first()
+                                "Unknown payment proof type tag: 0x{tag:02x}"
                             )));
                         }
                     }

--- a/src/storage/handler.rs
+++ b/src/storage/handler.rs
@@ -28,8 +28,9 @@
 
 use crate::ant_protocol::{
     ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkMessageBody, ChunkPutRequest,
-    ChunkPutResponse, ChunkQuoteRequest, ChunkQuoteResponse, ProtocolError, CHUNK_PROTOCOL_ID,
-    DATA_TYPE_CHUNK, MAX_CHUNK_SIZE,
+    ChunkPutResponse, ChunkQuoteRequest, ChunkQuoteResponse, MerkleCandidateQuoteRequest,
+    MerkleCandidateQuoteResponse, ProtocolError, CHUNK_PROTOCOL_ID, DATA_TYPE_CHUNK,
+    MAX_CHUNK_SIZE,
 };
 use crate::client::compute_address;
 use crate::error::{Error, Result};
@@ -49,6 +50,7 @@ pub struct AntProtocol {
     /// Payment verifier for checking payments.
     payment_verifier: Arc<PaymentVerifier>,
     /// Quote generator for creating storage quotes.
+    /// Also handles merkle candidate quote signing via ML-DSA-65.
     quote_generator: Arc<QuoteGenerator>,
 }
 
@@ -108,10 +110,16 @@ impl AntProtocol {
             ChunkMessageBody::QuoteRequest(ref req) => {
                 ChunkMessageBody::QuoteResponse(self.handle_quote(req))
             }
+            ChunkMessageBody::MerkleCandidateQuoteRequest(ref req) => {
+                ChunkMessageBody::MerkleCandidateQuoteResponse(
+                    self.handle_merkle_candidate_quote(req),
+                )
+            }
             // Response messages shouldn't be received as requests
             ChunkMessageBody::PutResponse(_)
             | ChunkMessageBody::GetResponse(_)
-            | ChunkMessageBody::QuoteResponse(_) => {
+            | ChunkMessageBody::QuoteResponse(_)
+            | ChunkMessageBody::MerkleCandidateQuoteResponse(_) => {
                 let error = ProtocolError::Internal("Unexpected response message".to_string());
                 ChunkMessageBody::PutResponse(ChunkPutResponse::Error(error))
             }
@@ -276,6 +284,50 @@ impl AntProtocol {
                 }
             }
             Err(e) => ChunkQuoteResponse::Error(ProtocolError::QuoteFailed(e.to_string())),
+        }
+    }
+
+    /// Handle a merkle candidate quote request.
+    fn handle_merkle_candidate_quote(
+        &self,
+        request: &MerkleCandidateQuoteRequest,
+    ) -> MerkleCandidateQuoteResponse {
+        let addr_hex = hex::encode(request.address);
+        let data_size = request.data_size;
+        debug!(
+            "Handling merkle candidate quote request for {addr_hex} (size: {data_size}, ts: {})",
+            request.merkle_payment_timestamp
+        );
+
+        let Ok(data_size_usize) = usize::try_from(request.data_size) else {
+            return MerkleCandidateQuoteResponse::Error(ProtocolError::ChunkTooLarge {
+                size: MAX_CHUNK_SIZE + 1,
+                max_size: MAX_CHUNK_SIZE,
+            });
+        };
+        if data_size_usize > MAX_CHUNK_SIZE {
+            return MerkleCandidateQuoteResponse::Error(ProtocolError::ChunkTooLarge {
+                size: data_size_usize,
+                max_size: MAX_CHUNK_SIZE,
+            });
+        }
+
+        match self.quote_generator.create_merkle_candidate_quote(
+            data_size_usize,
+            request.data_type,
+            request.merkle_payment_timestamp,
+        ) {
+            Ok(candidate_node) => match rmp_serde::to_vec(&candidate_node) {
+                Ok(bytes) => MerkleCandidateQuoteResponse::Success {
+                    candidate_node: bytes,
+                },
+                Err(e) => MerkleCandidateQuoteResponse::Error(ProtocolError::QuoteFailed(format!(
+                    "Failed to serialize merkle candidate node: {e}"
+                ))),
+            },
+            Err(e) => {
+                MerkleCandidateQuoteResponse::Error(ProtocolError::QuoteFailed(e.to_string()))
+            }
         }
     }
 
@@ -719,6 +771,60 @@ mod tests {
         let (protocol, _temp) = create_test_protocol().await;
         let stats = protocol.storage_stats();
         assert_eq!(stats.chunks_stored, 0);
+    }
+
+    #[tokio::test]
+    async fn test_merkle_candidate_quote_request() {
+        use crate::payment::quote::verify_merkle_candidate_signature;
+        use ant_evm::merkle_payments::MerklePaymentCandidateNode;
+
+        // create_test_protocol already wires ML-DSA-65 signing
+        let (protocol, _temp) = create_test_protocol().await;
+
+        let address = [0x77; 32];
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_secs();
+
+        let request = MerkleCandidateQuoteRequest {
+            address,
+            data_type: DATA_TYPE_CHUNK,
+            data_size: 4096,
+            merkle_payment_timestamp: timestamp,
+        };
+        let msg = ChunkMessage {
+            request_id: 600,
+            body: ChunkMessageBody::MerkleCandidateQuoteRequest(request),
+        };
+        let msg_bytes = msg.encode().expect("encode request");
+
+        let response_bytes = protocol
+            .handle_message(&msg_bytes)
+            .await
+            .expect("handle merkle candidate quote");
+        let response = ChunkMessage::decode(&response_bytes).expect("decode response");
+
+        assert_eq!(response.request_id, 600);
+        match response.body {
+            ChunkMessageBody::MerkleCandidateQuoteResponse(
+                MerkleCandidateQuoteResponse::Success { candidate_node },
+            ) => {
+                let candidate: MerklePaymentCandidateNode =
+                    rmp_serde::from_slice(&candidate_node).expect("deserialize candidate node");
+
+                // Verify ML-DSA-65 signature
+                assert!(
+                    verify_merkle_candidate_signature(&candidate),
+                    "ML-DSA-65 candidate signature must be valid"
+                );
+
+                assert_eq!(candidate.merkle_payment_timestamp, timestamp);
+                assert_eq!(candidate.quoting_metrics.data_size, 4096);
+                assert_eq!(candidate.quoting_metrics.data_type, DATA_TYPE_CHUNK);
+            }
+            other => panic!("expected MerkleCandidateQuoteResponse::Success, got: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/src/storage/handler.rs
+++ b/src/storage/handler.rs
@@ -300,10 +300,10 @@ impl AntProtocol {
         );
 
         let Ok(data_size_usize) = usize::try_from(request.data_size) else {
-            return MerkleCandidateQuoteResponse::Error(ProtocolError::ChunkTooLarge {
-                size: MAX_CHUNK_SIZE + 1,
-                max_size: MAX_CHUNK_SIZE,
-            });
+            return MerkleCandidateQuoteResponse::Error(ProtocolError::QuoteFailed(format!(
+                "data_size {} overflows usize",
+                request.data_size
+            )));
         };
         if data_size_usize > MAX_CHUNK_SIZE {
             return MerkleCandidateQuoteResponse::Error(ProtocolError::ChunkTooLarge {


### PR DESCRIPTION
## Summary

Integrates merkle batch payments into saorsa-node, enabling clients to pay for large chunk batches in a single on-chain transaction via the MerklePaymentVault contract. Uses ML-DSA-65 post-quantum cryptography throughout (not ed25519).

## Changes

### Protocol (`src/ant_protocol/chunk.rs`)
- `MerkleCandidateQuoteRequest` / `MerkleCandidateQuoteResponse` message types
- `PROOF_TAG_SINGLE_NODE` (0x01) / `PROOF_TAG_MERKLE` (0x02) proof type tags

### Payment signing (`src/payment/quote.rs`)
- `create_merkle_candidate_quote()` — constructs `MerklePaymentCandidateNode` with ML-DSA-65 signature (bypasses upstream ant-evm ed25519)
- `verify_merkle_candidate_signature()` — ML-DSA-65 verification counterpart

### Payment verification (`src/payment/verifier.rs`)
- Proof type dispatch from tag byte (SingleNode vs Merkle vs reject unknown)
- `verify_merkle_payment()`:
  - ML-DSA-65 signature check on all 16 candidate nodes
  - On-chain query via `MerklePaymentVault.getPaymentInfo()`
  - Pool-level LRU cache (1,000 entries) to avoid repeated on-chain queries per batch
  - Merkle tree proof verification (address belongs to tree, midpoint valid, roots match)
  - Paid node index/address validation
- `MAX_PAYMENT_PROOF_SIZE` raised to 256KB (ML-DSA proofs with 16 candidates are ~130KB)

### Proof serialization (`src/payment/proof.rs`)
- `ProofType` enum, `detect_proof_type()`, tagged serialize/deserialize
- Both SingleNode and Merkle proofs require tag byte (no legacy untagged support)

### Handler (`src/storage/handler.rs`)
- Routes `MerkleCandidateQuoteRequest` to quote generator
- `MAX_CHUNK_SIZE` check on merkle candidate quotes

### Infrastructure
- `merkle_payments_address` field in `DevnetEvmInfo`
- Wired through `saorsa-devnet` binary

## Test plan

- [x] 258 unit tests pass (18 new merkle tests)
- [x] Protocol message encode/decode round-trips
- [x] Tagged proof serialization/deserialization
- [x] ML-DSA-65 merkle candidate signing + verification
- [x] Handler merkle quote request/response
- [x] Proof type detection and dispatch
- [x] Pool cache behavior
- [x] `cfd` (cargo fmt + clippy) passes clean