### PR TITLE
chore: rename saorsa-node to ant-node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,28 +114,28 @@ jobs:
           # Use ubuntu-22.04 for GLIBC 2.35 compatibility with server deployments
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-22.04
-            binary: saorsa-node
+            binary: ant-node
             archive: tar.gz
             friendly_name: linux-x64
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-22.04
-            binary: saorsa-node
+            binary: ant-node
             archive: tar.gz
             cross: true
             friendly_name: linux-arm64
           - target: x86_64-apple-darwin
             os: macos-latest
-            binary: saorsa-node
+            binary: ant-node
             archive: tar.gz
             friendly_name: macos-x64
           - target: aarch64-apple-darwin
             os: macos-latest
-            binary: saorsa-node
+            binary: ant-node
             archive: tar.gz
             friendly_name: macos-arm64
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            binary: saorsa-node.exe
+            binary: ant-node.exe
             archive: zip
             friendly_name: windows-x64
 
@@ -167,20 +167,20 @@ jobs:
         if: matrix.archive == 'tar.gz'
         run: |
           cd target/${{ matrix.target }}/release
-          tar -czvf ../../../saorsa-node-cli-${{ matrix.friendly_name }}.tar.gz ${{ matrix.binary }} saorsa-keygen
+          tar -czvf ../../../ant-node-cli-${{ matrix.friendly_name }}.tar.gz ${{ matrix.binary }} ant-keygen
           cd ../../..
 
       - name: Create archive (Windows)
         if: matrix.archive == 'zip'
         shell: pwsh
         run: |
-          Compress-Archive -Path "target/${{ matrix.target }}/release/${{ matrix.binary }}", "target/${{ matrix.target }}/release/saorsa-keygen.exe" -DestinationPath "saorsa-node-cli-${{ matrix.friendly_name }}.zip"
+          Compress-Archive -Path "target/${{ matrix.target }}/release/${{ matrix.binary }}", "target/${{ matrix.target }}/release/ant-keygen.exe" -DestinationPath "ant-node-cli-${{ matrix.friendly_name }}.zip"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: cli-${{ matrix.friendly_name }}
-          path: saorsa-node-cli-${{ matrix.friendly_name }}.${{ matrix.archive }}
+          path: ant-node-cli-${{ matrix.friendly_name }}.${{ matrix.archive }}
           retention-days: 1
 
   installers-linux:
@@ -205,23 +205,23 @@ jobs:
         run: cargo build --release
 
       - name: Build .deb package
-        run: cargo deb --no-build --output saorsa-node.deb
+        run: cargo deb --no-build --output ant-node.deb
 
       - name: Build .rpm package
-        run: cargo generate-rpm --output saorsa-node.rpm
+        run: cargo generate-rpm --output ant-node.rpm
 
       - name: Upload .deb
         uses: actions/upload-artifact@v4
         with:
           name: installer-deb
-          path: saorsa-node.deb
+          path: ant-node.deb
           retention-days: 1
 
       - name: Upload .rpm
         uses: actions/upload-artifact@v4
         with:
           name: installer-rpm
-          path: saorsa-node.rpm
+          path: ant-node.rpm
           retention-days: 1
 
   installers-windows:
@@ -280,12 +280,12 @@ jobs:
             $g.Clear([System.Drawing.Color]::FromArgb(0, 120, 212))
             $bmp.Save("wix\dialog.bmp")
           }
-          if (-not (Test-Path "wix\saorsa.ico")) {
+          if (-not (Test-Path "wix\ant.ico")) {
             # Use a default icon
             Copy-Item "C:\Windows\System32\shell32.dll" -Destination "wix\temp.dll"
             Add-Type -AssemblyName System.Drawing
             $icon = [System.Drawing.Icon]::ExtractAssociatedIcon("C:\Windows\System32\cmd.exe")
-            $stream = [System.IO.File]::Create("wix\saorsa.ico")
+            $stream = [System.IO.File]::Create("wix\ant.ico")
             $icon.Save($stream)
             $stream.Close()
           }
@@ -299,13 +299,13 @@ jobs:
 
           $version = "${{ steps.version.outputs.version }}"
           candle.exe wix\main.wxs -o wix\main.wixobj -ext WixUIExtension -dProductVersion="$version"
-          light.exe wix\main.wixobj -o saorsa-node.msi -ext WixUIExtension
+          light.exe wix\main.wixobj -o ant-node.msi -ext WixUIExtension
 
       - name: Upload MSI
         uses: actions/upload-artifact@v4
         with:
           name: installer-msi
-          path: saorsa-node.msi
+          path: ant-node.msi
           retention-days: 1
 
   sign:
@@ -331,18 +331,18 @@ jobs:
 
       - name: Decode signing key
         run: |
-          echo "${{ secrets.SAORSA_NODE_SIGNING_KEY }}" | xxd -r -p > /tmp/signing-key.secret
+          echo "${{ secrets.ANT_NODE_SIGNING_KEY }}" | xxd -r -p > /tmp/signing-key.secret
           chmod 600 /tmp/signing-key.secret
 
       - name: Build signing tool
-        run: cargo build --release --bin saorsa-keygen
+        run: cargo build --release --bin ant-keygen
 
       - name: Sign all release files
         run: |
-          for file in artifacts/saorsa-node-cli-*.tar.gz artifacts/saorsa-node-cli-*.zip artifacts/*.deb artifacts/*.rpm artifacts/*.msi; do
+          for file in artifacts/ant-node-cli-*.tar.gz artifacts/ant-node-cli-*.zip artifacts/*.deb artifacts/*.rpm artifacts/*.msi; do
             if [ -f "$file" ]; then
               echo "Signing $file..."
-              ./target/release/saorsa-keygen sign \
+              ./target/release/ant-keygen sign \
                 --key /tmp/signing-key.secret \
                 --input "$file" \
                 --output "${file}.sig"
@@ -356,7 +356,7 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
-          sha256sum saorsa-node-cli-* *.deb *.rpm *.msi 2>/dev/null > SHA256SUMS.txt || true
+          sha256sum ant-node-cli-* *.deb *.rpm *.msi 2>/dev/null > SHA256SUMS.txt || true
           cat SHA256SUMS.txt
 
       - name: Upload signed artifacts
@@ -408,9 +408,9 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: Saorsa Node ${{ needs.validate.outputs.version }}
+          name: Autonomi Node ${{ needs.validate.outputs.version }}
           body: |
-            ## Saorsa Node ${{ needs.validate.outputs.version }}
+            ## Autonomi Node ${{ needs.validate.outputs.version }}
 
             ### CLI Downloads (Manual Installation)
 
@@ -418,21 +418,21 @@ jobs:
 
             | Platform | Download |
             |----------|----------|
-            | Linux x64 | `saorsa-node-cli-linux-x64.tar.gz` |
-            | Linux ARM64 | `saorsa-node-cli-linux-arm64.tar.gz` |
-            | macOS x64 | `saorsa-node-cli-macos-x64.tar.gz` |
-            | macOS ARM64 (Apple Silicon) | `saorsa-node-cli-macos-arm64.tar.gz` |
-            | Windows x64 | `saorsa-node-cli-windows-x64.zip` |
+            | Linux x64 | `ant-node-cli-linux-x64.tar.gz` |
+            | Linux ARM64 | `ant-node-cli-linux-arm64.tar.gz` |
+            | macOS x64 | `ant-node-cli-macos-x64.tar.gz` |
+            | macOS ARM64 (Apple Silicon) | `ant-node-cli-macos-arm64.tar.gz` |
+            | Windows x64 | `ant-node-cli-windows-x64.zip` |
 
             **CLI Usage:**
             ```bash
             # Linux/macOS
-            tar -xzf saorsa-node-cli-linux-x64.tar.gz
-            ./saorsa-node --testnet
+            tar -xzf ant-node-cli-linux-x64.tar.gz
+            ./ant-node --testnet
 
             # Windows (PowerShell)
-            Expand-Archive saorsa-node-cli-windows-x64.zip
-            .\saorsa-node.exe --testnet
+            Expand-Archive ant-node-cli-windows-x64.zip
+            .\ant-node.exe --testnet
             ```
 
             ### Service Installers (Automatic Startup)
@@ -441,21 +441,21 @@ jobs:
 
             | Platform | Download |
             |----------|----------|
-            | Debian/Ubuntu | `saorsa-node.deb` |
-            | RHEL/Fedora | `saorsa-node.rpm` |
-            | Windows | `saorsa-node.msi` |
+            | Debian/Ubuntu | `ant-node.deb` |
+            | RHEL/Fedora | `ant-node.rpm` |
+            | Windows | `ant-node.msi` |
 
             **Service Installation:**
             ```bash
             # Debian/Ubuntu
-            sudo dpkg -i saorsa-node.deb
-            sudo systemctl enable --now saorsa-node
+            sudo dpkg -i ant-node.deb
+            sudo systemctl enable --now ant-node
 
             # RHEL/Fedora
-            sudo rpm -i saorsa-node.rpm
-            sudo systemctl enable --now saorsa-node
+            sudo rpm -i ant-node.rpm
+            sudo systemctl enable --now ant-node
 
-            # Windows: Run saorsa-node.msi installer
+            # Windows: Run ant-node.msi installer
             ```
 
             ### Verification
@@ -464,7 +464,7 @@ jobs:
             Download the corresponding `.sig` file and verify:
 
             ```bash
-            saorsa-keygen verify --key release-signing-key.pub --input <file> --signature <file>.sig
+            ant-keygen verify --key release-signing-key.pub --input <file> --signature <file>.sig
             ```
 
             SHA256 checksums provided in `SHA256SUMS.txt`.
@@ -474,9 +474,9 @@ jobs:
             Running nodes automatically detect and upgrade to this version
             within a 24-hour staged rollout window.
           files: |
-            release/saorsa-node-cli-*.tar.gz
-            release/saorsa-node-cli-*.zip
-            release/saorsa-node-cli-*.sig
+            release/ant-node-cli-*.tar.gz
+            release/ant-node-cli-*.zip
+            release/ant-node-cli-*.sig
             release/*.deb
             release/*.rpm
             release/*.msi

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # =============================================================================
-# SECURITY-FOCUSED .gitignore for saorsa-node
+# SECURITY-FOCUSED .gitignore for ant-node
 # =============================================================================
 
 # -----------------------------------------------------------------------------
@@ -133,7 +133,7 @@ $RECYCLE.BIN/
 # Node data directories (may contain keys)
 node_data/
 data/
-.saorsa/
+.ant-node/
 .ant/
 .antnode/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-saorsa-node is the core P2P network node binary for the Saorsa ecosystem. It provides the decentralized storage and networking foundation using post-quantum cryptography.
+ant-node is the core P2P network node binary for the Autonomi ecosystem. It provides the decentralized storage and networking foundation using post-quantum cryptography.
 
 ## Development Commands
 
@@ -60,7 +60,7 @@ See `src/payment/verifier.rs` for implementation details.
 
 ---
 
-## 🚨 CRITICAL: Saorsa Network Infrastructure & Port Isolation
+## CRITICAL: Autonomi Network Infrastructure & Port Isolation
 
 ### Infrastructure Documentation
 Full infrastructure documentation is available at: `docs/infrastructure/INFRASTRUCTURE.md`
@@ -71,41 +71,41 @@ This includes:
 - Firewall configurations and SSH access
 - Systemd service templates
 
-### ⚠️ PORT ISOLATION - MANDATORY
+### PORT ISOLATION - MANDATORY
 
-**Production saorsa-node instances use UDP port range 10000-10999 exclusively.**
+**Production ant-node instances use UDP port range 10000-10999 exclusively.**
 
 | Service | UDP Port Range | Default | Description |
 |---------|----------------|---------|-------------|
 | ant-quic | 9000-9999 | 9000 | QUIC transport layer |
-| **saorsa-node** | **10000-10999** | **10000** | Core P2P network nodes (THIS PROJECT) |
+| **ant-node** | **10000-10999** | **10000** | Core P2P network nodes (THIS PROJECT) |
 | communitas | 11000-11999 | 11000 | Collaboration platform nodes |
-| **saorsa-node tests** | **20000-60000** | **random** | E2E test isolation (local only) |
+| **ant-node tests** | **20000-60000** | **random** | E2E test isolation (local only) |
 
 **Note:** The E2E test suite uses ports 20000-60000 with random allocation to prevent conflicts between parallel test runs and local development instances. Production deployments MUST use 10000-10999.
 
-### 🛑 DO NOT DISTURB OTHER NETWORKS
+### DO NOT DISTURB OTHER NETWORKS
 
-When testing or developing saorsa-node:
+When testing or developing ant-node:
 
-1. **ONLY use ports 10000-10999** for saorsa-node services
+1. **ONLY use ports 10000-10999** for ant-node services
 2. **NEVER** kill processes on ports 9000-9999 or 11000-11999
 3. **NEVER** restart services outside our port range
 4. **NEVER** modify firewall rules for other port ranges
 
 ```bash
-# ✅ CORRECT - saorsa-node operations (within 10000-10999)
+# CORRECT - ant-node operations (within 10000-10999)
 cargo run --release -- --listen 0.0.0.0:10000
 cargo run --release -- --listen 0.0.0.0:10001  # Second instance OK
-ssh root@saorsa-2.saorsalabs.com "systemctl restart saorsa-node-bootstrap"
+ssh root@saorsa-2.saorsalabs.com "systemctl restart ant-node-bootstrap"
 
-# ❌ WRONG - Would disrupt other networks
+# WRONG - Would disrupt other networks
 ssh root@saorsa-2.saorsalabs.com "pkill -f ':9'"    # NEVER - matches ant-quic ports
 ssh root@saorsa-2.saorsalabs.com "pkill -f ':11'"   # NEVER - matches communitas ports
 ssh root@saorsa-2.saorsalabs.com "systemctl restart ant-quic-bootstrap"  # NOT OUR SERVICE
 ```
 
-### Bootstrap Endpoints (saorsa-node)
+### Bootstrap Endpoints (ant-node)
 ```
 saorsa-2.saorsalabs.com:10000  (NYC - 142.93.199.50)
 saorsa-3.saorsalabs.com:10000  (SFO - 147.182.234.192)
@@ -113,7 +113,7 @@ saorsa-3.saorsalabs.com:10000  (SFO - 147.182.234.192)
 
 ### Before Any VPS Operations
 1. Verify you're targeting ports 10000-10999 only
-2. Double-check service names contain "saorsa-node"
+2. Double-check service names contain "ant-node"
 3. Never run broad `pkill` commands that could affect other services
 
 ### Deploy New Binary
@@ -122,6 +122,6 @@ saorsa-3.saorsalabs.com:10000  (SFO - 147.182.234.192)
 cargo build --release
 
 # Deploy to bootstrap node
-scp target/release/saorsa-node root@saorsa-2.saorsalabs.com:/opt/saorsa-node/
-ssh root@saorsa-2.saorsalabs.com "systemctl restart saorsa-node-bootstrap"
+scp target/release/ant-node root@saorsa-2.saorsalabs.com:/opt/ant-node/
+ssh root@saorsa-2.saorsalabs.com "systemctl restart ant-node-bootstrap"
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,10 +858,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "ant-node"
+version = "0.5.0"
+dependencies = [
+ "aes-gcm-siv",
+ "alloy",
+ "ant-evm",
+ "blake3",
+ "bytes",
+ "chrono",
+ "clap",
+ "color-eyre",
+ "directories",
+ "evmlib",
+ "flate2",
+ "fs2",
+ "futures",
+ "heed",
+ "hex",
+ "hkdf",
+ "libp2p",
+ "lru",
+ "multihash",
+ "objc2",
+ "objc2-foundation",
+ "parking_lot",
+ "postcard",
+ "proptest",
+ "rand 0.8.5",
+ "reqwest 0.13.1",
+ "rmp-serde",
+ "saorsa-core",
+ "saorsa-pqc 0.5.0",
+ "self-replace",
+ "self_encryption",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "sha2",
+ "tar",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-test",
+ "tokio-util",
+ "toml",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "xor_name",
+ "zip",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "ark-ff"
@@ -1346,7 +1409,7 @@ dependencies = [
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq",
+ "constant_time_eq 0.4.2",
  "cpufeatures",
 ]
 
@@ -1357,6 +1420,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -1455,6 +1527,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1695,6 +1786,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "constant_time_eq"
@@ -2027,6 +2124,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,6 +2172,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2164,6 +2278,16 @@ dependencies = [
  "option-ext",
  "redox_users 0.5.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -2514,6 +2638,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3570,6 +3704,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "macro-string"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3816,6 +3971,45 @@ dependencies = [
  "ruint",
  "serde",
  "smallvec",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -4081,6 +4275,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "poly1305"
@@ -4966,54 +5166,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "saorsa-node"
-version = "0.5.0"
-dependencies = [
- "aes-gcm-siv",
- "alloy",
- "ant-evm",
- "blake3",
- "bytes",
- "chrono",
- "clap",
- "color-eyre",
- "directories",
- "evmlib",
- "flate2",
- "futures",
- "heed",
- "hex",
- "hkdf",
- "libp2p",
- "lru",
- "multihash",
- "parking_lot",
- "postcard",
- "proptest",
- "rand 0.8.5",
- "reqwest 0.13.1",
- "rmp-serde",
- "saorsa-core",
- "saorsa-pqc 0.5.0",
- "self_encryption",
- "semver 1.0.27",
- "serde",
- "serde_json",
- "serial_test",
- "tar",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tokio-test",
- "tokio-util",
- "toml",
- "tracing",
- "tracing-appender",
- "tracing-subscriber",
- "xor_name",
-]
-
-[[package]]
 name = "saorsa-pqc"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5271,6 +5423,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "self_encryption"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5467,6 +5630,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6979,6 +7153,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yasna"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7105,7 +7288,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq 0.3.1",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap 2.13.0",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror 2.0.18",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,30 +1,30 @@
 [package]
-name = "saorsa-node"
+name = "ant-node"
 version = "0.5.0"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
-description = "Pure quantum-proof network node for the Saorsa decentralized network"
+description = "Pure quantum-proof network node for the Autonomi decentralized network"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/saorsa-labs/saorsa-node"
+repository = "https://github.com/WithAutonomi/ant-node"
 keywords = ["p2p", "decentralized", "quantum-safe", "post-quantum", "dht"]
 categories = ["network-programming", "cryptography"]
 rust-version = "1.75"
 
 [lib]
-name = "saorsa_node"
+name = "ant_node"
 path = "src/lib.rs"
 
 [[bin]]
-name = "saorsa-node"
-path = "src/bin/saorsa-node/main.rs"
+name = "ant-node"
+path = "src/bin/ant-node/main.rs"
 
 [[bin]]
-name = "saorsa-keygen"
+name = "ant-keygen"
 path = "src/bin/keygen.rs"
 
 [[bin]]
-name = "saorsa-devnet"
-path = "src/bin/saorsa-devnet/main.rs"
+name = "ant-devnet"
+path = "src/bin/ant-devnet/main.rs"
 
 [dependencies]
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
@@ -161,10 +161,10 @@ missing_const_for_fn = "allow"
 # Debian package metadata (cargo-deb)
 [package.metadata.deb]
 maintainer = "David Irvine <david.irvine@maidsafe.net>"
-copyright = "2024-2025 Saorsa Labs"
+copyright = "2024-2025 Autonomi"
 license-file = ["LICENSE-MIT", "0"]
 extended-description = """
-Saorsa Node is a pure quantum-proof network node for the Saorsa decentralized network.
+Ant Node is a pure quantum-proof network node for the Autonomi decentralized network.
 It provides secure, private, and censorship-resistant data storage using post-quantum
 cryptography (ML-DSA-65, ML-KEM-768). Features include:
 - Quantum-resistant authentication and encryption
@@ -175,21 +175,21 @@ cryptography (ML-DSA-65, ML-KEM-768). Features include:
 section = "net"
 priority = "optional"
 assets = [
-    ["target/release/saorsa-node", "usr/bin/", "755"],
-    ["target/release/saorsa-keygen", "usr/bin/", "755"],
-    ["README.md", "usr/share/doc/saorsa-node/", "644"],
+    ["target/release/ant-node", "usr/bin/", "755"],
+    ["target/release/ant-keygen", "usr/bin/", "755"],
+    ["README.md", "usr/share/doc/ant-node/", "644"],
 ]
-conf-files = ["/etc/saorsa/config.toml"]
+conf-files = ["/etc/ant/config.toml"]
 depends = "$auto"
 systemd-units = { enable = true }
 
 # RPM package metadata (cargo-generate-rpm)
 [package.metadata.generate-rpm]
 assets = [
-    { source = "target/release/saorsa-node", dest = "/usr/bin/saorsa-node", mode = "755" },
-    { source = "target/release/saorsa-keygen", dest = "/usr/bin/saorsa-keygen", mode = "755" },
-    { source = "README.md", dest = "/usr/share/doc/saorsa-node/README.md", mode = "644" },
-    { source = "systemd/saorsa-node.service", dest = "/usr/lib/systemd/system/saorsa-node.service", mode = "644" },
+    { source = "target/release/ant-node", dest = "/usr/bin/ant-node", mode = "755" },
+    { source = "target/release/ant-keygen", dest = "/usr/bin/ant-keygen", mode = "755" },
+    { source = "README.md", dest = "/usr/share/doc/ant-node/README.md", mode = "644" },
+    { source = "systemd/ant-node.service", dest = "/usr/lib/systemd/system/ant-node.service", mode = "644" },
 ]
 
 [package.metadata.generate-rpm.requires]

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# saorsa-node
+# ant-node
 
 **The quantum-proof evolution of Autonomi network nodes.**
 
-saorsa-node is the next-generation node software for the Autonomi decentralized network, replacing ant-node with future-proof cryptography and advanced network security.
+ant-node is the next-generation node software for the Autonomi decentralized network, replacing the legacy ant-node with future-proof cryptography and advanced network security.
 
-> **Why Upgrade?** Current ant-node uses Ed25519/X25519 cryptography that will be broken by quantum computers. Data encrypted today can be harvested and decrypted later. saorsa-node uses FIPS-approved post-quantum algorithms to protect your data forever.
+> **Why Upgrade?** Current legacy ant-node uses Ed25519/X25519 cryptography that will be broken by quantum computers. Data encrypted today can be harvested and decrypted later. ant-node uses FIPS-approved post-quantum algorithms to protect your data forever.
 
 ---
 
 ## Table of Contents
 
 1. [The Quantum Threat](#the-quantum-threat)
-2. [Key Advantages Over ant-node](#key-advantages-over-ant-node)
+2. [Key Advantages Over Legacy ant-node](#key-advantages-over-legacy-ant-node)
 3. [Post-Quantum Cryptography](#post-quantum-cryptography)
 4. [NAT Traversal](#nat-traversal)
 5. [Network Hardening](#network-hardening)
 6. [Dual IPv4/IPv6 DHT](#dual-ipv4ipv6-dht)
-7. [Migration from ant-node](#migration-from-ant-node)
+7. [Migration from Legacy ant-node](#migration-from-legacy-ant-node)
 8. [Development Status](#development-status)
 9. [Auto-Upgrade System](#auto-upgrade-system)
 10. [Running as a Service](#running-as-a-service)
@@ -53,7 +53,7 @@ Nation-state actors and sophisticated adversaries are already collecting encrypt
 
 ### The Autonomi Network Risk
 
-ant-node uses:
+Legacy ant-node uses:
 - **BLS signatures** - Quantum vulnerable (elliptic curve based)
 - **Ed25519 signatures** - Quantum vulnerable (elliptic curve based)
 - **X25519 key exchange** - Quantum vulnerable (elliptic curve based)
@@ -62,9 +62,9 @@ Even though the Autonomi nettwork self encrypted data is secure, he Autonomi net
 
 ---
 
-## Key Advantages Over ant-node
+## Key Advantages Over Legacy ant-node
 
-| Feature | ant-node | saorsa-node |
+| Feature | Legacy ant-node | ant-node |
 |---------|----------|-------------|
 | **Digital Signatures** | BLS/Ed25519 (quantum-vulnerable) | ML-DSA-65 (FIPS 204, quantum-proof) |
 | **Key Exchange** | X25519 (quantum-vulnerable) | ML-KEM-768 (FIPS 203, quantum-proof) |
@@ -84,7 +84,7 @@ Even though the Autonomi nettwork self encrypted data is secure, he Autonomi net
 
 ## Post-Quantum Cryptography
 
-saorsa-node implements **pure post-quantum cryptography** with no hybrid fallbacks. All algorithms are NIST FIPS-approved standards.
+ant-node implements **pure post-quantum cryptography** with no hybrid fallbacks. All algorithms are NIST FIPS-approved standards.
 
 ### ML-DSA-65 (FIPS 204) - Digital Signatures
 
@@ -114,7 +114,7 @@ Symmetric algorithms remain quantum-resistant at sufficient key sizes. ChaCha20-
 
 ### No Hybrid Mode
 
-Unlike some transitional implementations, saorsa-node uses **pure post-quantum cryptography**:
+Unlike some transitional implementations, ant-node uses **pure post-quantum cryptography**:
 
 - No Ed25519 fallback
 - No X25519 hybrid key exchange
@@ -126,7 +126,7 @@ This ensures maximum security and eliminates the complexity of dual-algorithm sy
 
 saorsa-core fully supports **legacy classical encrypted data**:
 
-- **Existing Data**: AES-256-GCM-SIV encrypted content from ant-node remains readable
+- **Existing Data**: AES-256-GCM-SIV encrypted content from legacy ant-node remains readable
 - **New Signatures**: All new signatures use ML-DSA-65 (quantum-proof)
 - **New Key Exchange**: All new key exchanges use ML-KEM-768 (quantum-proof)
 - **Gradual Migration**: Network can operate with mixed classical/quantum-proof data
@@ -139,13 +139,13 @@ This allows seamless migration without data loss while ensuring all new data is 
 
 ### Everyone Can Run a Node
 
-One of the most significant advantages of saorsa-node is **full native QUIC NAT traversal**. Unlike ant-node, which requires manual port forwarding, saorsa-core implements NAT traversal directly within the QUIC protocol itself - **no ICE, no STUN, no external protocols**.
+One of the most significant advantages of ant-node is **full native QUIC NAT traversal**. Unlike legacy ant-node, which requires manual port forwarding, saorsa-core implements NAT traversal directly within the QUIC protocol itself - **no ICE, no STUN, no external protocols**.
 
 > **100% Success Rate**: In our testing, we have successfully traversed 100% of network connections using native QUIC NAT traversal.
 
-### The ant-node Limitation
+### The Legacy ant-node Limitation
 
-ant-node has **no native NAT traversal**:
+Legacy ant-node has **no native NAT traversal**:
 - Requires manual router configuration or UPnP
 - Excludes users behind carrier-grade NAT (CGNAT)
 - Excludes most mobile and residential users
@@ -157,7 +157,7 @@ Based on **draft-seemann-quic-nat-traversal-02** (Marten Seemann & Eric Kinnear,
 
 **Why Not ICE/STUN?**
 
-| Aspect | ICE/STUN | Native QUIC (saorsa) |
+| Aspect | ICE/STUN | Native QUIC (Autonomi) |
 |--------|----------|----------------------|
 | **External Dependencies** | Requires STUN/TURN servers | None - 100% within QUIC |
 | **Protocol Complexity** | Separate signaling (SDP) | QUIC frames only |
@@ -174,11 +174,11 @@ Based on **draft-seemann-quic-nat-traversal-02** (Marten Seemann & Eric Kinnear,
 ### How It Works
 
 ```
-1. Node starts → enumerates local interfaces and addresses
+1. Node starts -> enumerates local interfaces and addresses
 2. Peers exchange addresses via ADD_ADDRESS frames
 3. Client sends PUNCH_ME_NOW to coordinate timing
 4. Both peers simultaneously send QUIC PATH_CHALLENGE packets
-5. NAT bindings created → PATH_RESPONSE packets received
+5. NAT bindings created -> PATH_RESPONSE packets received
 6. QUIC connection migrates to direct path automatically
 7. Application data flows directly (no relay needed)
 ```
@@ -202,7 +202,7 @@ This ensures that **everyone can contribute to the network**, democratizing part
 
 ### Multi-Layer Sybil Resistance
 
-Sybil attacks involve creating many fake identities to gain disproportionate influence. saorsa-node implements defense-in-depth:
+Sybil attacks involve creating many fake identities to gain disproportionate influence. ant-node implements defense-in-depth:
 
 #### Layer 1: IPv6 Node Identity Binding
 
@@ -329,7 +329,7 @@ The EigenTrust++ system provides the foundation for **continuous network health 
 
 ## Dual IPv4/IPv6 DHT
 
-saorsa-node implements a novel dual-stack DHT architecture that maximizes network connectivity.
+ant-node implements a novel dual-stack DHT architecture that maximizes network connectivity.
 
 ### Separate Close Groups
 
@@ -346,7 +346,7 @@ Data is replicated to **both** close groups:
 
 ### Happy Eyeballs (RFC 8305)
 
-For connections, saorsa-node implements Happy Eyeballs:
+For connections, ant-node implements Happy Eyeballs:
 1. Attempt IPv6 connection first
 2. Start IPv4 connection after short delay
 3. Use whichever completes first
@@ -360,15 +360,15 @@ For connections, saorsa-node implements Happy Eyeballs:
 
 ---
 
-## Migration from ant-node
+## Migration from Legacy ant-node
 
-saorsa-node provides seamless migration from existing ant-node installations.
+ant-node provides seamless migration from existing legacy ant-node installations.
 
 ### Automatic Detection
 
 ```bash
-# Auto-detect ant-node data directories
-saorsa-node --migrate-ant-data auto
+# Auto-detect legacy ant-node data directories
+ant-node --migrate-ant-data auto
 ```
 
 Searches common locations:
@@ -378,10 +378,10 @@ Searches common locations:
 
 ### Migration Process
 
-1. **Scan**: Enumerate all record files in ant-node `record_store/`
+1. **Scan**: Enumerate all record files in legacy ant-node `record_store/`
 2. **Classify**: Identify record types (Chunk, Register, Scratchpad, GraphEntry)
 3. **Decrypt**: Decrypt AES-256-GCM-SIV encrypted records
-4. **Upload**: Store on saorsa-network
+4. **Upload**: Store on Autonomi network
 5. **Track**: Save progress for resume capability
 
 ### Progress Tracking
@@ -390,7 +390,7 @@ Migration can be interrupted and resumed:
 
 ```bash
 # Migration continues from last checkpoint
-saorsa-node --migrate-ant-data ~/.local/share/safe/node
+ant-node --migrate-ant-data ~/.local/share/safe/node
 ```
 
 ### Payment Model
@@ -411,11 +411,11 @@ Mutable data types (Scratchpad, Pointer, GraphEntry) present a **fundamental cha
 
 #### Why CRDT Data Cannot Be Directly Migrated
 
-**saorsa-nodes are pure post-quantum** - they only understand ML-DSA-65 signatures:
+**ant-nodes are pure post-quantum** - they only understand ML-DSA-65 signatures:
 
 ```
 User: "Here's my Scratchpad update, signed with Ed25519"
-saorsa-node: "Invalid signature - rejected" ❌
+ant-node: "Invalid signature - rejected"
 ```
 
 This is by design. Adding classical crypto verification would:
@@ -426,36 +426,36 @@ This is by design. Adding classical crypto verification would:
 #### The Two-Network Reality
 
 ```
-┌─────────────────────────────────────────────────────────────────────┐
-│                     TWO SEPARATE NETWORKS                            │
-├────────────────────────────────┬────────────────────────────────────┤
-│      AUTONOMI NETWORK          │         SAORSA NETWORK             │
-│      (Classical Crypto)        │         (Quantum Crypto)           │
-├────────────────────────────────┼────────────────────────────────────┤
-│  Nodes: ant-node               │  Nodes: saorsa-node                │
-│  Signatures: Ed25519/BLS       │  Signatures: ML-DSA-65 ONLY        │
-│  Key Exchange: X25519          │  Key Exchange: ML-KEM-768          │
-│                                │                                    │
-│  Scratchpad address:           │  Scratchpad address:               │
-│  hash("scratchpad:" ||         │  hash("scratchpad:" ||             │
-│       Ed25519_pubkey)          │       ML-DSA-65_pubkey)            │
-│           ↓                    │           ↓                        │
-│    0x7a3f...                   │    0xb2c8...                       │
-│                                │                                    │
-│  DIFFERENT ADDRESSES - SAME USER, DIFFERENT IDENTITY                │
-└────────────────────────────────┴────────────────────────────────────┘
++---------------------------------------------------------------------+
+|                     TWO SEPARATE NETWORKS                            |
++--------------------------------+------------------------------------+
+|      AUTONOMI NETWORK          |         AUTONOMI NETWORK           |
+|      (Classical Crypto)        |         (Quantum Crypto)           |
++--------------------------------+------------------------------------+
+|  Nodes: legacy ant-node        |  Nodes: ant-node                   |
+|  Signatures: Ed25519/BLS       |  Signatures: ML-DSA-65 ONLY        |
+|  Key Exchange: X25519          |  Key Exchange: ML-KEM-768          |
+|                                |                                    |
+|  Scratchpad address:           |  Scratchpad address:               |
+|  hash("scratchpad:" ||         |  hash("scratchpad:" ||             |
+|       Ed25519_pubkey)          |       ML-DSA_65_pubkey)            |
+|           |                    |           |                        |
+|    0x7a3f...                   |    0xb2c8...                       |
+|                                |                                    |
+|  DIFFERENT ADDRESSES - SAME USER, DIFFERENT IDENTITY                |
++--------------------------------+------------------------------------+
 ```
 
 #### What This Means for Users
 
-| Data Type | Autonomi → Saorsa | Notes |
+| Data Type | Autonomi Legacy -> Autonomi PQ | Notes |
 |-----------|-------------------|-------|
-| **Chunk** | ✅ Migratable | Content-addressed, no signature needed |
-| **Scratchpad** | ❌ New identity | Different address on Saorsa |
-| **Pointer** | ❌ New identity | Different address on Saorsa |
-| **GraphEntry** | ❌ New identity | Different address on Saorsa |
+| **Chunk** | Migratable | Content-addressed, no signature needed |
+| **Scratchpad** | New identity | Different address on PQ network |
+| **Pointer** | New identity | Different address on PQ network |
+| **GraphEntry** | New identity | Different address on PQ network |
 
-**Users don't "migrate" their CRDT data - they establish a new quantum-safe identity on Saorsa.**
+**Users don't "migrate" their CRDT data - they establish a new quantum-safe identity on the Autonomi network.**
 
 #### The HybridClient Architecture
 
@@ -465,10 +465,10 @@ The HybridClient connects to **both networks simultaneously**:
 // HybridClient talks to TWO different networks
 let hybrid = HybridClient::new(config)?;
 
-// Read from Autonomi network (via ant-node peers)
+// Read from Autonomi network (via legacy ant-node peers)
 let legacy_data = hybrid.legacy().get_scratchpad(&ed25519_owner).await?;
 
-// Write to Saorsa network (via saorsa-node peers)
+// Write to Autonomi network (via ant-node peers)
 let new_scratchpad = hybrid.quantum().put_scratchpad(
     &mldsa_keypair,
     content_type,
@@ -485,15 +485,15 @@ let new_scratchpad = hybrid.quantum().put_scratchpad(
 ```
 1. Read final state from Autonomi (LegacyClient)
 2. Generate new ML-DSA-65 keypair (new identity)
-3. Create equivalent Scratchpad on Saorsa (QuantumClient)
+3. Create equivalent Scratchpad on PQ network (QuantumClient)
 4. Update applications to use new address
 5. Old Autonomi data becomes read-only archive
 ```
 
 **Strategy 2: Identity Registry**
 ```
-1. Create a public "migration registry" on Saorsa
-2. Users register: Ed25519_pubkey_hash → ML-DSA_pubkey_hash
+1. Create a public "migration registry" on PQ network
+2. Users register: Ed25519_pubkey_hash -> ML-DSA_pubkey_hash
 3. Applications can resolve old addresses to new ones
 4. Provides continuity for social/reputation systems
 ```
@@ -501,9 +501,9 @@ let new_scratchpad = hybrid.quantum().put_scratchpad(
 **Strategy 3: Parallel Operation (Transition Period)**
 ```
 1. Autonomi network continues running for existing CRDT data
-2. Users gradually create new identities on Saorsa
+2. Users gradually create new identities on PQ network
 3. Applications support both networks during transition
-4. Eventually deprecate Autonomi access
+4. Eventually deprecate legacy access
 ```
 
 #### Chunk Migration: The Easy Case
@@ -515,26 +515,26 @@ Chunks are content-addressed and immutable - they can be directly migrated:
 let chunk = hybrid.legacy().get_chunk(&xorname).await?;
 hybrid.quantum().store_chunk(chunk.data()).await?;
 
-// Address is hash(content) - identical on both networks ✅
+// Address is hash(content) - identical on both networks
 ```
 
 #### Security Implications
 
-| Aspect | Autonomi (Legacy) | Saorsa (New) |
+| Aspect | Autonomi (Legacy) | Autonomi (New) |
 |--------|-------------------|--------------|
 | **Signatures** | Ed25519 | ML-DSA-65 |
-| **Quantum Safe** | ❌ Vulnerable | ✅ Protected |
-| **CRDT Updates** | Via Autonomi only | Via Saorsa only |
+| **Quantum Safe** | Vulnerable | Protected |
+| **CRDT Updates** | Via Autonomi only | Via Autonomi PQ only |
 | **Identity** | Ed25519 pubkey | ML-DSA-65 pubkey |
 
-**Critical**: Users cannot update their Autonomi CRDT data through saorsa-nodes. To update legacy data, they must connect to the Autonomi network directly (which continues to run ant-nodes).
+**Critical**: Users cannot update their Autonomi CRDT data through PQ ant-nodes. To update legacy data, they must connect to the Autonomi network directly (which continues to run legacy ant-nodes).
 
 #### Long-Term Vision
 
 ```
 Phase 1 (Now):     Both networks operate, HybridClient bridges them
-Phase 2 (Transition): Users migrate to Saorsa identities, Autonomi read-only
-Phase 3 (Future):  Autonomi deprecated, Saorsa is the primary network
+Phase 2 (Transition): Users migrate to PQ identities, legacy read-only
+Phase 3 (Future):  Legacy deprecated, PQ network is the primary network
 ```
 
 The goal is not to maintain classical crypto forever, but to provide a **clean migration path** where users can:
@@ -550,12 +550,12 @@ The goal is not to maintain classical crypto forever, but to provide a **clean m
 
 | Component | Status | Description |
 |-----------|--------|-------------|
-| **Core Library** | ✅ Complete | Full node implementation with client APIs |
-| **Data Types** | ✅ Complete | Chunk, Scratchpad, Pointer, GraphEntry |
-| **Payment Verification** | ✅ Complete | Autonomi lookup + EVM verification + LRU cache |
-| **Migration Decryption** | ✅ Complete | AES-256-GCM-SIV decryption for ant-node data |
-| **Auto-Upgrade** | ✅ Complete | Cross-platform with ML-DSA-65 signature verification |
-| **E2E Test Infrastructure** | ✅ Complete | Real P2P testnet with 25+ nodes |
+| **Core Library** | Complete | Full node implementation with client APIs |
+| **Data Types** | Complete | Chunk, Scratchpad, Pointer, GraphEntry |
+| **Payment Verification** | Complete | Autonomi lookup + EVM verification + LRU cache |
+| **Migration Decryption** | Complete | AES-256-GCM-SIV decryption for legacy ant-node data |
+| **Auto-Upgrade** | Complete | Cross-platform with ML-DSA-65 signature verification |
+| **E2E Test Infrastructure** | Complete | Real P2P testnet with 25+ nodes |
 
 ### Test Coverage
 
@@ -563,7 +563,7 @@ The goal is not to maintain classical crypto forever, but to provide a **clean m
 Library Unit Tests:     104 passing
 E2E Unit Tests:          35 passing
 E2E Integration Tests:   49 passing (real P2P testnet)
-────────────────────────────────────
+------------------------------------
 Total:                  188 tests
 ```
 
@@ -582,21 +582,21 @@ The migration system is **fully implemented** and ready for use:
 
 1. **Decryption Module** (`src/migration/decrypt.rs`)
    - AES-256-GCM-SIV decryption with HKDF key derivation
-   - Handles embedded nonces from ant-node format
+   - Handles embedded nonces from legacy ant-node format
    - Full round-trip encryption/decryption verified
 
 2. **Scanner Module** (`src/migration/scanner.rs`)
-   - Auto-detection of ant-node data directories
+   - Auto-detection of legacy ant-node data directories
    - Cross-platform path discovery
    - Record enumeration and classification
 
 3. **Client APIs** (`src/client/`)
-   - `QuantumClient`: Pure saorsa-network operations
-   - `LegacyClient`: Read-only access to Autonomi network
+   - `QuantumClient`: Pure Autonomi PQ network operations
+   - `LegacyClient`: Read-only access to Autonomi legacy network
    - `HybridClient`: Seamless access to both networks
 
 4. **Payment Verification** (`src/payment/`)
-   - Three-layer verification: LRU cache → Autonomi lookup → EVM check
+   - Three-layer verification: LRU cache -> Autonomi lookup -> EVM check
    - Legacy data is FREE (already paid on Autonomi)
    - New data requires EVM payment (Arbitrum One)
 
@@ -621,25 +621,25 @@ assert!(harness.anvil().is_healthy().await);
 
 | Phase | Target | Status |
 |-------|--------|--------|
-| **Phase 1** | Core implementation | ✅ Complete |
-| **Phase 2** | E2E test infrastructure | ✅ Complete |
-| **Phase 3** | Testnet deployment | 🔄 In Progress |
-| **Phase 4** | Migration tooling CLI | 📋 Planned |
-| **Phase 5** | Mainnet preparation | 📋 Planned |
+| **Phase 1** | Core implementation | Complete |
+| **Phase 2** | E2E test infrastructure | Complete |
+| **Phase 3** | Testnet deployment | In Progress |
+| **Phase 4** | Migration tooling CLI | Planned |
+| **Phase 5** | Mainnet preparation | Planned |
 
 ---
 
 ## Auto-Upgrade System
 
-saorsa-node automatically stays up-to-date with secure, verified upgrades across **all platforms** - Windows, macOS, and Linux.
+ant-node automatically stays up-to-date with secure, verified upgrades across **all platforms** - Windows, macOS, and Linux.
 
 ### Cross-Platform Support
 
 | Platform | Architecture | Binary |
 |----------|--------------|--------|
-| **Linux** | x86_64, aarch64 | `saorsa-node-linux-*` |
-| **macOS** | x86_64, aarch64 (Apple Silicon) | `saorsa-node-darwin-*` |
-| **Windows** | x86_64 | `saorsa-node-windows-*.exe` |
+| **Linux** | x86_64, aarch64 | `ant-node-linux-*` |
+| **macOS** | x86_64, aarch64 (Apple Silicon) | `ant-node-darwin-*` |
+| **Windows** | x86_64 | `ant-node-windows-*.exe` |
 
 The auto-upgrade system automatically detects the current platform and downloads the correct binary.
 
@@ -654,7 +654,7 @@ The auto-upgrade system automatically detects the current platform and downloads
 
 ### Network-Safe Staged Rollout
 
-To prevent **network collapse** from simultaneous upgrades, saorsa-node implements **randomized staged rollout**:
+To prevent **network collapse** from simultaneous upgrades, ant-node implements **randomized staged rollout**:
 
 **How Staged Rollout Works:**
 - Each node adds a **random delay** (0-24 hours) before applying upgrades
@@ -696,7 +696,7 @@ The only way to change the signing key is a manual upgrade with a new binary.
 
 ### Unattended Operation
 
-saorsa-node is designed for **true unattended operation**:
+ant-node is designed for **true unattended operation**:
 
 - **Zero Intervention**: Nodes upgrade themselves without human action
 - **Self-Healing**: Failed upgrades automatically rollback
@@ -714,10 +714,10 @@ This enables node operators to deploy and forget, knowing their nodes will stay 
 
 ```bash
 # Use stable channel (default)
-saorsa-node --upgrade-channel stable
+ant-node --upgrade-channel stable
 
 # Use beta channel for testing
-saorsa-node --upgrade-channel beta
+ant-node --upgrade-channel beta
 ```
 
 ### Configuration
@@ -726,7 +726,7 @@ saorsa-node --upgrade-channel beta
 [upgrade]
 channel = "stable"
 check_interval_hours = 1
-github_repo = "saorsa-labs/saorsa-node"
+github_repo = "WithAutonomi/ant-node"
 stop_on_upgrade = false  # Set true when running under a service manager
 # staged_rollout_hours = 24  # For staged rollout
 ```
@@ -735,17 +735,17 @@ stop_on_upgrade = false  # Set true when running under a service manager
 
 ## Running as a Service
 
-For production deployments, run saorsa-node under a service manager so it restarts automatically after upgrades.
+For production deployments, run ant-node under a service manager so it restarts automatically after upgrades.
 
 ### systemd (Linux)
 
-A service file is included at `systemd/saorsa-node.service` and installed automatically by RPM/DEB packages.
+A service file is included at `systemd/ant-node.service` and installed automatically by RPM/DEB packages.
 
 ```bash
 # Install and enable
-sudo cp systemd/saorsa-node.service /etc/systemd/system/
+sudo cp systemd/ant-node.service /etc/systemd/system/
 sudo systemctl daemon-reload
-sudo systemctl enable --now saorsa-node
+sudo systemctl enable --now ant-node
 ```
 
 Key settings:
@@ -755,7 +755,7 @@ Key settings:
 
 ### launchd (macOS)
 
-Create a plist at `~/Library/LaunchAgents/com.saorsa.node.plist`:
+Create a plist at `~/Library/LaunchAgents/com.autonomi.node.plist`:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -764,10 +764,10 @@ Create a plist at `~/Library/LaunchAgents/com.saorsa.node.plist`:
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.saorsa.node</string>
+    <string>com.autonomi.node</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/usr/local/bin/saorsa-node</string>
+        <string>/usr/local/bin/ant-node</string>
         <string>--stop-on-upgrade</string>
     </array>
     <key>KeepAlive</key>
@@ -779,20 +779,20 @@ Create a plist at `~/Library/LaunchAgents/com.saorsa.node.plist`:
 ```
 
 ```bash
-launchctl load ~/Library/LaunchAgents/com.saorsa.node.plist
+launchctl load ~/Library/LaunchAgents/com.autonomi.node.plist
 ```
 
 ### Windows Service
 
-Use [WinSW](https://github.com/winsw/winsw) or [NSSM](https://nssm.cc/) to wrap saorsa-node as a Windows service.
+Use [WinSW](https://github.com/winsw/winsw) or [NSSM](https://nssm.cc/) to wrap ant-node as a Windows service.
 
-With WinSW, create `saorsa-node-service.xml`:
+With WinSW, create `ant-node-service.xml`:
 
 ```xml
 <service>
-  <id>saorsa-node</id>
-  <name>Saorsa Node</name>
-  <executable>C:\saorsa\saorsa-node.exe</executable>
+  <id>ant-node</id>
+  <name>Ant Node</name>
+  <executable>C:\ant-node\ant-node.exe</executable>
   <arguments>--stop-on-upgrade</arguments>
   <onfailure action="restart" delay="5 sec"/>
 </service>
@@ -808,7 +808,7 @@ Without `--stop-on-upgrade`, the node spawns the upgraded binary as a new proces
 
 ## Architecture
 
-saorsa-node follows a **thin wrapper** design philosophy, adding minimal code on top of saorsa-core.
+ant-node follows a **thin wrapper** design philosophy, adding minimal code on top of saorsa-core.
 
 ### Component Responsibilities
 
@@ -820,13 +820,13 @@ saorsa-node follows a **thin wrapper** design philosophy, adding minimal code on
 | **Security** | saorsa-core | Rate limiting, blacklisting, diversity scoring |
 | **Content Storage** | saorsa-core | Local chunk storage |
 | **Replication** | saorsa-core | Data redundancy management |
-| **Auto-Upgrade** | saorsa-node | Binary update system |
-| **Migration** | saorsa-node | ant-node data import |
-| **CLI** | saorsa-node | User interface |
+| **Auto-Upgrade** | ant-node | Binary update system |
+| **Migration** | ant-node | Legacy ant-node data import |
+| **CLI** | ant-node | User interface |
 
 ### Code Size
 
-saorsa-node adds approximately **1,000 lines** of new code:
+ant-node adds approximately **1,000 lines** of new code:
 - Easy to audit
 - Minimal attack surface
 - Clear separation of concerns
@@ -834,9 +834,9 @@ saorsa-node adds approximately **1,000 lines** of new code:
 ### Dependency Chain
 
 ```
-saorsa-node
-    └── saorsa-core
-            └── saorsa-pqc (ML-DSA, ML-KEM)
+ant-node
+    +-- saorsa-core
+            +-- saorsa-pqc (ML-DSA, ML-KEM)
 ```
 
 ---
@@ -852,31 +852,31 @@ saorsa-node
 
 ```bash
 # Clone the repository
-git clone https://github.com/saorsa-labs/saorsa-node
-cd saorsa-node
+git clone https://github.com/WithAutonomi/ant-node
+cd ant-node
 
 # Build release binary
 cargo build --release
 
 # Binary location
-./target/release/saorsa-node --version
+./target/release/ant-node --version
 ```
 
 ### Run with Defaults
 
 ```bash
 # Start node with default settings
-./target/release/saorsa-node
+./target/release/ant-node
 ```
 
 ### Join Testnet
 
 ```bash
 # Connect to testnet bootstrap nodes
-./target/release/saorsa-node --testnet
+./target/release/ant-node --testnet
 
 # Or specify bootstrap peers manually
-./target/release/saorsa-node \
+./target/release/ant-node \
     --bootstrap "165.22.4.178:12000" \
     --bootstrap "164.92.111.156:12000"
 ```
@@ -884,14 +884,14 @@ cargo build --release
 **Testnet Bootstrap Nodes:**
 | Node | Location | Address |
 |------|----------|---------|
-| saorsa-bootstrap-1 | NYC (DigitalOcean) | `165.22.4.178:12000` |
-| saorsa-bootstrap-2 | SFO (DigitalOcean) | `164.92.111.156:12000` |
+| ant-bootstrap-1 | NYC (DigitalOcean) | `165.22.4.178:12000` |
+| ant-bootstrap-2 | SFO (DigitalOcean) | `164.92.111.156:12000` |
 
 ### Full Configuration
 
 ```bash
-./target/release/saorsa-node \
-    --root-dir ~/.saorsa \
+./target/release/ant-node \
+    --root-dir ~/.ant-node \
     --port 12000 \
     --ip-version dual \
     --upgrade-channel stable \
@@ -904,12 +904,12 @@ cargo build --release
 ## CLI Reference
 
 ```
-saorsa-node [OPTIONS]
+ant-node [OPTIONS]
 
 Options:
     --root-dir <PATH>
         Node data directory
-        [default: ~/.saorsa]
+        [default: ~/.ant-node]
 
     --port <PORT>
         Listening port (0 for automatic selection)
@@ -924,7 +924,7 @@ Options:
         Example: /ip4/1.2.3.4/udp/12000/quic-v1
 
     --migrate-ant-data <PATH>
-        Path to ant-node data directory to migrate
+        Path to legacy ant-node data directory to migrate
         Use 'auto' for automatic detection
 
     --upgrade-channel <CHANNEL>
@@ -949,27 +949,27 @@ Options:
 Configuration sources (highest to lowest priority):
 
 1. **Command-line arguments**
-2. **Environment variables** (`SAORSA_*`)
-3. **Configuration file** (`~/.saorsa/config.toml`)
+2. **Environment variables** (`ANT_*`)
+3. **Configuration file** (`~/.ant-node/config.toml`)
 
 ### Environment Variables
 
 ```bash
-export SAORSA_ROOT_DIR=~/.saorsa
-export SAORSA_PORT=12000
-export SAORSA_IP_VERSION=dual
-export SAORSA_LOG_LEVEL=info
-export SAORSA_AUTO_UPGRADE=true
-export SAORSA_UPGRADE_CHANNEL=stable
+export ANT_ROOT_DIR=~/.ant-node
+export ANT_PORT=12000
+export ANT_IP_VERSION=dual
+export ANT_LOG_LEVEL=info
+export ANT_AUTO_UPGRADE=true
+export ANT_UPGRADE_CHANNEL=stable
 ```
 
 ### Configuration File
 
-`~/.saorsa/config.toml`:
+`~/.ant-node/config.toml`:
 
 ```toml
 [node]
-root_dir = "~/.saorsa"
+root_dir = "~/.ant-node"
 port = 0  # Auto-select
 
 [network]
@@ -983,7 +983,7 @@ bootstrap = [
 # Upgrades are always enabled; configure behavior here
 channel = "stable"
 check_interval_hours = 1
-github_repo = "saorsa-labs/saorsa-node"
+github_repo = "WithAutonomi/ant-node"
 stop_on_upgrade = false
 
 [migration]
@@ -1043,7 +1043,7 @@ All security-relevant events are logged:
 Enable detailed logging:
 
 ```bash
-RUST_LOG=saorsa_node=debug,saorsa_core=debug ./saorsa-node
+RUST_LOG=ant_node=debug,saorsa_core=debug ./ant-node
 ```
 
 ---
@@ -1052,9 +1052,9 @@ RUST_LOG=saorsa_node=debug,saorsa_core=debug ./saorsa-node
 
 | Project | Description | Repository |
 |---------|-------------|------------|
-| **saorsa-core** | Core networking and security library | [github.com/dirvine/saorsa-core](https://github.com/dirvine/saorsa-core) |
-| **saorsa-pqc** | Post-quantum cryptography primitives | [github.com/dirvine/saorsa-pqc](https://github.com/dirvine/saorsa-pqc) |
-| **saorsa-cli** | Unified CLI for file and chunk operations with EVM payments | Built into saorsa-node |
+| **saorsa-core** | Core networking and security library | [github.com/WithAutonomi/saorsa-core](https://github.com/WithAutonomi/saorsa-core) |
+| **saorsa-pqc** | Post-quantum cryptography primitives | [github.com/WithAutonomi/saorsa-pqc](https://github.com/WithAutonomi/saorsa-pqc) |
+| **ant-cli** | Unified CLI for file and chunk operations with EVM payments | Built into ant-node |
 
 ---
 
@@ -1091,4 +1091,4 @@ cargo fmt
 
 ---
 
-**saorsa-node**: Securing the future of decentralized data, one quantum-proof node at a time.
+**ant-node**: Securing the future of decentralized data, one quantum-proof node at a time.

--- a/S3-vs-Saorsa-Architecture-Analysis.md
+++ b/S3-vs-Saorsa-Architecture-Analysis.md
@@ -1,4 +1,4 @@
-# Comprehensive Architecture Analysis: Saorsa + Communitas vs Amazon S3
+# Comprehensive Architecture Analysis: Autonomi + Communitas vs Amazon S3
 
 **Date**: December 18, 2025
 **Author**: Architecture Research Report
@@ -8,10 +8,10 @@
 
 ## Executive Summary
 
-This report provides a comprehensive comparison between Amazon S3's centralized object storage model and the Saorsa Network + Communitas decentralized architecture. The key differentiator is the **pay-once-store-forever archival model** with upfront token payments, versus S3's **recurring subscription-based** approach.
+This report provides a comprehensive comparison between Amazon S3's centralized object storage model and the Autonomi Network + Communitas decentralized architecture. The key differentiator is the **pay-once-store-forever archival model** with upfront token payments, versus S3's **recurring subscription-based** approach.
 
 **Key Findings**:
-- Saorsa excels for permanent archives with superior economics over 10+ year horizons
+- Autonomi excels for permanent archives with superior economics over 10+ year horizons
 - Communitas provides Byzantine-resilient metadata management via CRDTs
 - The architecture survives catastrophic infrastructure failures where S3 would fail
 - Post-quantum cryptography throughout provides future-proof security
@@ -36,38 +36,38 @@ This report provides a comprehensive comparison between Amazon S3's centralized 
 ## 1. The Complete Storage Ecosystem
 
 ```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                        USER DATA LIFECYCLE                                   │
-└─────────────────────────────────────────────────────────────────────────────┘
-                                    │
-                    ┌───────────────┴───────────────┐
-                    ▼                               ▼
-           ┌───────────────┐               ┌───────────────┐
-           │  PUBLIC DATA  │               │ PRIVATE DATA  │
-           └───────┬───────┘               └───────┬───────┘
-                   │                               │
-                   ▼                               ▼
-    ┌──────────────────────────┐    ┌──────────────────────────────────┐
-    │    self_encryption       │    │       self_encryption            │
-    │  ┌────────────────────┐  │    │  ┌────────────────────────────┐  │
-    │  │ File → Chunks      │  │    │  │ File → Chunks              │  │
-    │  │ Chunks → DataMap   │  │    │  │ Chunks → DataMap           │  │
-    │  └────────────────────┘  │    │  └────────────────────────────┘  │
-    └───────────┬──────────────┘    └────────────────┬─────────────────┘
-                │                                    │
-                ▼                                    ▼
-    ┌──────────────────────────┐    ┌──────────────────────────────────┐
-    │      SAORSA NETWORK      │    │         COMMUNITAS               │
-    │  ┌────────────────────┐  │    │  ┌────────────────────────────┐  │
-    │  │ Chunks: DHT        │  │    │  │ Chunks: Saorsa DHT         │  │
-    │  │ DataMap: as Chunk  │◄─┼────┼──┤ DataMap: CRDT + MLS        │  │
-    │  │ (content-addressed)│  │    │  │ (shared, encrypted)        │  │
-    │  └────────────────────┘  │    │  └────────────────────────────┘  │
-    │                          │    │                                  │
-    │  Payment: One-time token │    │  Sync: Plumtree gossip          │
-    │  Duration: Forever       │    │  Encryption: ChaCha20-Poly1305  │
-    │  Retrieval: Free         │    │  Groups: MLS per-topic          │
-    └──────────────────────────┘    └──────────────────────────────────┘
++-----------------------------------------------------------------------------+
+|                        USER DATA LIFECYCLE                                   |
++-----------------------------------------------------------------------------+
+                                    |
+                    +---------------+---------------+
+                    v                               v
+           +---------------+               +---------------+
+           |  PUBLIC DATA  |               | PRIVATE DATA  |
+           +-------+-------+               +-------+-------+
+                   |                               |
+                   v                               v
+    +--------------------------+    +----------------------------------+
+    |    self_encryption       |    |       self_encryption            |
+    |  +--------------------+  |    |  +----------------------------+  |
+    |  | File -> Chunks      |  |    |  | File -> Chunks              |  |
+    |  | Chunks -> DataMap   |  |    |  | Chunks -> DataMap           |  |
+    |  +--------------------+  |    |  +----------------------------+  |
+    +-----------+--------------+    +----------------+-----------------+
+                |                                    |
+                v                                    v
+    +--------------------------+    +----------------------------------+
+    |      AUTONOMI NETWORK    |    |         COMMUNITAS               |
+    |  +--------------------+  |    |  +----------------------------+  |
+    |  | Chunks: DHT        |  |    |  | Chunks: Autonomi DHT       |  |
+    |  | DataMap: as Chunk  |<-+----+--| DataMap: CRDT + MLS        |  |
+    |  | (content-addressed)|  |    |  | (shared, encrypted)        |  |
+    |  +--------------------+  |    |  +----------------------------+  |
+    |                          |    |                                  |
+    |  Payment: One-time token |    |  Sync: Plumtree gossip          |
+    |  Duration: Forever       |    |  Encryption: ChaCha20-Poly1305  |
+    |  Retrieval: Free         |    |  Groups: MLS per-topic          |
+    +--------------------------+    +----------------------------------+
 ```
 
 ### Self-Encryption Process
@@ -91,66 +91,66 @@ The `self_encryption` library (maidsafe/self_encryption) implements convergent e
 ### Amazon S3 Mental Model
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                     AMAZON S3 PARADIGM                          │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                 │
-│  Namespace: s3://bucket-name/path/to/object.ext                │
-│             └───────┬───────┘└────────┬───────┘                │
-│              Location       Path (mutable pointer)              │
-│                                                                 │
-│  ┌─────────────────────────────────────────────────────────┐   │
-│  │ OBJECT = { key, body, metadata, ACL, versioning }       │   │
-│  │                                                         │   │
-│  │ • Key is arbitrary string (user-chosen)                 │   │
-│  │ • Body can be overwritten (mutable)                     │   │
-│  │ • Metadata is key-value pairs (user-defined)            │   │
-│  │ • Versioning is optional (costs extra)                  │   │
-│  └─────────────────────────────────────────────────────────┘   │
-│                                                                 │
-│  Trust Model: You trust AWS completely                         │
-│  - AWS controls access                                          │
-│  - AWS can read your data (unless client-side encrypted)       │
-│  - AWS can delete your data                                     │
-│  - AWS can raise prices                                         │
-│  - AWS can terminate your account                               │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
++-------------------------------------------------------------+
+|                     AMAZON S3 PARADIGM                          |
++-------------------------------------------------------------+
+|                                                                 |
+|  Namespace: s3://bucket-name/path/to/object.ext                |
+|             +-------+-------++--------+-------+                |
+|              Location       Path (mutable pointer)              |
+|                                                                 |
+|  +---------------------------------------------------------+   |
+|  | OBJECT = { key, body, metadata, ACL, versioning }       |   |
+|  |                                                         |   |
+|  | - Key is arbitrary string (user-chosen)                 |   |
+|  | - Body can be overwritten (mutable)                     |   |
+|  | - Metadata is key-value pairs (user-defined)            |   |
+|  | - Versioning is optional (costs extra)                  |   |
+|  +---------------------------------------------------------+   |
+|                                                                 |
+|  Trust Model: You trust AWS completely                         |
+|  - AWS controls access                                          |
+|  - AWS can read your data (unless client-side encrypted)       |
+|  - AWS can delete your data                                     |
+|  - AWS can raise prices                                         |
+|  - AWS can terminate your account                               |
+|                                                                 |
++-------------------------------------------------------------+
 ```
 
-### Saorsa + Communitas Mental Model
+### Autonomi + Communitas Mental Model
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                SAORSA + COMMUNITAS PARADIGM                     │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                 │
-│  Namespace: XorName (32-byte SHA256 hash of content)           │
-│             └─────────────────┬─────────────────┘              │
-│                    Content IS the address                       │
-│                                                                 │
-│  ┌─────────────────────────────────────────────────────────┐   │
-│  │ CHUNK = { address: SHA256(content), content: Bytes }    │   │
-│  │                                                         │   │
-│  │ • Address is derived (not chosen)                       │   │
-│  │ • Content is immutable (by cryptographic design)        │   │
-│  │ • No metadata in storage layer (by design)              │   │
-│  │ • Deduplication is automatic                            │   │
-│  └─────────────────────────────────────────────────────────┘   │
-│                                                                 │
-│  Trust Model: Trust mathematics, not corporations              │
-│  - No single entity controls access                             │
-│  - Data is self-verifying (address = hash)                     │
-│  - No one can tamper without detection                         │
-│  - No one can selectively censor                                │
-│  - Price paid once, storage guaranteed by economics            │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
++-------------------------------------------------------------+
+|                AUTONOMI + COMMUNITAS PARADIGM                   |
++-------------------------------------------------------------+
+|                                                                 |
+|  Namespace: XorName (32-byte SHA256 hash of content)           |
+|             +-----------------+-----------------+              |
+|                    Content IS the address                       |
+|                                                                 |
+|  +---------------------------------------------------------+   |
+|  | CHUNK = { address: SHA256(content), content: Bytes }    |   |
+|  |                                                         |   |
+|  | - Address is derived (not chosen)                       |   |
+|  | - Content is immutable (by cryptographic design)        |   |
+|  | - No metadata in storage layer (by design)              |   |
+|  | - Deduplication is automatic                            |   |
+|  +---------------------------------------------------------+   |
+|                                                                 |
+|  Trust Model: Trust mathematics, not corporations              |
+|  - No single entity controls access                             |
+|  - Data is self-verifying (address = hash)                     |
+|  - No one can tamper without detection                         |
+|  - No one can selectively censor                                |
+|  - Price paid once, storage guaranteed by economics            |
+|                                                                 |
++-------------------------------------------------------------+
 ```
 
 ### Core Architecture Differences
 
-| Aspect | Amazon S3 | Saorsa Network |
+| Aspect | Amazon S3 | Autonomi Network |
 |--------|-----------|----------------|
 | **Addressing** | Location-based: `s3://bucket/key` | Content-based: `XorName = SHA256(content)` |
 | **Mutability** | Mutable objects (can overwrite) | **Immutable** - content defines address |
@@ -170,8 +170,8 @@ The architecture creates a **separation of concerns**:
 
 | Layer | What It Stores | Addressing | Mutability |
 |-------|---------------|------------|------------|
-| **Saorsa (chunks)** | Raw encrypted data | Content-addressed | Immutable |
-| **Saorsa (DataMaps)** | Chunk references for public data | Content-addressed | Immutable |
+| **Autonomi (chunks)** | Raw encrypted data | Content-addressed | Immutable |
+| **Autonomi (DataMaps)** | Chunk references for public data | Content-addressed | Immutable |
 | **Communitas (CRDTs)** | DataMaps + metadata for private data | Identity-based | Mutable (CRDT) |
 
 ### Dual-Track Metadata Solution
@@ -180,21 +180,21 @@ The architecture creates a **separation of concerns**:
 
 ```
 File "research-paper.pdf"
-     │
-     ▼ self_encrypt()
-┌─────────────────────────────────────────────────────────────────────┐
-│  Encrypted Chunks (stored in Saorsa DHT)                            │
-│  c1: 0xabc123... (1MB)                                              │
-│  c2: 0xdef456... (1MB)                                              │
-│  c3: 0x789ghi... (500KB)                                            │
-└─────────────────────────────────────────────────────────────────────┘
-     │
-     ▼ DataMap serialized as chunk
-┌─────────────────────────────────────────────────────────────────────┐
-│  DataMap Chunk: 0xDATAMAP_HASH...                                   │
-│  Content: { chunks: [c1, c2, c3], src_hashes: [...] }               │
-│  PUBLISHED PUBLICLY - Anyone with hash can retrieve                 │
-└─────────────────────────────────────────────────────────────────────┘
+     |
+     v self_encrypt()
++---------------------------------------------------------------------+
+|  Encrypted Chunks (stored in Autonomi DHT)                            |
+|  c1: 0xabc123... (1MB)                                              |
+|  c2: 0xdef456... (1MB)                                              |
+|  c3: 0x789ghi... (500KB)                                            |
++---------------------------------------------------------------------+
+     |
+     v DataMap serialized as chunk
++---------------------------------------------------------------------+
+|  DataMap Chunk: 0xDATAMAP_HASH...                                   |
+|  Content: { chunks: [c1, c2, c3], src_hashes: [...] }               |
+|  PUBLISHED PUBLICLY - Anyone with hash can retrieve                 |
++---------------------------------------------------------------------+
 
 DISCOVERY: External publication (website, DNS, social media, QR code)
 ```
@@ -203,31 +203,31 @@ DISCOVERY: External publication (website, DNS, social media, QR code)
 
 ```
 File "family-photos.zip"
-     │
-     ▼ self_encrypt()
-┌─────────────────────────────────────────────────────────────────────┐
-│  Encrypted Chunks (stored in Saorsa DHT)                            │
-│  Same as public path - chunks don't know if they're "private"       │
-└─────────────────────────────────────────────────────────────────────┘
-     │
-     ▼ DataMap stored in Communitas
-┌─────────────────────────────────────────────────────────────────────┐
-│  Communitas CRDT Document (yrs Y.Map)                               │
-│  ┌───────────────────────────────────────────────────────────────┐  │
-│  │ MemberDocument {                                              │  │
-│  │   files: OR-Set<FileEntry> {                                  │  │
-│  │     "family-photos.zip" → {                                   │  │
-│  │       data_map: DataMap { chunks: [...] },                    │  │
-│  │       metadata: { size, created, permissions }                │  │
-│  │     }                                                         │  │
-│  │   }                                                           │  │
-│  │ }                                                             │  │
-│  └───────────────────────────────────────────────────────────────┘  │
-│                                                                      │
-│  Encryption: ChaCha20-Poly1305 (per-group key via MLS)              │
-│  Sync: Plumtree gossip to group members                             │
-│  Storage: Each member's local vault                                  │
-└─────────────────────────────────────────────────────────────────────┘
+     |
+     v self_encrypt()
++---------------------------------------------------------------------+
+|  Encrypted Chunks (stored in Autonomi DHT)                            |
+|  Same as public path - chunks don't know if they're "private"       |
++---------------------------------------------------------------------+
+     |
+     v DataMap stored in Communitas
++---------------------------------------------------------------------+
+|  Communitas CRDT Document (yrs Y.Map)                               |
+|  +---------------------------------------------------------------+  |
+|  | MemberDocument {                                              |  |
+|  |   files: OR-Set<FileEntry> {                                  |  |
+|  |     "family-photos.zip" -> {                                  |  |
+|  |       data_map: DataMap { chunks: [...] },                    |  |
+|  |       metadata: { size, created, permissions }                |  |
+|  |     }                                                         |  |
+|  |   }                                                           |  |
+|  | }                                                             |  |
+|  +---------------------------------------------------------------+  |
+|                                                                      |
+|  Encryption: ChaCha20-Poly1305 (per-group key via MLS)              |
+|  Sync: Plumtree gossip to group members                             |
+|  Storage: Each member's local vault                                  |
++---------------------------------------------------------------------+
 
 DISCOVERY: Group members have DataMap in their synced CRDT state
 ACCESS CONTROL: MLS group membership = who can decrypt DataMaps
@@ -239,7 +239,7 @@ ACCESS CONTROL: MLS group membership = who can decrypt DataMaps
 
 ### 4.1 Cryptographic Separation of Concerns
 
-| Property | S3 | Saorsa+Communitas |
+| Property | S3 | Autonomi+Communitas |
 |----------|----|--------------------|
 | **Data at rest encryption** | Optional, AWS-managed keys | Mandatory, user-controlled |
 | **Access control** | IAM policies (revocable) | Cryptographic (mathematical) |
@@ -252,11 +252,11 @@ ACCESS CONTROL: MLS group membership = who can decrypt DataMaps
 
 ```
 Communitas CRDT Properties:
-├── OR-Set for file lists → Add/remove always converges
-├── LWW-Register for metadata → Last write wins deterministically
-├── Vector Clocks → Causal ordering preserved
-├── Anti-Entropy → Eventually consistent (provably)
-└── MLS Groups → Forward secrecy + post-compromise security
++-- OR-Set for file lists -> Add/remove always converges
++-- LWW-Register for metadata -> Last write wins deterministically
++-- Vector Clocks -> Causal ordering preserved
++-- Anti-Entropy -> Eventually consistent (provably)
++-- MLS Groups -> Forward secrecy + post-compromise security
 ```
 
 **Expert Opinion**: Using CRDTs for metadata is superior to S3's strong consistency for collaborative scenarios:
@@ -282,13 +282,13 @@ Communitas CRDT Properties:
 **S3 Glacier Deep Archive:**
 | Cost Component | Calculation | Total |
 |----------------|-------------|-------|
-| Storage | $0.00099/GB/month × 1000GB × 120 months | $118.80 |
-| PUT requests | ~$0.05/1000 × initial upload | ~$0.50 |
-| Retrieval (once/year) | $0.02/GB × 1000GB × 10 retrievals | $200.00 |
-| Data transfer out | $0.09/GB × 1000GB × 10 transfers | $900.00 |
+| Storage | $0.00099/GB/month x 1000GB x 120 months | $118.80 |
+| PUT requests | ~$0.05/1000 x initial upload | ~$0.50 |
+| Retrieval (once/year) | $0.02/GB x 1000GB x 10 retrievals | $200.00 |
+| Data transfer out | $0.09/GB x 1000GB x 10 transfers | $900.00 |
 | **TOTAL** | | **~$1,220+** |
 
-**Saorsa:**
+**Autonomi:**
 | Cost Component | Calculation | Total |
 |----------------|-------------|-------|
 | One-time token payment | $X (set by network economics) | $X |
@@ -296,7 +296,7 @@ Communitas CRDT Properties:
 | Egress | Free | $0 |
 | **TOTAL** | | **$X (fixed, forever)** |
 
-**Break-even**: If $X < $1,220, Saorsa wins for 10+ year archives.
+**Break-even**: If $X < $1,220, Autonomi wins for 10+ year archives.
 
 ---
 
@@ -309,10 +309,10 @@ Communitas CRDT Properties:
 ```
 Problem:
 User A uploads "important-document.pdf"
-  → DataMap stored at XorName: 0x7f3a9b2c...
+  -> DataMap stored at XorName: 0x7f3a9b2c...
 
 User B wants to retrieve it
-  → How does User B know the XorName?
+  -> How does User B know the XorName?
 ```
 
 **Current Options:**
@@ -325,11 +325,11 @@ User B wants to retrieve it
 
 ```
 User's PrivateArchive (in Communitas CRDT):
-┌──────────────────────────────────────────────┐
-│ my_published_files: OR-Set<(name, XorName)>  │
-│   "research-paper" → 0x7f3a9b2c...           │
-│   "family-archive" → 0x9d2e4f1a...           │
-└──────────────────────────────────────────────┘
++----------------------------------------------+
+| my_published_files: OR-Set<(name, XorName)>  |
+|   "research-paper" -> 0x7f3a9b2c...           |
+|   "family-archive" -> 0x9d2e4f1a...           |
++----------------------------------------------+
 
 Share via: four-words identity + file petname
 "Get 'research-paper' from david-lion-castle-wind"
@@ -342,9 +342,9 @@ Share via: four-words identity + file petname
 ```
 Scenario: User maintains a public photo gallery
 
-Day 1: Upload 100 photos → Archive at 0xABC...
-Day 2: Add 10 photos → NEW Archive at 0xDEF...
-Day 3: Add 5 photos → NEW Archive at 0xGHI...
+Day 1: Upload 100 photos -> Archive at 0xABC...
+Day 2: Add 10 photos -> NEW Archive at 0xDEF...
+Day 3: Add 5 photos -> NEW Archive at 0xGHI...
 
 Problem: All links to 0xABC... are now stale
 ```
@@ -353,25 +353,25 @@ Problem: All links to 0xABC... are now stale
 
 ```
 Communitas CRDT (user's public profile):
-┌───────────────────────────────────────────────────────────────┐
-│ public_sites: LWW-Register<SitePointer> {                     │
-│   "photo-gallery" → {                                         │
-│     current_archive: XorName(0xGHI...),  // mutable!          │
-│     previous_versions: [0xABC..., 0xDEF...],                  │
-│     last_updated: timestamp                                   │
-│   }                                                           │
-│ }                                                             │
-└───────────────────────────────────────────────────────────────┘
++---------------------------------------------------------------+
+| public_sites: LWW-Register<SitePointer> {                     |
+|   "photo-gallery" -> {                                        |
+|     current_archive: XorName(0xGHI...),  // mutable!          |
+|     previous_versions: [0xABC..., 0xDEF...],                  |
+|     last_updated: timestamp                                   |
+|   }                                                           |
+| }                                                             |
++---------------------------------------------------------------+
 
 Resolution Flow:
 1. Query "david's photo-gallery" via FOAF gossip
 2. David's peers return LWW-Register value
-3. Fetch archive from Saorsa at current XorName
+3. Fetch archive from Autonomi at current XorName
 ```
 
 ### 5.3 Recovery Scenarios
 
-| Scenario | S3 | Saorsa+Communitas |
+| Scenario | S3 | Autonomi+Communitas |
 |----------|-----|-------------------|
 | User loses all devices | Login to AWS console, data intact | **PROBLEM**: DataMaps lost with devices |
 
@@ -386,18 +386,18 @@ Resolution Flow:
 
 ```
 Shamir Secret Sharing for Master Key:
-┌───────────────────────────────────────────────────────────────┐
-│ vault_master_key → split into N shares (threshold K)          │
-│                                                               │
-│ Share 1 → Trusted Contact A (encrypted to their ML-KEM)      │
-│ Share 2 → Trusted Contact B                                   │
-│ Share 3 → Trusted Contact C                                   │
-│ Share 4 → User's backup (paper, safety deposit)               │
-│ Share 5 → Optional: Escrow service                            │
-│                                                               │
-│ Recovery: Collect K shares → reconstruct master key           │
-│ → Decrypt vault → Access all DataMaps                         │
-└───────────────────────────────────────────────────────────────┘
++---------------------------------------------------------------+
+| vault_master_key -> split into N shares (threshold K)          |
+|                                                               |
+| Share 1 -> Trusted Contact A (encrypted to their ML-KEM)      |
+| Share 2 -> Trusted Contact B                                   |
+| Share 3 -> Trusted Contact C                                   |
+| Share 4 -> User's backup (paper, safety deposit)               |
+| Share 5 -> Optional: Escrow service                            |
+|                                                               |
+| Recovery: Collect K shares -> reconstruct master key           |
+| -> Decrypt vault -> Access all DataMaps                         |
++---------------------------------------------------------------+
 ```
 
 ---
@@ -406,34 +406,34 @@ Shamir Secret Sharing for Master Key:
 
 ### 6.1 Feature-by-Feature Analysis
 
-| Dimension | Amazon S3 | Saorsa + Communitas | Winner |
+| Dimension | Amazon S3 | Autonomi + Communitas | Winner |
 |-----------|-----------|---------------------|--------|
 | **Addressing** | Location-based (mutable) | Content-based (immutable) | *Depends on use case* |
-| **Deduplication** | None | Automatic | **Saorsa** |
+| **Deduplication** | None | Automatic | **Autonomi** |
 | **Consistency** | Strong | Eventual (CRDT) | *S3 for transactions* |
 | **Availability** | 99.99% | Depends on network | **S3** (for now) |
 | **Durability** | 11 nines | Emergent from replication | **S3** (proven) |
-| **Censorship Resistance** | None | Strong | **Saorsa** |
-| **Privacy** | AWS can read | End-to-end encrypted | **Saorsa+Communitas** |
-| **Cost Model** | Recurring | One-time | **Saorsa** (for archives) |
+| **Censorship Resistance** | None | Strong | **Autonomi** |
+| **Privacy** | AWS can read | End-to-end encrypted | **Autonomi+Communitas** |
+| **Cost Model** | Recurring | One-time | **Autonomi** (for archives) |
 | **Metadata Flexibility** | Rich (tags, ACLs) | Separate layer (Communitas) | *S3 more convenient* |
 | **Ecosystem** | Massive | Emerging | **S3** |
 | **Offline Support** | None | Full (Communitas) | **Communitas** |
 | **Disaster Recovery** | AWS manages | User-controlled + social | *Depends on scenario* |
-| **Quantum Safety** | Not yet | ML-DSA, ML-KEM, ChaCha20 | **Saorsa+Communitas** |
+| **Quantum Safety** | Not yet | ML-DSA, ML-KEM, ChaCha20 | **Autonomi+Communitas** |
 
 ### 6.2 Use Case Fit Analysis
 
 | Use Case | Best Choice | Reasoning |
 |----------|-------------|-----------|
 | **Enterprise file storage** | S3 | IAM, compliance, SLAs |
-| **Permanent archives** | Saorsa | Pay once, immutable proof |
+| **Permanent archives** | Autonomi | Pay once, immutable proof |
 | **Private collaboration** | Communitas | E2E encrypted, offline-first |
 | **Public websites** | S3 (for now) | CDN, HTTPS, DNS integration |
-| **Research data** | Saorsa | Content-addressed citations |
-| **Legal/compliance** | Saorsa | Immutability, audit trail |
+| **Research data** | Autonomi | Content-addressed citations |
+| **Legal/compliance** | Autonomi | Immutability, audit trail |
 | **Real-time apps** | S3 | Strong consistency |
-| **Censorship-resistant publishing** | Saorsa + Communitas | No single point of control |
+| **Censorship-resistant publishing** | Autonomi + Communitas | No single point of control |
 | **Family/friend file sharing** | Communitas | Private groups, local sync |
 | **Disaster-resilient backup** | Communitas | Survives infrastructure failures |
 
@@ -453,60 +453,60 @@ Shamir Secret Sharing for Master Key:
 ### 7.1 The Decentralized Data Stack
 
 ```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                                                                             │
-│                    THE DECENTRALIZED DATA STACK                            │
-│                                                                             │
-├─────────────────────────────────────────────────────────────────────────────┤
-│                                                                             │
-│  Layer 4: Applications                                                      │
-│  ┌───────────────────────────────────────────────────────────────────────┐ │
-│  │  Communitas UI │ Future Apps │ Third-Party Integrations              │ │
-│  └───────────────────────────────────────────────────────────────────────┘ │
-│                                                                             │
-│  Layer 3: Collaboration (Communitas)                                        │
-│  ┌───────────────────────────────────────────────────────────────────────┐ │
-│  │  CRDTs │ MLS Groups │ Presence │ Private DataMaps │ Access Control   │ │
-│  └───────────────────────────────────────────────────────────────────────┘ │
-│                                                                             │
-│  Layer 2: Communication (saorsa-gossip)                                     │
-│  ┌───────────────────────────────────────────────────────────────────────┐ │
-│  │  HyParView │ Plumtree │ SWIM │ FOAF │ Anti-Entropy │ NAT Traversal   │ │
-│  └───────────────────────────────────────────────────────────────────────┘ │
-│                                                                             │
-│  Layer 1: Storage (Saorsa Network)                                          │
-│  ┌───────────────────────────────────────────────────────────────────────┐ │
-│  │  Chunks │ DHT │ Content Addressing │ Payment │ Self-Encryption       │ │
-│  └───────────────────────────────────────────────────────────────────────┘ │
-│                                                                             │
-│  Layer 0: Transport (ant-quic)                                              │
-│  ┌───────────────────────────────────────────────────────────────────────┐ │
-│  │  QUIC │ ML-DSA Signatures │ ML-KEM Key Exchange │ Multi-Transport    │ │
-│  └───────────────────────────────────────────────────────────────────────┘ │
-│                                                                             │
-└─────────────────────────────────────────────────────────────────────────────┘
++-----------------------------------------------------------------------------+
+|                                                                             |
+|                    THE DECENTRALIZED DATA STACK                            |
+|                                                                             |
++-----------------------------------------------------------------------------+
+|                                                                             |
+|  Layer 4: Applications                                                      |
+|  +-----------------------------------------------------------------------+ |
+|  |  Communitas UI | Future Apps | Third-Party Integrations              | |
+|  +-----------------------------------------------------------------------+ |
+|                                                                             |
+|  Layer 3: Collaboration (Communitas)                                        |
+|  +-----------------------------------------------------------------------+ |
+|  |  CRDTs | MLS Groups | Presence | Private DataMaps | Access Control   | |
+|  +-----------------------------------------------------------------------+ |
+|                                                                             |
+|  Layer 2: Communication (ant-gossip)                                        |
+|  +-----------------------------------------------------------------------+ |
+|  |  HyParView | Plumtree | SWIM | FOAF | Anti-Entropy | NAT Traversal   | |
+|  +-----------------------------------------------------------------------+ |
+|                                                                             |
+|  Layer 1: Storage (Autonomi Network)                                        |
+|  +-----------------------------------------------------------------------+ |
+|  |  Chunks | DHT | Content Addressing | Payment | Self-Encryption       | |
+|  +-----------------------------------------------------------------------+ |
+|                                                                             |
+|  Layer 0: Transport (ant-quic)                                              |
+|  +-----------------------------------------------------------------------+ |
+|  |  QUIC | ML-DSA Signatures | ML-KEM Key Exchange | Multi-Transport    | |
+|  +-----------------------------------------------------------------------+ |
+|                                                                             |
++-----------------------------------------------------------------------------+
 ```
 
 ### 7.2 Stack Comparison
 
 **Amazon S3 Stack:**
 ```
-├── Application: Your code
-├── SDK: AWS SDK (proprietary)
-├── API: S3 REST API (HTTP)
-├── Storage: S3 (proprietary, closed)
-├── Network: AWS Global Infrastructure (proprietary)
-└── Trust: Amazon (single point of failure/control)
++-- Application: Your code
++-- SDK: AWS SDK (proprietary)
++-- API: S3 REST API (HTTP)
++-- Storage: S3 (proprietary, closed)
++-- Network: AWS Global Infrastructure (proprietary)
++-- Trust: Amazon (single point of failure/control)
 ```
 
-**Saorsa + Communitas Stack:**
+**Autonomi + Communitas Stack:**
 ```
-├── Application: Communitas (open source)
-├── SDK: Rust crates (open source)
-├── Protocol: Content-addressed chunks (open standard)
-├── Storage: DHT (decentralized, open)
-├── Network: saorsa-gossip (open, multi-transport)
-└── Trust: Mathematics (cryptographic guarantees)
++-- Application: Communitas (open source)
++-- SDK: Rust crates (open source)
++-- Protocol: Content-addressed chunks (open standard)
++-- Storage: DHT (decentralized, open)
++-- Network: ant-gossip (open, multi-transport)
++-- Trust: Mathematics (cryptographic guarantees)
 ```
 
 ### 7.3 Communitas Technical Details
@@ -523,7 +523,7 @@ Shamir Secret Sharing for Master Key:
 - **ChaCha20-Poly1305**: Symmetric authenticated encryption
 - **PBKDF2**: Key derivation (100,000 iterations)
 
-**Gossip Protocol (saorsa-gossip):**
+**Gossip Protocol (ant-gossip):**
 - **HyParView**: Peer membership (8 active, 64+ passive)
 - **SWIM**: Failure detection (3-second suspect timeout)
 - **Plumtree**: Message dissemination (eager push + lazy gossip)
@@ -532,13 +532,13 @@ Shamir Secret Sharing for Master Key:
 **Storage Architecture:**
 ```
 vault_dir/{four_words}/
-├── metadata.json              # Vault metadata
-├── files/                     # Secret group files (encrypted)
-├── group_shards/              # Reed-Solomon shards from groups
-├── dht_cache/                 # Local DHT cache
-├── metadata/                  # Storage indices
-├── temp/                      # Temporary files
-└── web/                       # Public markdown content
++-- metadata.json              # Vault metadata
++-- files/                     # Secret group files (encrypted)
++-- group_shards/              # Reed-Solomon shards from groups
++-- dht_cache/                 # Local DHT cache
++-- metadata/                  # Storage indices
++-- temp/                      # Temporary files
++-- web/                       # Public markdown content
 ```
 
 ---
@@ -548,7 +548,7 @@ vault_dir/{four_words}/
 ### 8.1 Launch Strategy (Confirmed Correct)
 
 Your focus is correct:
-- **Communitas + Saorsa as hard archive first**
+- **Communitas + Autonomi as hard archive first**
 - Private shared data working
 - Public immutable data working
 - Defer public mutable data (websites, etc.)
@@ -563,7 +563,7 @@ Before public launch, solve "how do I share this file?":
 ### 8.3 Document the Trust Model (Priority: High)
 
 Create clear documentation explaining:
-- What survives if Saorsa Labs disappears
+- What survives if Autonomi Labs disappears
 - What survives if all your devices are lost
 - What survives if the internet fragments
 - Recovery paths for each scenario
@@ -578,7 +578,7 @@ For adoption, an S3-compatible API would unlock:
 ### 8.5 Quantify the Economics (Priority: Medium)
 
 Publish clear pricing comparisons:
-- "Store 1TB for 10 years: S3 = $X, Saorsa = $Y"
+- "Store 1TB for 10 years: S3 = $X, Autonomi = $Y"
 - Break-even calculator
 - Total cost of ownership models
 
@@ -586,7 +586,7 @@ Publish clear pricing comparisons:
 
 | Aspect | Assessment |
 |--------|------------|
-| **Storage Layer (Saorsa)** | Excellent - content-addressed, immutable, paid-once |
+| **Storage Layer (Autonomi)** | Excellent - content-addressed, immutable, paid-once |
 | **Metadata Layer (Communitas)** | Excellent - CRDT-based, encrypted, resilient |
 | **Gossip Layer** | Production-ready - HyParView+Plumtree+SWIM |
 | **Cryptography** | Future-proof - post-quantum throughout |
@@ -610,11 +610,11 @@ Publish clear pricing comparisons:
 - [Filebase: S3-Compatible IPFS](https://filebase.com/blog/introducing-support-for-ipfs-backed-by-decentralized-storage/)
 - [Top Decentralized Storage Platforms 2025](https://blog.apillon.io/the-top-7-decentralized-cloud-storage-platforms-in-2023-d9bdfc0e1f2d/)
 
-### MaidSafe/Saorsa Technical References
+### MaidSafe/Autonomi Technical References
 - [maidsafe/self_encryption](https://github.com/maidsafe/self_encryption)
-- saorsa-node source code analysis
+- ant-node source code analysis
 - communitas source code analysis
-- saorsa-gossip source code analysis
+- ant-gossip source code analysis
 
 ### Pricing Guides
 - [nOps AWS S3 Pricing Guide](https://www.nops.io/blog/aws-s3-pricing/)
@@ -629,7 +629,7 @@ Publish clear pricing comparisons:
 The key insight: You're not building "decentralized S3" - you're building something more sophisticated. S3 is a bucket of mutable objects. You're building a **permanent archive with a collaboration layer** - fundamentally different and arguably more valuable for the use cases you're targeting.
 
 The combination of:
-- **Immutable, content-addressed storage** (Saorsa)
+- **Immutable, content-addressed storage** (Autonomi)
 - **Byzantine-resilient metadata** (Communitas CRDTs)
 - **Post-quantum cryptography** throughout
 - **Pay-once economics**

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-//! Build script for saorsa-node.
+//! Build script for ant-node.
 
 use std::process::Command;
 
@@ -19,5 +19,5 @@ fn main() {
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map_or_else(|| "unknown".to_string(), |s| s.trim().to_string());
 
-    println!("cargo:rustc-env=SAORSA_GIT_COMMIT={commit}");
+    println!("cargo:rustc-env=ANT_GIT_COMMIT={commit}");
 }

--- a/config/production.toml
+++ b/config/production.toml
@@ -1,10 +1,10 @@
-# Production Configuration for saorsa-node
+# Production Configuration for ant-node
 #
 # This file matches the NodeConfig struct schema.
 # See src/config.rs for all available fields and defaults.
 
 # Root directory for node data
-root_dir = "/var/lib/saorsa-node"
+root_dir = "/var/lib/ant"
 
 # Listening port (10000-10999 for production)
 port = 10000
@@ -60,7 +60,7 @@ db_size_gb = 0
 enabled = false
 channel = "stable"
 check_interval_hours = 1
-github_repo = "dirvine/saorsa-node"
+github_repo = "WithAutonomi/ant-node"
 staged_rollout_hours = 1
 
 # --- Bootstrap cache ---

--- a/deploy/monitoring/grafana-ant-complete.json
+++ b/deploy/monitoring/grafana-ant-complete.json
@@ -1083,7 +1083,7 @@
   "refresh": "30s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["saorsa", "p2p", "dht", "security", "payment", "testnet", "skademlia"],
+  "tags": ["ant", "p2p", "dht", "security", "payment", "testnet", "skademlia"],
   "templating": {
     "list": [
       {
@@ -1105,8 +1105,8 @@
   "time": { "from": "now-1h", "to": "now" },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Saorsa Network - Complete Security Dashboard (v0.7.4)",
-  "uid": "saorsa-security-v074",
+  "title": "Autonomi Network - Complete Security Dashboard (v0.7.4)",
+  "uid": "ant-security-v074",
   "version": 2,
   "weekStart": ""
 }

--- a/deploy/monitoring/grafana-ant-data.json
+++ b/deploy/monitoring/grafana-ant-data.json
@@ -15,6 +15,7 @@
       }
     ]
   },
+  "description": "Data operations, storage, replication, and integrity monitoring for Autonomi nodes",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -25,9 +26,9 @@
       "icon": "external link",
       "includeVars": true,
       "keepTime": true,
-      "tags": ["saorsa"],
+      "tags": ["ant"],
       "targetBlank": true,
-      "title": "Saorsa Dashboards",
+      "title": "Autonomi Dashboards",
       "type": "dashboards"
     }
   ],
@@ -43,7 +44,7 @@
       },
       "id": 1,
       "panels": [],
-      "title": "Payment Overview",
+      "title": "Data Overview",
       "type": "row"
     },
     {
@@ -51,7 +52,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Total payments processed by this node",
+      "description": "Total records stored on this node",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -67,7 +68,7 @@
               },
               {
                 "color": "green",
-                "value": 100
+                "value": 1000
               }
             ]
           },
@@ -101,12 +102,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_payments_total{instance=~\"$instance\"}",
-          "legendFormat": "Total Payments",
+          "expr": "ant_records_stored_total{instance=~\"$instance\"}",
+          "legendFormat": "Records",
           "refId": "A"
         }
       ],
-      "title": "Total Payments",
+      "title": "Total Records",
       "type": "stat"
     },
     {
@@ -114,7 +115,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Total payment quotes generated",
+      "description": "Total records retrieved from this node",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -130,7 +131,7 @@
               },
               {
                 "color": "green",
-                "value": 50
+                "value": 100
               }
             ]
           },
@@ -164,12 +165,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_quotes_generated_total{instance=~\"$instance\"}",
-          "legendFormat": "Quotes Generated",
+          "expr": "ant_records_retrieved_total{instance=~\"$instance\"}",
+          "legendFormat": "Retrieved",
           "refId": "A"
         }
       ],
-      "title": "Quotes Generated",
+      "title": "Records Retrieved",
       "type": "stat"
     },
     {
@@ -177,7 +178,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Total records stored after payment verification",
+      "description": "Current storage usage",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -190,14 +191,10 @@
               {
                 "color": "blue",
                 "value": null
-              },
-              {
-                "color": "green",
-                "value": 100
               }
             ]
           },
-          "unit": "short"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -227,12 +224,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_records_stored_total{instance=~\"$instance\"}",
-          "legendFormat": "Records Stored",
+          "expr": "ant_storage_bytes_used{instance=~\"$instance\"}",
+          "legendFormat": "Used",
           "refId": "A"
         }
       ],
-      "title": "Records Stored",
+      "title": "Storage Used",
       "type": "stat"
     },
     {
@@ -240,137 +237,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Total revenue earned from storage payments",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "orange",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1000
-              }
-            ]
-          },
-          "unit": "currencyUSD"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 4,
-        "x": 12,
-        "y": 1
-      },
-      "id": 5,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "saorsa_revenue_total{instance=~\"$instance\"}",
-          "legendFormat": "Total Revenue",
-          "refId": "A"
-        }
-      ],
-      "title": "Total Revenue",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Current network size (connected peers)",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 10
-              },
-              {
-                "color": "green",
-                "value": 50
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 4,
-        "x": 16,
-        "y": 1
-      },
-      "id": 6,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "saorsa_connected_peers{instance=~\"$instance\"}",
-          "legendFormat": "Connected Peers",
-          "refId": "A"
-        }
-      ],
-      "title": "Network Size",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Node uptime",
+      "description": "Total storage capacity",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -386,17 +253,17 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "bytes"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 5,
         "w": 4,
-        "x": 20,
+        "x": 12,
         "y": 1
       },
-      "id": 7,
+      "id": 5,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -416,12 +283,138 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_uptime_seconds{instance=~\"$instance\"}",
-          "legendFormat": "Uptime",
+          "expr": "ant_storage_capacity_bytes{instance=~\"$instance\"}",
+          "legendFormat": "Capacity",
           "refId": "A"
         }
       ],
-      "title": "Live Time",
+      "title": "Storage Capacity",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current replication factor",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 2
+              },
+              {
+                "color": "green",
+                "value": 3
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ant_replication_factor{instance=~\"$instance\"}",
+          "legendFormat": "Factor",
+          "refId": "A"
+        }
+      ],
+      "title": "Replication Factor",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Data integrity checks performed",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ant_data_integrity_checks_total{instance=~\"$instance\"}",
+          "legendFormat": "Checks",
+          "refId": "A"
+        }
+      ],
+      "title": "Integrity Checks",
       "type": "stat"
     },
     {
@@ -434,7 +427,7 @@
       },
       "id": 10,
       "panels": [],
-      "title": "Payment Rates & Trends",
+      "title": "Storage Utilization",
       "type": "row"
     },
     {
@@ -442,74 +435,52 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Payment processing rate over time",
+      "description": "Storage utilization percentage",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+            "mode": "thresholds"
           },
           "mappings": [],
+          "max": 100,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
               }
             ]
           },
-          "unit": "ops"
+          "unit": "percent"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
+        "w": 6,
         "x": 0,
         "y": 7
       },
       "id": 11,
       "options": {
-        "legend": {
-          "calcs": ["mean", "max"],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
         },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
       },
       "pluginVersion": "10.0.0",
       "targets": [
@@ -518,20 +489,20 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(saorsa_payments_total{instance=~\"$instance\"}[5m]) * 3600",
-          "legendFormat": "Payments/Hour",
+          "expr": "(ant_storage_bytes_used{instance=~\"$instance\"} / ant_storage_capacity_bytes{instance=~\"$instance\"}) * 100",
+          "legendFormat": "Utilization",
           "refId": "A"
         }
       ],
-      "title": "Payment Rate",
-      "type": "timeseries"
+      "title": "Storage Utilization",
+      "type": "gauge"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Quote generation rate over time",
+      "description": "Storage usage over time",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -557,7 +528,7 @@
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -577,14 +548,14 @@
               }
             ]
           },
-          "unit": "ops"
+          "unit": "bytes"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 8,
+        "w": 18,
+        "x": 6,
         "y": 7
       },
       "id": 12,
@@ -607,20 +578,42 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(saorsa_quotes_generated_total{instance=~\"$instance\"}[5m]) * 3600",
-          "legendFormat": "Quotes/Hour",
+          "expr": "ant_storage_bytes_used{instance=~\"$instance\"}",
+          "legendFormat": "Used",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ant_storage_capacity_bytes{instance=~\"$instance\"}",
+          "legendFormat": "Capacity",
+          "refId": "B"
         }
       ],
-      "title": "Quote Generation Rate",
+      "title": "Storage Over Time",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 20,
+      "panels": [],
+      "title": "Data Operations",
+      "type": "row"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Storage rate over time",
+      "description": "Store and retrieve operations over time",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -646,7 +639,136 @@
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Stores"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Retrievals"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ant_records_stored_total{instance=~\"$instance\"}[5m])",
+          "legendFormat": "Stores",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ant_records_retrieved_total{instance=~\"$instance\"}[5m])",
+          "legendFormat": "Retrievals",
+          "refId": "B"
+        }
+      ],
+      "title": "Store/Retrieve Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "DHT store operations",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -672,14 +794,14 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 7
+        "w": 12,
+        "x": 12,
+        "y": 16
       },
-      "id": 13,
+      "id": 22,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": ["mean", "sum"],
           "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
@@ -696,12 +818,21 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(saorsa_records_stored_total{instance=~\"$instance\"}[5m]) * 3600",
-          "legendFormat": "Records/Hour",
+          "expr": "rate(ant_dht_stores_total{instance=~\"$instance\"}[5m])",
+          "legendFormat": "DHT Stores",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ant_dht_store_success_total{instance=~\"$instance\"}[5m])",
+          "legendFormat": "DHT Store Success",
+          "refId": "B"
         }
       ],
-      "title": "Storage Rate",
+      "title": "DHT Store Operations",
       "type": "timeseries"
     },
     {
@@ -710,11 +841,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 24
       },
-      "id": 20,
+      "id": 30,
       "panels": [],
-      "title": "Payment Verification",
+      "title": "DHT Lookups",
       "type": "row"
     },
     {
@@ -722,7 +853,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Payment verification success rate",
+      "description": "DHT lookup success rate",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -756,9 +887,9 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 16
+        "y": 25
       },
-      "id": 21,
+      "id": 31,
       "options": {
         "orientation": "auto",
         "reduceOptions": {
@@ -776,12 +907,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(saorsa_payment_verifications_success{instance=~\"$instance\"} / (saorsa_payment_verifications_success{instance=~\"$instance\"} + saorsa_payment_verifications_failed{instance=~\"$instance\"})) * 100",
+          "expr": "(ant_dht_lookup_success_total{instance=~\"$instance\"} / ant_dht_lookups_total{instance=~\"$instance\"}) * 100",
           "legendFormat": "Success Rate",
           "refId": "A"
         }
       ],
-      "title": "Verification Success Rate",
+      "title": "Lookup Success Rate",
       "type": "gauge"
     },
     {
@@ -789,200 +920,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Quote generation latency (P95)",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 100
-              },
-              {
-                "color": "red",
-                "value": 500
-              }
-            ]
-          },
-          "unit": "ms"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 6,
-        "y": 16
-      },
-      "id": 22,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "histogram_quantile(0.95, sum(rate(saorsa_quote_generation_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
-          "legendFormat": "P95 Latency",
-          "refId": "A"
-        }
-      ],
-      "title": "Quote Generation P95",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Payment verification status breakdown",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": []
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Success"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Failed"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Pending"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 12,
-        "y": 16
-      },
-      "id": 23,
-      "options": {
-        "displayLabels": ["name", "percent"],
-        "legend": {
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": true
-        },
-        "pieType": "pie",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "saorsa_payment_verifications_success{instance=~\"$instance\"}",
-          "legendFormat": "Success",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "saorsa_payment_verifications_failed{instance=~\"$instance\"}",
-          "legendFormat": "Failed",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "saorsa_payment_verifications_pending{instance=~\"$instance\"}",
-          "legendFormat": "Pending",
-          "refId": "C"
-        }
-      ],
-      "title": "Verification Status",
-      "type": "piechart"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Payment verification latency over time",
+      "description": "DHT lookup latency percentiles",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1034,11 +972,11 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 6,
-        "x": 18,
-        "y": 16
+        "w": 18,
+        "x": 6,
+        "y": 25
       },
-      "id": 24,
+      "id": 32,
       "options": {
         "legend": {
           "calcs": ["mean", "max"],
@@ -1058,7 +996,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(saorsa_payment_verification_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
+          "expr": "histogram_quantile(0.50, sum(rate(ant_dht_lookup_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
           "legendFormat": "P50",
           "refId": "A"
         },
@@ -1067,7 +1005,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(saorsa_payment_verification_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
+          "expr": "histogram_quantile(0.95, sum(rate(ant_dht_lookup_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
           "legendFormat": "P95",
           "refId": "B"
         },
@@ -1076,12 +1014,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(saorsa_payment_verification_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
+          "expr": "histogram_quantile(0.99, sum(rate(ant_dht_lookup_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
           "legendFormat": "P99",
           "refId": "C"
         }
       ],
-      "title": "Verification Latency",
+      "title": "Lookup Latency",
       "type": "timeseries"
     },
     {
@@ -1090,11 +1028,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 42
       },
-      "id": 30,
+      "id": 50,
       "panels": [],
-      "title": "Payment Cache Performance",
+      "title": "Data Integrity",
       "type": "row"
     },
     {
@@ -1102,7 +1040,198 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Payment cache hit ratio",
+      "description": "Data integrity check rate",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "id": 51,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ant_data_integrity_checks_total{instance=~\"$instance\"}[5m])",
+          "legendFormat": "Integrity Checks",
+          "refId": "A"
+        }
+      ],
+      "title": "Integrity Check Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Network bandwidth usage for data operations",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "id": 52,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ant_network_bandwidth_bytes_total{instance=~\"$instance\"}[5m])",
+          "legendFormat": "Bandwidth",
+          "refId": "A"
+        }
+      ],
+      "title": "Network Bandwidth",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
+      "id": 60,
+      "panels": [],
+      "title": "Replication & Placement",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Data placement success rate",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1120,11 +1249,11 @@
               },
               {
                 "color": "yellow",
-                "value": 50
+                "value": 90
               },
               {
                 "color": "green",
-                "value": 80
+                "value": 98
               }
             ]
           },
@@ -1133,12 +1262,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 8,
         "w": 6,
         "x": 0,
-        "y": 25
+        "y": 52
       },
-      "id": 31,
+      "id": 61,
       "options": {
         "orientation": "auto",
         "reduceOptions": {
@@ -1156,12 +1285,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(saorsa_payment_cache_hits{instance=~\"$instance\"} / (saorsa_payment_cache_hits{instance=~\"$instance\"} + saorsa_payment_cache_misses{instance=~\"$instance\"})) * 100",
-          "legendFormat": "Hit Ratio",
+          "expr": "(ant_placement_success_total{instance=~\"$instance\"} / ant_placement_attempts_total{instance=~\"$instance\"}) * 100",
+          "legendFormat": "Success Rate",
           "refId": "A"
         }
       ],
-      "title": "Cache Hit Ratio",
+      "title": "Placement Success Rate",
       "type": "gauge"
     },
     {
@@ -1169,66 +1298,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Current cache size",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 6,
-        "y": 25
-      },
-      "id": 32,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "saorsa_payment_cache_size{instance=~\"$instance\"}",
-          "legendFormat": "Cache Size",
-          "refId": "A"
-        }
-      ],
-      "title": "Cache Size",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Cache hits and misses over time",
+      "description": "Placement operations over time",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1280,7 +1350,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Hits"
+              "options": "Success"
             },
             "properties": [
               {
@@ -1295,13 +1365,13 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Misses"
+              "options": "Failures"
             },
             "properties": [
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "orange",
+                  "fixedColor": "red",
                   "mode": "fixed"
                 }
               }
@@ -1310,12 +1380,12 @@
         ]
       },
       "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 12,
-        "y": 25
+        "h": 8,
+        "w": 18,
+        "x": 6,
+        "y": 52
       },
-      "id": 33,
+      "id": 62,
       "options": {
         "legend": {
           "calcs": ["sum"],
@@ -1335,8 +1405,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(saorsa_payment_cache_hits{instance=~\"$instance\"}[5m])",
-          "legendFormat": "Hits",
+          "expr": "rate(ant_placement_attempts_total{instance=~\"$instance\"}[5m])",
+          "legendFormat": "Attempts",
           "refId": "A"
         },
         {
@@ -1344,558 +1414,28 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(saorsa_payment_cache_misses{instance=~\"$instance\"}[5m])",
-          "legendFormat": "Misses",
-          "refId": "B"
-        }
-      ],
-      "title": "Cache Performance",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 31
-      },
-      "id": 40,
-      "panels": [],
-      "title": "Top Earners & Storage Leaders",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Top 10 nodes by payment revenue",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Revenue"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "gauge"
-                }
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "continuous-GrYlRd"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 32
-      },
-      "id": 41,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": ["sum"],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": true,
-            "displayName": "Revenue"
-          }
-        ]
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "topk(10, saorsa_revenue_total)",
-          "format": "table",
-          "instant": true,
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Top 10 Earners",
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "__name__": true,
-              "job": true
-            },
-            "indexByName": {},
-            "renameByName": {
-              "Value": "Revenue",
-              "instance": "Node"
-            }
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Top 10 nodes by records stored",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Records"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "gauge"
-                }
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "continuous-BlYlRd"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 32
-      },
-      "id": 42,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": ["sum"],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": true,
-            "displayName": "Records"
-          }
-        ]
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "topk(10, saorsa_records_stored_total)",
-          "format": "table",
-          "instant": true,
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Top 10 Storage Leaders",
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "__name__": true,
-              "job": true
-            },
-            "indexByName": {},
-            "renameByName": {
-              "Value": "Records",
-              "instance": "Node"
-            }
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 40
-      },
-      "id": 50,
-      "panels": [],
-      "title": "EVM Integration",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "EVM payment verification calls",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 0,
-        "y": 41
-      },
-      "id": 51,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "saorsa_evm_calls_total{instance=~\"$instance\"}",
-          "legendFormat": "EVM Calls",
-          "refId": "A"
-        }
-      ],
-      "title": "EVM Calls",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "EVM call success rate",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "max": 100,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 90
-              },
-              {
-                "color": "green",
-                "value": 98
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 4,
-        "y": 41
-      },
-      "id": 52,
-      "options": {
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "(saorsa_evm_calls_success{instance=~\"$instance\"} / saorsa_evm_calls_total{instance=~\"$instance\"}) * 100",
-          "legendFormat": "Success Rate",
-          "refId": "A"
-        }
-      ],
-      "title": "EVM Success Rate",
-      "type": "gauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "EVM call latency",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 500
-              },
-              {
-                "color": "red",
-                "value": 2000
-              }
-            ]
-          },
-          "unit": "ms"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 8,
-        "y": 41
-      },
-      "id": 53,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "histogram_quantile(0.95, sum(rate(saorsa_evm_call_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
-          "legendFormat": "P95 Latency",
-          "refId": "A"
-        }
-      ],
-      "title": "EVM Latency P95",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "EVM call performance over time",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 12,
-        "y": 41
-      },
-      "id": 54,
-      "options": {
-        "legend": {
-          "calcs": ["mean", "max"],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "rate(saorsa_evm_calls_success{instance=~\"$instance\"}[5m])",
+          "expr": "rate(ant_placement_success_total{instance=~\"$instance\"}[5m])",
           "legendFormat": "Success",
-          "refId": "A"
+          "refId": "B"
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(saorsa_evm_calls_failed{instance=~\"$instance\"}[5m])",
-          "legendFormat": "Failed",
-          "refId": "B"
+          "expr": "rate(ant_placement_failures_total{instance=~\"$instance\"}[5m])",
+          "legendFormat": "Failures",
+          "refId": "C"
         }
       ],
-      "title": "EVM Call Rate",
+      "title": "Placement Operations",
       "type": "timeseries"
     }
   ],
   "refresh": "30s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["saorsa", "payments", "revenue"],
+  "tags": ["ant", "data", "storage"],
   "templating": {
     "list": [
       {
@@ -1928,7 +1468,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(saorsa_payments_total, instance)",
+        "definition": "label_values(ant_records_stored_total, instance)",
         "hide": 0,
         "includeAll": true,
         "label": "Instance",
@@ -1936,7 +1476,7 @@
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(saorsa_payments_total, instance)",
+          "query": "label_values(ant_records_stored_total, instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -1955,8 +1495,8 @@
     "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"]
   },
   "timezone": "browser",
-  "title": "Saorsa Payments Dashboard",
-  "uid": "saorsa-payments",
+  "title": "Autonomi Data Operations",
+  "uid": "ant-data-operations",
   "version": 1,
   "weekStart": ""
 }

--- a/deploy/monitoring/grafana-ant-metrics.json
+++ b/deploy/monitoring/grafana-ant-metrics.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Complete inventory of all 60+ Prometheus metrics from saorsa-core and saorsa-node",
+  "description": "Complete inventory of all 60+ Prometheus metrics from saorsa-core and ant-node",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -26,9 +26,9 @@
       "icon": "external link",
       "includeVars": true,
       "keepTime": true,
-      "tags": ["saorsa"],
+      "tags": ["ant"],
       "targetBlank": true,
-      "title": "Saorsa Dashboards",
+      "title": "Autonomi Dashboards",
       "type": "dashboards"
     }
   ],
@@ -102,7 +102,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_security_sybil_attacks_detected_total{instance=~\"$instance\"}",
+          "expr": "ant_security_sybil_attacks_detected_total{instance=~\"$instance\"}",
           "legendFormat": "sybil_attacks_detected",
           "refId": "A"
         },
@@ -111,7 +111,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_security_nodes_blacklisted_total{instance=~\"$instance\"}",
+          "expr": "ant_security_nodes_blacklisted_total{instance=~\"$instance\"}",
           "legendFormat": "nodes_blacklisted",
           "refId": "B"
         },
@@ -120,7 +120,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_security_invalid_signatures_total{instance=~\"$instance\"}",
+          "expr": "ant_security_invalid_signatures_total{instance=~\"$instance\"}",
           "legendFormat": "invalid_signatures",
           "refId": "C"
         },
@@ -129,7 +129,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_security_eclipse_attacks_detected_total{instance=~\"$instance\"}",
+          "expr": "ant_security_eclipse_attacks_detected_total{instance=~\"$instance\"}",
           "legendFormat": "eclipse_attacks_detected",
           "refId": "D"
         },
@@ -138,7 +138,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_ip_diversity_rejections_total{instance=~\"$instance\"}",
+          "expr": "ant_ip_diversity_rejections_total{instance=~\"$instance\"}",
           "legendFormat": "ip_diversity_rejections (0.7.5)",
           "refId": "E"
         },
@@ -147,7 +147,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_geographic_diversity_rejections_total{instance=~\"$instance\"}",
+          "expr": "ant_geographic_diversity_rejections_total{instance=~\"$instance\"}",
           "legendFormat": "geographic_diversity_rejections (0.7.5)",
           "refId": "F"
         },
@@ -156,7 +156,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_trust_threshold_violations_total{instance=~\"$instance\"}",
+          "expr": "ant_trust_threshold_violations_total{instance=~\"$instance\"}",
           "legendFormat": "trust_threshold_violations (0.7.6)",
           "refId": "G"
         }
@@ -266,7 +266,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(saorsa_security_sybil_attacks_detected_total{instance=~\"$instance\"}[5m])",
+          "expr": "rate(ant_security_sybil_attacks_detected_total{instance=~\"$instance\"}[5m])",
           "legendFormat": "Sybil Attacks",
           "refId": "A"
         },
@@ -275,7 +275,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(saorsa_security_nodes_blacklisted_total{instance=~\"$instance\"}[5m])",
+          "expr": "rate(ant_security_nodes_blacklisted_total{instance=~\"$instance\"}[5m])",
           "legendFormat": "Blacklisted",
           "refId": "B"
         },
@@ -284,7 +284,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(saorsa_ip_diversity_rejections_total{instance=~\"$instance\"}[5m])",
+          "expr": "rate(ant_ip_diversity_rejections_total{instance=~\"$instance\"}[5m])",
           "legendFormat": "IP Diversity Reject",
           "refId": "C"
         }
@@ -360,7 +360,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_dht_routing_table_size{instance=~\"$instance\"}",
+          "expr": "ant_dht_routing_table_size{instance=~\"$instance\"}",
           "legendFormat": "routing_table_size",
           "refId": "A"
         },
@@ -369,7 +369,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_dht_lookups_total{instance=~\"$instance\"}",
+          "expr": "ant_dht_lookups_total{instance=~\"$instance\"}",
           "legendFormat": "lookups_total",
           "refId": "B"
         },
@@ -378,7 +378,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_dht_lookup_success_total{instance=~\"$instance\"}",
+          "expr": "ant_dht_lookup_success_total{instance=~\"$instance\"}",
           "legendFormat": "lookup_success_total",
           "refId": "C"
         },
@@ -387,7 +387,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_dht_stores_total{instance=~\"$instance\"}",
+          "expr": "ant_dht_stores_total{instance=~\"$instance\"}",
           "legendFormat": "stores_total",
           "refId": "D"
         },
@@ -396,7 +396,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_dht_store_success_total{instance=~\"$instance\"}",
+          "expr": "ant_dht_store_success_total{instance=~\"$instance\"}",
           "legendFormat": "store_success_total",
           "refId": "E"
         },
@@ -405,7 +405,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_dht_messages_sent_total{instance=~\"$instance\"}",
+          "expr": "ant_dht_messages_sent_total{instance=~\"$instance\"}",
           "legendFormat": "messages_sent_total",
           "refId": "F"
         },
@@ -414,7 +414,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_dht_messages_received_total{instance=~\"$instance\"}",
+          "expr": "ant_dht_messages_received_total{instance=~\"$instance\"}",
           "legendFormat": "messages_received_total",
           "refId": "G"
         },
@@ -423,7 +423,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_dht_kbuckets_count{instance=~\"$instance\"}",
+          "expr": "ant_dht_kbuckets_count{instance=~\"$instance\"}",
           "legendFormat": "kbuckets_count",
           "refId": "H"
         },
@@ -432,7 +432,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_close_group_failure_by_type{instance=~\"$instance\"}",
+          "expr": "ant_close_group_failure_by_type{instance=~\"$instance\"}",
           "legendFormat": "close_group_failure (0.7.6)",
           "refId": "I"
         }
@@ -542,7 +542,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(saorsa_dht_lookups_total{instance=~\"$instance\"}[5m])",
+          "expr": "rate(ant_dht_lookups_total{instance=~\"$instance\"}[5m])",
           "legendFormat": "Lookups",
           "refId": "A"
         },
@@ -551,7 +551,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(saorsa_dht_stores_total{instance=~\"$instance\"}[5m])",
+          "expr": "rate(ant_dht_stores_total{instance=~\"$instance\"}[5m])",
           "legendFormat": "Stores",
           "refId": "B"
         },
@@ -560,7 +560,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(saorsa_dht_messages_sent_total{instance=~\"$instance\"}[5m])",
+          "expr": "rate(ant_dht_messages_sent_total{instance=~\"$instance\"}[5m])",
           "legendFormat": "Messages Sent",
           "refId": "C"
         },
@@ -569,7 +569,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(saorsa_dht_messages_received_total{instance=~\"$instance\"}[5m])",
+          "expr": "rate(ant_dht_messages_received_total{instance=~\"$instance\"}[5m])",
           "legendFormat": "Messages Received",
           "refId": "D"
         }
@@ -645,7 +645,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_trust_score_average{instance=~\"$instance\"}",
+          "expr": "ant_trust_score_average{instance=~\"$instance\"}",
           "legendFormat": "trust_score_average",
           "refId": "A"
         },
@@ -654,7 +654,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_trust_promotions_total{instance=~\"$instance\"}",
+          "expr": "ant_trust_promotions_total{instance=~\"$instance\"}",
           "legendFormat": "trust_promotions_total",
           "refId": "B"
         },
@@ -663,7 +663,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_trust_demotions_total{instance=~\"$instance\"}",
+          "expr": "ant_trust_demotions_total{instance=~\"$instance\"}",
           "legendFormat": "trust_demotions_total",
           "refId": "C"
         },
@@ -672,7 +672,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_trust_level_changes_total{instance=~\"$instance\"}",
+          "expr": "ant_trust_level_changes_total{instance=~\"$instance\"}",
           "legendFormat": "trust_level_changes_total",
           "refId": "D"
         },
@@ -681,7 +681,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_low_trust_nodes_current{instance=~\"$instance\"}",
+          "expr": "ant_low_trust_nodes_current{instance=~\"$instance\"}",
           "legendFormat": "low_trust_nodes_current (0.7.6)",
           "refId": "E"
         },
@@ -690,7 +690,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_enforcement_mode_strict{instance=~\"$instance\"}",
+          "expr": "ant_enforcement_mode_strict{instance=~\"$instance\"}",
           "legendFormat": "enforcement_mode_strict (0.7.6)",
           "refId": "F"
         },
@@ -699,7 +699,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_eviction_by_reason{instance=~\"$instance\"}",
+          "expr": "ant_eviction_by_reason{instance=~\"$instance\"}",
           "legendFormat": "eviction_by_reason (0.7.6)",
           "refId": "G"
         }
@@ -809,7 +809,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_trust_score_average{instance=~\"$instance\"}",
+          "expr": "ant_trust_score_average{instance=~\"$instance\"}",
           "legendFormat": "Average Score",
           "refId": "A"
         },
@@ -818,7 +818,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_low_trust_nodes_current{instance=~\"$instance\"}",
+          "expr": "ant_low_trust_nodes_current{instance=~\"$instance\"}",
           "legendFormat": "Low Trust Nodes",
           "refId": "B"
         },
@@ -827,7 +827,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(saorsa_trust_promotions_total{instance=~\"$instance\"}[5m])",
+          "expr": "rate(ant_trust_promotions_total{instance=~\"$instance\"}[5m])",
           "legendFormat": "Promotions/s",
           "refId": "C"
         },
@@ -836,7 +836,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(saorsa_trust_demotions_total{instance=~\"$instance\"}[5m])",
+          "expr": "rate(ant_trust_demotions_total{instance=~\"$instance\"}[5m])",
           "legendFormat": "Demotions/s",
           "refId": "D"
         }
@@ -912,7 +912,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_placement_attempts_total{instance=~\"$instance\"}",
+          "expr": "ant_placement_attempts_total{instance=~\"$instance\"}",
           "legendFormat": "placement_attempts_total",
           "refId": "A"
         },
@@ -921,7 +921,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_placement_success_total{instance=~\"$instance\"}",
+          "expr": "ant_placement_success_total{instance=~\"$instance\"}",
           "legendFormat": "placement_success_total",
           "refId": "B"
         },
@@ -930,7 +930,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_placement_failures_total{instance=~\"$instance\"}",
+          "expr": "ant_placement_failures_total{instance=~\"$instance\"}",
           "legendFormat": "placement_failures_total",
           "refId": "C"
         },
@@ -939,7 +939,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_connected_peers{instance=~\"$instance\"}",
+          "expr": "ant_connected_peers{instance=~\"$instance\"}",
           "legendFormat": "connected_peers",
           "refId": "D"
         },
@@ -948,7 +948,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_nodes_per_region{instance=~\"$instance\"}",
+          "expr": "ant_nodes_per_region{instance=~\"$instance\"}",
           "legendFormat": "nodes_per_region (0.7.5)",
           "refId": "E"
         },
@@ -957,7 +957,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_network_bandwidth_bytes_total{instance=~\"$instance\"}",
+          "expr": "ant_network_bandwidth_bytes_total{instance=~\"$instance\"}",
           "legendFormat": "network_bandwidth_bytes",
           "refId": "F"
         }
@@ -1040,7 +1040,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_nodes_per_region{instance=~\"$instance\"}",
+          "expr": "ant_nodes_per_region{instance=~\"$instance\"}",
           "legendFormat": "{{region}}",
           "refId": "A"
         }
@@ -1116,7 +1116,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_records_stored_total{instance=~\"$instance\"}",
+          "expr": "ant_records_stored_total{instance=~\"$instance\"}",
           "legendFormat": "records_stored_total",
           "refId": "A"
         },
@@ -1125,7 +1125,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_records_retrieved_total{instance=~\"$instance\"}",
+          "expr": "ant_records_retrieved_total{instance=~\"$instance\"}",
           "legendFormat": "records_retrieved_total",
           "refId": "B"
         },
@@ -1134,7 +1134,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_storage_bytes_used{instance=~\"$instance\"}",
+          "expr": "ant_storage_bytes_used{instance=~\"$instance\"}",
           "legendFormat": "storage_bytes_used",
           "refId": "C"
         },
@@ -1143,7 +1143,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_storage_capacity_bytes{instance=~\"$instance\"}",
+          "expr": "ant_storage_capacity_bytes{instance=~\"$instance\"}",
           "legendFormat": "storage_capacity_bytes",
           "refId": "D"
         },
@@ -1152,7 +1152,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_replication_factor{instance=~\"$instance\"}",
+          "expr": "ant_replication_factor{instance=~\"$instance\"}",
           "legendFormat": "replication_factor",
           "refId": "E"
         },
@@ -1161,7 +1161,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_data_integrity_checks_total{instance=~\"$instance\"}",
+          "expr": "ant_data_integrity_checks_total{instance=~\"$instance\"}",
           "legendFormat": "data_integrity_checks_total",
           "refId": "F"
         }
@@ -1249,7 +1249,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(saorsa_storage_bytes_used{instance=~\"$instance\"} / saorsa_storage_capacity_bytes{instance=~\"$instance\"}) * 100",
+          "expr": "(ant_storage_bytes_used{instance=~\"$instance\"} / ant_storage_capacity_bytes{instance=~\"$instance\"}) * 100",
           "legendFormat": "Storage Used %",
           "refId": "A"
         }
@@ -1351,7 +1351,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(saorsa_dht_lookup_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
+          "expr": "histogram_quantile(0.95, sum(rate(ant_dht_lookup_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
           "legendFormat": "DHT Lookup P95",
           "refId": "A"
         },
@@ -1360,7 +1360,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(saorsa_dht_store_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
+          "expr": "histogram_quantile(0.95, sum(rate(ant_dht_store_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
           "legendFormat": "DHT Store P95",
           "refId": "B"
         },
@@ -1369,7 +1369,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(saorsa_quote_generation_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
+          "expr": "histogram_quantile(0.95, sum(rate(ant_quote_generation_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
           "legendFormat": "Quote Generation P95",
           "refId": "C"
         },
@@ -1378,7 +1378,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(saorsa_payment_verification_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
+          "expr": "histogram_quantile(0.95, sum(rate(ant_payment_verification_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
           "legendFormat": "Payment Verification P95",
           "refId": "D"
         },
@@ -1387,7 +1387,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(saorsa_evm_call_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
+          "expr": "histogram_quantile(0.95, sum(rate(ant_evm_call_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
           "legendFormat": "EVM Call P95",
           "refId": "E"
         }
@@ -1463,7 +1463,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_uptime_seconds{instance=~\"$instance\"}",
+          "expr": "ant_uptime_seconds{instance=~\"$instance\"}",
           "legendFormat": "uptime_seconds",
           "refId": "A"
         },
@@ -1472,7 +1472,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_node_version{instance=~\"$instance\"}",
+          "expr": "ant_node_version{instance=~\"$instance\"}",
           "legendFormat": "node_version",
           "refId": "B"
         },
@@ -1481,7 +1481,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_bootstrap_attempts_total{instance=~\"$instance\"}",
+          "expr": "ant_bootstrap_attempts_total{instance=~\"$instance\"}",
           "legendFormat": "bootstrap_attempts_total",
           "refId": "C"
         },
@@ -1490,7 +1490,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_bootstrap_success_total{instance=~\"$instance\"}",
+          "expr": "ant_bootstrap_success_total{instance=~\"$instance\"}",
           "legendFormat": "bootstrap_success_total",
           "refId": "D"
         },
@@ -1656,7 +1656,7 @@
   "refresh": "30s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["saorsa", "metrics", "inventory"],
+  "tags": ["ant", "metrics", "inventory"],
   "templating": {
     "list": [
       {
@@ -1689,7 +1689,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(saorsa_uptime_seconds, instance)",
+        "definition": "label_values(ant_uptime_seconds, instance)",
         "hide": 0,
         "includeAll": true,
         "label": "Instance",
@@ -1697,7 +1697,7 @@
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(saorsa_uptime_seconds, instance)",
+          "query": "label_values(ant_uptime_seconds, instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -1716,8 +1716,8 @@
     "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"]
   },
   "timezone": "browser",
-  "title": "Saorsa Metrics Inventory",
-  "uid": "saorsa-metrics-inventory",
+  "title": "Autonomi Metrics Inventory",
+  "uid": "ant-metrics-inventory",
   "version": 1,
   "weekStart": ""
 }

--- a/deploy/monitoring/grafana-ant-payments.json
+++ b/deploy/monitoring/grafana-ant-payments.json
@@ -15,7 +15,6 @@
       }
     ]
   },
-  "description": "Data operations, storage, replication, and integrity monitoring for Saorsa nodes",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -26,9 +25,9 @@
       "icon": "external link",
       "includeVars": true,
       "keepTime": true,
-      "tags": ["saorsa"],
+      "tags": ["ant"],
       "targetBlank": true,
-      "title": "Saorsa Dashboards",
+      "title": "Autonomi Dashboards",
       "type": "dashboards"
     }
   ],
@@ -44,7 +43,7 @@
       },
       "id": 1,
       "panels": [],
-      "title": "Data Overview",
+      "title": "Payment Overview",
       "type": "row"
     },
     {
@@ -52,7 +51,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Total records stored on this node",
+      "description": "Total payments processed by this node",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -68,7 +67,7 @@
               },
               {
                 "color": "green",
-                "value": 1000
+                "value": 100
               }
             ]
           },
@@ -102,12 +101,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_records_stored_total{instance=~\"$instance\"}",
-          "legendFormat": "Records",
+          "expr": "ant_payments_total{instance=~\"$instance\"}",
+          "legendFormat": "Total Payments",
           "refId": "A"
         }
       ],
-      "title": "Total Records",
+      "title": "Total Payments",
       "type": "stat"
     },
     {
@@ -115,7 +114,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Total records retrieved from this node",
+      "description": "Total payment quotes generated",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -131,7 +130,7 @@
               },
               {
                 "color": "green",
-                "value": 100
+                "value": 50
               }
             ]
           },
@@ -165,12 +164,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_records_retrieved_total{instance=~\"$instance\"}",
-          "legendFormat": "Retrieved",
+          "expr": "ant_quotes_generated_total{instance=~\"$instance\"}",
+          "legendFormat": "Quotes Generated",
           "refId": "A"
         }
       ],
-      "title": "Records Retrieved",
+      "title": "Quotes Generated",
       "type": "stat"
     },
     {
@@ -178,7 +177,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Current storage usage",
+      "description": "Total records stored after payment verification",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -191,10 +190,14 @@
               {
                 "color": "blue",
                 "value": null
+              },
+              {
+                "color": "green",
+                "value": 100
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "short"
         },
         "overrides": []
       },
@@ -224,12 +227,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_storage_bytes_used{instance=~\"$instance\"}",
-          "legendFormat": "Used",
+          "expr": "ant_records_stored_total{instance=~\"$instance\"}",
+          "legendFormat": "Records Stored",
           "refId": "A"
         }
       ],
-      "title": "Storage Used",
+      "title": "Records Stored",
       "type": "stat"
     },
     {
@@ -237,7 +240,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Total storage capacity",
+      "description": "Total revenue earned from storage payments",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -248,12 +251,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "blue",
+                "color": "orange",
                 "value": null
+              },
+              {
+                "color": "green",
+                "value": 1000
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "currencyUSD"
         },
         "overrides": []
       },
@@ -264,132 +271,6 @@
         "y": 1
       },
       "id": 5,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "saorsa_storage_capacity_bytes{instance=~\"$instance\"}",
-          "legendFormat": "Capacity",
-          "refId": "A"
-        }
-      ],
-      "title": "Storage Capacity",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Current replication factor",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 2
-              },
-              {
-                "color": "green",
-                "value": 3
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 4,
-        "x": 16,
-        "y": 1
-      },
-      "id": 6,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "saorsa_replication_factor{instance=~\"$instance\"}",
-          "legendFormat": "Factor",
-          "refId": "A"
-        }
-      ],
-      "title": "Replication Factor",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Data integrity checks performed",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 4,
-        "x": 20,
-        "y": 1
-      },
-      "id": 7,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -409,12 +290,138 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_data_integrity_checks_total{instance=~\"$instance\"}",
-          "legendFormat": "Checks",
+          "expr": "ant_revenue_total{instance=~\"$instance\"}",
+          "legendFormat": "Total Revenue",
           "refId": "A"
         }
       ],
-      "title": "Integrity Checks",
+      "title": "Total Revenue",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current network size (connected peers)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "green",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ant_connected_peers{instance=~\"$instance\"}",
+          "legendFormat": "Connected Peers",
+          "refId": "A"
+        }
+      ],
+      "title": "Network Size",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Node uptime",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ant_uptime_seconds{instance=~\"$instance\"}",
+          "legendFormat": "Uptime",
+          "refId": "A"
+        }
+      ],
+      "title": "Live Time",
       "type": "stat"
     },
     {
@@ -427,7 +434,7 @@
       },
       "id": 10,
       "panels": [],
-      "title": "Storage Utilization",
+      "title": "Payment Rates & Trends",
       "type": "row"
     },
     {
@@ -435,74 +442,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Storage utilization percentage",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "max": 100,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 70
-              },
-              {
-                "color": "red",
-                "value": 90
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 0,
-        "y": 7
-      },
-      "id": 11,
-      "options": {
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "(saorsa_storage_bytes_used{instance=~\"$instance\"} / saorsa_storage_capacity_bytes{instance=~\"$instance\"}) * 100",
-          "legendFormat": "Utilization",
-          "refId": "A"
-        }
-      ],
-      "title": "Storage Utilization",
-      "type": "gauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Storage usage over time",
+      "description": "Payment processing rate over time",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -528,7 +468,7 @@
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "never",
+            "showPoints": "auto",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -548,14 +488,103 @@
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "ops"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
-        "w": 18,
-        "x": 6,
+        "w": 8,
+        "x": 0,
+        "y": 7
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ant_payments_total{instance=~\"$instance\"}[5m]) * 3600",
+          "legendFormat": "Payments/Hour",
+          "refId": "A"
+        }
+      ],
+      "title": "Payment Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Quote generation rate over time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
         "y": 7
       },
       "id": 12,
@@ -578,42 +607,20 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "saorsa_storage_bytes_used{instance=~\"$instance\"}",
-          "legendFormat": "Used",
+          "expr": "rate(ant_quotes_generated_total{instance=~\"$instance\"}[5m]) * 3600",
+          "legendFormat": "Quotes/Hour",
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "saorsa_storage_capacity_bytes{instance=~\"$instance\"}",
-          "legendFormat": "Capacity",
-          "refId": "B"
         }
       ],
-      "title": "Storage Over Time",
+      "title": "Quote Generation Rate",
       "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 15
-      },
-      "id": 20,
-      "panels": [],
-      "title": "Data Operations",
-      "type": "row"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Store and retrieve operations over time",
+      "description": "Storage rate over time",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -639,136 +646,7 @@
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "ops"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Stores"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Retrievals"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 16
-      },
-      "id": 21,
-      "options": {
-        "legend": {
-          "calcs": ["mean", "sum"],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "rate(saorsa_records_stored_total{instance=~\"$instance\"}[5m])",
-          "legendFormat": "Stores",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "rate(saorsa_records_retrieved_total{instance=~\"$instance\"}[5m])",
-          "legendFormat": "Retrievals",
-          "refId": "B"
-        }
-      ],
-      "title": "Store/Retrieve Rate",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "DHT store operations",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
+            "showPoints": "auto",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -794,14 +672,14 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 16
+        "w": 8,
+        "x": 16,
+        "y": 7
       },
-      "id": 22,
+      "id": 13,
       "options": {
         "legend": {
-          "calcs": ["mean", "sum"],
+          "calcs": ["mean", "max"],
           "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
@@ -818,21 +696,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(saorsa_dht_stores_total{instance=~\"$instance\"}[5m])",
-          "legendFormat": "DHT Stores",
+          "expr": "rate(ant_records_stored_total{instance=~\"$instance\"}[5m]) * 3600",
+          "legendFormat": "Records/Hour",
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "rate(saorsa_dht_store_success_total{instance=~\"$instance\"}[5m])",
-          "legendFormat": "DHT Store Success",
-          "refId": "B"
         }
       ],
-      "title": "DHT Store Operations",
+      "title": "Storage Rate",
       "type": "timeseries"
     },
     {
@@ -841,11 +710,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 15
       },
-      "id": 30,
+      "id": 20,
       "panels": [],
-      "title": "DHT Lookups",
+      "title": "Payment Verification",
       "type": "row"
     },
     {
@@ -853,7 +722,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "DHT lookup success rate",
+      "description": "Payment verification success rate",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -887,9 +756,9 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 25
+        "y": 16
       },
-      "id": 31,
+      "id": 21,
       "options": {
         "orientation": "auto",
         "reduceOptions": {
@@ -907,12 +776,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(saorsa_dht_lookup_success_total{instance=~\"$instance\"} / saorsa_dht_lookups_total{instance=~\"$instance\"}) * 100",
+          "expr": "(ant_payment_verifications_success{instance=~\"$instance\"} / (ant_payment_verifications_success{instance=~\"$instance\"} + ant_payment_verifications_failed{instance=~\"$instance\"})) * 100",
           "legendFormat": "Success Rate",
           "refId": "A"
         }
       ],
-      "title": "Lookup Success Rate",
+      "title": "Verification Success Rate",
       "type": "gauge"
     },
     {
@@ -920,7 +789,200 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "DHT lookup latency percentiles",
+      "description": "Quote generation latency (P95)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 100
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 16
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(ant_quote_generation_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
+          "legendFormat": "P95 Latency",
+          "refId": "A"
+        }
+      ],
+      "title": "Quote Generation P95",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Payment verification status breakdown",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Success"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Pending"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 16
+      },
+      "id": 23,
+      "options": {
+        "displayLabels": ["name", "percent"],
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ant_payment_verifications_success{instance=~\"$instance\"}",
+          "legendFormat": "Success",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ant_payment_verifications_failed{instance=~\"$instance\"}",
+          "legendFormat": "Failed",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ant_payment_verifications_pending{instance=~\"$instance\"}",
+          "legendFormat": "Pending",
+          "refId": "C"
+        }
+      ],
+      "title": "Verification Status",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Payment verification latency over time",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -972,11 +1034,11 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 18,
-        "x": 6,
-        "y": 25
+        "w": 6,
+        "x": 18,
+        "y": 16
       },
-      "id": 32,
+      "id": 24,
       "options": {
         "legend": {
           "calcs": ["mean", "max"],
@@ -996,7 +1058,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(saorsa_dht_lookup_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
+          "expr": "histogram_quantile(0.50, sum(rate(ant_payment_verification_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
           "legendFormat": "P50",
           "refId": "A"
         },
@@ -1005,7 +1067,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(saorsa_dht_lookup_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
+          "expr": "histogram_quantile(0.95, sum(rate(ant_payment_verification_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
           "legendFormat": "P95",
           "refId": "B"
         },
@@ -1014,12 +1076,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(saorsa_dht_lookup_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
+          "expr": "histogram_quantile(0.99, sum(rate(ant_payment_verification_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
           "legendFormat": "P99",
           "refId": "C"
         }
       ],
-      "title": "Lookup Latency",
+      "title": "Verification Latency",
       "type": "timeseries"
     },
     {
@@ -1028,11 +1090,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 24
       },
-      "id": 50,
+      "id": 30,
       "panels": [],
-      "title": "Data Integrity",
+      "title": "Payment Cache Performance",
       "type": "row"
     },
     {
@@ -1040,198 +1102,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Data integrity check rate",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 43
-      },
-      "id": 51,
-      "options": {
-        "legend": {
-          "calcs": ["mean", "sum"],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "rate(saorsa_data_integrity_checks_total{instance=~\"$instance\"}[5m])",
-          "legendFormat": "Integrity Checks",
-          "refId": "A"
-        }
-      ],
-      "title": "Integrity Check Rate",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Network bandwidth usage for data operations",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "Bps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 43
-      },
-      "id": 52,
-      "options": {
-        "legend": {
-          "calcs": ["mean", "max"],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "rate(saorsa_network_bandwidth_bytes_total{instance=~\"$instance\"}[5m])",
-          "legendFormat": "Bandwidth",
-          "refId": "A"
-        }
-      ],
-      "title": "Network Bandwidth",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 51
-      },
-      "id": 60,
-      "panels": [],
-      "title": "Replication & Placement",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Data placement success rate",
+      "description": "Payment cache hit ratio",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1249,11 +1120,11 @@
               },
               {
                 "color": "yellow",
-                "value": 90
+                "value": 50
               },
               {
                 "color": "green",
-                "value": 98
+                "value": 80
               }
             ]
           },
@@ -1262,12 +1133,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 6,
         "w": 6,
         "x": 0,
-        "y": 52
+        "y": 25
       },
-      "id": 61,
+      "id": 31,
       "options": {
         "orientation": "auto",
         "reduceOptions": {
@@ -1285,12 +1156,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(saorsa_placement_success_total{instance=~\"$instance\"} / saorsa_placement_attempts_total{instance=~\"$instance\"}) * 100",
-          "legendFormat": "Success Rate",
+          "expr": "(ant_payment_cache_hits{instance=~\"$instance\"} / (ant_payment_cache_hits{instance=~\"$instance\"} + ant_payment_cache_misses{instance=~\"$instance\"})) * 100",
+          "legendFormat": "Hit Ratio",
           "refId": "A"
         }
       ],
-      "title": "Placement Success Rate",
+      "title": "Cache Hit Ratio",
       "type": "gauge"
     },
     {
@@ -1298,7 +1169,66 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Placement operations over time",
+      "description": "Current cache size",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 25
+      },
+      "id": 32,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ant_payment_cache_size{instance=~\"$instance\"}",
+          "legendFormat": "Cache Size",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Size",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Cache hits and misses over time",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1350,7 +1280,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Success"
+              "options": "Hits"
             },
             "properties": [
               {
@@ -1365,13 +1295,13 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Failures"
+              "options": "Misses"
             },
             "properties": [
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "red",
+                  "fixedColor": "orange",
                   "mode": "fixed"
                 }
               }
@@ -1380,12 +1310,12 @@
         ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 18,
-        "x": 6,
-        "y": 52
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 25
       },
-      "id": 62,
+      "id": 33,
       "options": {
         "legend": {
           "calcs": ["sum"],
@@ -1405,8 +1335,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(saorsa_placement_attempts_total{instance=~\"$instance\"}[5m])",
-          "legendFormat": "Attempts",
+          "expr": "rate(ant_payment_cache_hits{instance=~\"$instance\"}[5m])",
+          "legendFormat": "Hits",
           "refId": "A"
         },
         {
@@ -1414,28 +1344,558 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(saorsa_placement_success_total{instance=~\"$instance\"}[5m])",
-          "legendFormat": "Success",
+          "expr": "rate(ant_payment_cache_misses{instance=~\"$instance\"}[5m])",
+          "legendFormat": "Misses",
           "refId": "B"
+        }
+      ],
+      "title": "Cache Performance",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 40,
+      "panels": [],
+      "title": "Top Earners & Storage Leaders",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Top 10 nodes by payment revenue",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Revenue"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-GrYlRd"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 41,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Revenue"
+          }
+        ]
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, ant_revenue_total)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 Earners",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Revenue",
+              "instance": "Node"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Top 10 nodes by records stored",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Records"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-BlYlRd"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 42,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Records"
+          }
+        ]
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, ant_records_stored_total)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 Storage Leaders",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Records",
+              "instance": "Node"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 50,
+      "panels": [],
+      "title": "EVM Integration",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "EVM payment verification calls",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 41
+      },
+      "id": 51,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ant_evm_calls_total{instance=~\"$instance\"}",
+          "legendFormat": "EVM Calls",
+          "refId": "A"
+        }
+      ],
+      "title": "EVM Calls",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "EVM call success rate",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 90
+              },
+              {
+                "color": "green",
+                "value": 98
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 41
+      },
+      "id": 52,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "(ant_evm_calls_success{instance=~\"$instance\"} / ant_evm_calls_total{instance=~\"$instance\"}) * 100",
+          "legendFormat": "Success Rate",
+          "refId": "A"
+        }
+      ],
+      "title": "EVM Success Rate",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "EVM call latency",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 500
+              },
+              {
+                "color": "red",
+                "value": 2000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 8,
+        "y": 41
+      },
+      "id": 53,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(ant_evm_call_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)) * 1000",
+          "legendFormat": "P95 Latency",
+          "refId": "A"
+        }
+      ],
+      "title": "EVM Latency P95",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "EVM call performance over time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 41
+      },
+      "id": 54,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ant_evm_calls_success{instance=~\"$instance\"}[5m])",
+          "legendFormat": "Success",
+          "refId": "A"
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(saorsa_placement_failures_total{instance=~\"$instance\"}[5m])",
-          "legendFormat": "Failures",
-          "refId": "C"
+          "expr": "rate(ant_evm_calls_failed{instance=~\"$instance\"}[5m])",
+          "legendFormat": "Failed",
+          "refId": "B"
         }
       ],
-      "title": "Placement Operations",
+      "title": "EVM Call Rate",
       "type": "timeseries"
     }
   ],
   "refresh": "30s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["saorsa", "data", "storage"],
+  "tags": ["ant", "payments", "revenue"],
   "templating": {
     "list": [
       {
@@ -1468,7 +1928,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(saorsa_records_stored_total, instance)",
+        "definition": "label_values(ant_payments_total, instance)",
         "hide": 0,
         "includeAll": true,
         "label": "Instance",
@@ -1476,7 +1936,7 @@
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(saorsa_records_stored_total, instance)",
+          "query": "label_values(ant_payments_total, instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -1495,8 +1955,8 @@
     "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"]
   },
   "timezone": "browser",
-  "title": "Saorsa Data Operations",
-  "uid": "saorsa-data-operations",
+  "title": "Autonomi Payments Dashboard",
+  "uid": "ant-payments",
   "version": 1,
   "weekStart": ""
 }

--- a/deploy/monitoring/grafana/dashboards/ant-testnet.json
+++ b/deploy/monitoring/grafana/dashboards/ant-testnet.json
@@ -430,12 +430,12 @@
   "refresh": "30s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["saorsa", "testnet", "p2p"],
+  "tags": ["ant", "testnet", "p2p"],
   "templating": { "list": [] },
   "time": { "from": "now-1h", "to": "now" },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Saorsa Testnet Dashboard",
-  "uid": "saorsa-testnet",
+  "title": "Autonomi Testnet Dashboard",
+  "uid": "ant-testnet",
   "version": 1
 }

--- a/deploy/monitoring/prometheus/prometheus.yml
+++ b/deploy/monitoring/prometheus/prometheus.yml
@@ -1,11 +1,11 @@
-# Saorsa Testnet Prometheus Configuration
+# Autonomi Testnet Prometheus Configuration
 # Scrapes metrics from 500 nodes across 5 workers
 
 global:
   scrape_interval: 15s
   evaluation_interval: 15s
   external_labels:
-    monitor: 'saorsa-testnet'
+    monitor: 'ant-testnet'
 
 alerting:
   alertmanagers:
@@ -22,7 +22,7 @@ scrape_configs:
       - targets: ['localhost:9090']
 
   # NYC1 Worker (100 nodes)
-  - job_name: 'saorsa-nyc1'
+  - job_name: 'ant-nyc1'
     static_configs:
       - targets:
           # Ports 9100-9199 for 100 nodes
@@ -34,47 +34,47 @@ scrape_configs:
           # ... (generate full list with script)
         labels:
           region: 'nyc1'
-          worker: 'saorsa-worker-nyc1'
+          worker: 'ant-worker-nyc1'
 
   # SFO3 Worker (100 nodes)
-  - job_name: 'saorsa-sfo3'
+  - job_name: 'ant-sfo3'
     static_configs:
       - targets:
           - 'WORKER_SFO3_IP:9100'
           # ... (ports 9100-9199)
         labels:
           region: 'sfo3'
-          worker: 'saorsa-worker-sfo3'
+          worker: 'ant-worker-sfo3'
 
   # LON1 Worker (100 nodes)
-  - job_name: 'saorsa-lon1'
+  - job_name: 'ant-lon1'
     static_configs:
       - targets:
           - 'WORKER_LON1_IP:9100'
           # ... (ports 9100-9199)
         labels:
           region: 'lon1'
-          worker: 'saorsa-worker-lon1'
+          worker: 'ant-worker-lon1'
 
   # AMS3 Worker (100 nodes)
-  - job_name: 'saorsa-ams3'
+  - job_name: 'ant-ams3'
     static_configs:
       - targets:
           - 'WORKER_AMS3_IP:9100'
           # ... (ports 9100-9199)
         labels:
           region: 'ams3'
-          worker: 'saorsa-worker-ams3'
+          worker: 'ant-worker-ams3'
 
   # SGP1 Worker (100 nodes)
-  - job_name: 'saorsa-sgp1'
+  - job_name: 'ant-sgp1'
     static_configs:
       - targets:
           - 'WORKER_SGP1_IP:9100'
           # ... (ports 9100-9199)
         labels:
           region: 'sgp1'
-          worker: 'saorsa-worker-sgp1'
+          worker: 'ant-worker-sgp1'
 
 # Note: The cloud-init/monitoring.yml generates the full configuration
 # with all 100 ports per worker automatically. This file is a template.

--- a/deploy/monitoring/prometheus/rules/ant-alerts.yml
+++ b/deploy/monitoring/prometheus/rules/ant-alerts.yml
@@ -1,28 +1,28 @@
 groups:
-  - name: saorsa-node-alerts
+  - name: ant-node-alerts
     rules:
       # Node availability
-      - alert: SaorsaNodeDown
+      - alert: AntNodeDown
         expr: up == 0
         for: 2m
         labels:
           severity: critical
         annotations:
-          summary: "Saorsa node unreachable"
+          summary: "Autonomi node unreachable"
           description: "Node {{ $labels.instance }} in {{ $labels.region }} has been down for more than 2 minutes"
 
       # Health status
-      - alert: SaorsaNodeUnhealthy
+      - alert: AntNodeUnhealthy
         expr: p2p_health_status == 0
         for: 5m
         labels:
           severity: warning
         annotations:
-          summary: "Saorsa node unhealthy"
+          summary: "Autonomi node unhealthy"
           description: "Node {{ $labels.instance }} is reporting unhealthy status for more than 5 minutes"
 
       # Peer connectivity
-      - alert: SaorsaLowPeerCount
+      - alert: AntLowPeerCount
         expr: p2p_network_peer_count < 3
         for: 5m
         labels:
@@ -31,7 +31,7 @@ groups:
           summary: "Low peer count"
           description: "Node {{ $labels.instance }} has only {{ $value }} peers (minimum 3 expected)"
 
-      - alert: SaorsaNoPeers
+      - alert: AntNoPeers
         expr: p2p_network_peer_count == 0
         for: 2m
         labels:
@@ -41,7 +41,7 @@ groups:
           description: "Node {{ $labels.instance }} has no peers - potentially isolated"
 
       # DHT health
-      - alert: SaorsaLowDHTSize
+      - alert: AntLowDHTSize
         expr: p2p_dht_routing_table_size < 20
         for: 10m
         labels:
@@ -51,7 +51,7 @@ groups:
           description: "Node {{ $labels.instance }} has only {{ $value }} DHT entries (minimum 20 expected)"
 
       # Network stability
-      - alert: SaorsaHighPacketLoss
+      - alert: AntHighPacketLoss
         expr: rate(p2p_network_failed_connections_total[5m]) > 0.1
         for: 5m
         labels:
@@ -60,10 +60,10 @@ groups:
           summary: "High connection failure rate"
           description: "Node {{ $labels.instance }} is experiencing high connection failures"
 
-  - name: saorsa-cluster-alerts
+  - name: ant-cluster-alerts
     rules:
       # Cluster-wide health
-      - alert: SaorsaClusterUnhealthy
+      - alert: AntClusterUnhealthy
         expr: (sum(p2p_health_status == 1) / count(p2p_health_status)) < 0.95
         for: 5m
         labels:
@@ -73,7 +73,7 @@ groups:
           description: "Only {{ $value | humanizePercentage }} of nodes are healthy"
 
       # Regional issues
-      - alert: SaorsaRegionDegraded
+      - alert: AntRegionDegraded
         expr: (sum(p2p_health_status == 1) by (region) / count(p2p_health_status) by (region)) < 0.9
         for: 5m
         labels:
@@ -83,7 +83,7 @@ groups:
           description: "Only {{ $value | humanizePercentage }} of nodes in {{ $labels.region }} are healthy"
 
       # Network partitioning
-      - alert: SaorsaPotentialPartition
+      - alert: AntPotentialPartition
         expr: stddev(p2p_network_peer_count) > 10
         for: 10m
         labels:
@@ -92,10 +92,10 @@ groups:
           summary: "Possible network partition"
           description: "High variance in peer counts suggests potential network partition"
 
-  - name: saorsa-payment-alerts
+  - name: ant-payment-alerts
     rules:
       # Payment verification
-      - alert: SaorsaPaymentVerificationFailures
+      - alert: AntPaymentVerificationFailures
         expr: rate(payment_verification_failed_total[5m]) > 0.01
         for: 5m
         labels:
@@ -105,7 +105,7 @@ groups:
           description: "Node {{ $labels.instance }} has elevated payment verification failures"
 
       # Quote generation
-      - alert: SaorsaQuoteGenerationSlow
+      - alert: AntQuoteGenerationSlow
         expr: histogram_quantile(0.95, rate(quote_generation_duration_seconds_bucket[5m])) > 1
         for: 5m
         labels:
@@ -115,11 +115,11 @@ groups:
           description: "95th percentile quote generation time is {{ $value }}s (expected < 1s)"
 
   # NEW in 0.7.5/0.7.6: Security and Trust Alerts
-  - name: saorsa-security-alerts
+  - name: ant-security-alerts
     rules:
       # IP Diversity (NEW in 0.7.5)
-      - alert: SaorsaHighIPDiversityRejections
-        expr: rate(saorsa_ip_diversity_rejections_total[5m]) > 0.1
+      - alert: AntHighIPDiversityRejections
+        expr: rate(ant_ip_diversity_rejections_total[5m]) > 0.1
         for: 5m
         labels:
           severity: warning
@@ -128,8 +128,8 @@ groups:
           description: "Node {{ $labels.instance }} is rejecting {{ $value | humanize }}/s peers due to IP diversity enforcement"
 
       # Geographic Diversity (NEW in 0.7.5)
-      - alert: SaorsaHighGeoDiversityRejections
-        expr: rate(saorsa_geographic_diversity_rejections_total[5m]) > 0.1
+      - alert: AntHighGeoDiversityRejections
+        expr: rate(ant_geographic_diversity_rejections_total[5m]) > 0.1
         for: 5m
         labels:
           severity: warning
@@ -138,8 +138,8 @@ groups:
           description: "Node {{ $labels.instance }} is rejecting {{ $value | humanize }}/s peers due to geographic diversity enforcement"
 
       # Trust Threshold Violations (NEW in 0.7.6)
-      - alert: SaorsaTrustViolationsHigh
-        expr: rate(saorsa_trust_threshold_violations_total[5m]) > 0.05
+      - alert: AntTrustViolationsHigh
+        expr: rate(ant_trust_threshold_violations_total[5m]) > 0.05
         for: 5m
         labels:
           severity: warning
@@ -148,8 +148,8 @@ groups:
           description: "Node {{ $labels.instance }} is seeing {{ $value | humanize }}/s trust threshold violations"
 
       # Low Trust Nodes (NEW in 0.7.6)
-      - alert: SaorsaHighLowTrustNodes
-        expr: saorsa_low_trust_nodes_current > 10
+      - alert: AntHighLowTrustNodes
+        expr: ant_low_trust_nodes_current > 10
         for: 10m
         labels:
           severity: warning
@@ -158,8 +158,8 @@ groups:
           description: "Node {{ $labels.instance }} is tracking {{ $value }} low trust nodes in its routing table"
 
       # Enforcement Mode Strict (NEW in 0.7.6)
-      - alert: SaorsaStrictEnforcementActivated
-        expr: saorsa_enforcement_mode_strict == 1
+      - alert: AntStrictEnforcementActivated
+        expr: ant_enforcement_mode_strict == 1
         for: 1m
         labels:
           severity: info
@@ -168,8 +168,8 @@ groups:
           description: "Node {{ $labels.instance }} has activated strict trust enforcement mode"
 
       # Close Group Failures (NEW in 0.7.6)
-      - alert: SaorsaCloseGroupFailures
-        expr: rate(saorsa_close_group_failure_by_type[5m]) > 0.01
+      - alert: AntCloseGroupFailures
+        expr: rate(ant_close_group_failure_by_type[5m]) > 0.01
         for: 5m
         labels:
           severity: warning
@@ -178,8 +178,8 @@ groups:
           description: "Node {{ $labels.instance }} is experiencing close group failures of type {{ $labels.type }} at {{ $value | humanize }}/s"
 
       # High Eviction Rate (NEW in 0.7.6)
-      - alert: SaorsaHighEvictionRate
-        expr: sum(rate(saorsa_eviction_by_reason[5m])) by (instance) > 0.1
+      - alert: AntHighEvictionRate
+        expr: sum(rate(ant_eviction_by_reason[5m])) by (instance) > 0.1
         for: 5m
         labels:
           severity: warning

--- a/deploy/scripts/manage-nodes.sh
+++ b/deploy/scripts/manage-nodes.sh
@@ -1,47 +1,47 @@
 #!/bin/bash
-# Saorsa Node Manager - Start/stop/status for multiple nodes
+# Autonomi Node Manager - Start/stop/status for multiple nodes
 # Usage: ./manage-nodes.sh [action] [options]
 set -euo pipefail
 
 ACTION="${1:-status}"
-NODE_PATTERN="${2:-saorsa-node-*}"
+NODE_PATTERN="${2:-ant-node-*}"
 METRICS_BASE_PORT="${METRICS_BASE_PORT:-9100}"
 
 # Count nodes by matching systemd services
 get_node_count() {
     systemctl list-units --all --type=service \
-        | grep -c "saorsa-node-[0-9]" || echo "0"
+        | grep -c "ant-node-[0-9]" || echo "0"
 }
 
 # Get list of node indices
 get_node_indices() {
     systemctl list-units --all --type=service \
-        | grep "saorsa-node-[0-9]" \
-        | sed 's/.*saorsa-node-\([0-9]*\).*/\1/' \
+        | grep "ant-node-[0-9]" \
+        | sed 's/.*ant-node-\([0-9]*\).*/\1/' \
         | sort -n
 }
 
 case "$ACTION" in
     start)
-        echo "Starting all saorsa nodes..."
+        echo "Starting all ant nodes..."
         for i in $(get_node_indices); do
-            systemctl start "saorsa-node-$i" 2>/dev/null || true
+            systemctl start "ant-node-$i" 2>/dev/null || true
         done
         echo "Started $(get_node_count) nodes"
         ;;
 
     stop)
-        echo "Stopping all saorsa nodes..."
+        echo "Stopping all ant nodes..."
         for i in $(get_node_indices); do
-            systemctl stop "saorsa-node-$i" 2>/dev/null || true
+            systemctl stop "ant-node-$i" 2>/dev/null || true
         done
         echo "Stopped all nodes"
         ;;
 
     restart)
-        echo "Restarting all saorsa nodes..."
+        echo "Restarting all ant nodes..."
         for i in $(get_node_indices); do
-            systemctl restart "saorsa-node-$i" 2>/dev/null || true
+            systemctl restart "ant-node-$i" 2>/dev/null || true
             sleep 0.2  # Stagger restarts
         done
         echo "Restarted $(get_node_count) nodes"
@@ -54,7 +54,7 @@ case "$ACTION" in
         FAILED_NODES=""
 
         for i in $(get_node_indices); do
-            if systemctl is-active --quiet "saorsa-node-$i"; then
+            if systemctl is-active --quiet "ant-node-$i"; then
                 ((RUNNING++)) || true
             else
                 ((FAILED++)) || true
@@ -62,7 +62,7 @@ case "$ACTION" in
             fi
         done
 
-        echo "=== Saorsa Node Status ==="
+        echo "=== Autonomi Node Status ==="
         echo "Total nodes: $TOTAL"
         echo "Running: $RUNNING"
         echo "Failed: $FAILED"
@@ -70,7 +70,7 @@ case "$ACTION" in
             echo "Failed nodes:$FAILED_NODES"
         fi
         echo ""
-        echo "Use 'systemctl status saorsa-node-N' for individual node details"
+        echo "Use 'systemctl status ant-node-N' for individual node details"
         ;;
 
     health)
@@ -88,7 +88,7 @@ case "$ACTION" in
             else
                 ((UNHEALTHY++)) || true
                 # Get more details for unhealthy nodes
-                if systemctl is-active --quiet "saorsa-node-$i"; then
+                if systemctl is-active --quiet "ant-node-$i"; then
                     PEERS=$(curl -s --max-time 2 "http://localhost:$PORT/metrics" 2>/dev/null \
                         | grep -E "^p2p_network_peer_count" | awk '{print $2}' || echo "?")
                     echo "Node $i (port $PORT): unhealthy (peers: $PEERS)"
@@ -126,24 +126,24 @@ case "$ACTION" in
     logs)
         NODE_ID="${2:-0}"
         echo "=== Logs for node $NODE_ID ==="
-        journalctl -u "saorsa-node-$NODE_ID" -f --no-pager
+        journalctl -u "ant-node-$NODE_ID" -f --no-pager
         ;;
 
     cleanup)
-        echo "Cleaning up all saorsa nodes..."
+        echo "Cleaning up all ant nodes..."
 
         # Stop all nodes
         for i in $(get_node_indices); do
-            systemctl stop "saorsa-node-$i" 2>/dev/null || true
-            systemctl disable "saorsa-node-$i" 2>/dev/null || true
-            rm -f "/etc/systemd/system/saorsa-node-$i.service"
+            systemctl stop "ant-node-$i" 2>/dev/null || true
+            systemctl disable "ant-node-$i" 2>/dev/null || true
+            rm -f "/etc/systemd/system/ant-node-$i.service"
         done
 
         systemctl daemon-reload
 
         # Remove data directories
-        rm -rf /var/lib/saorsa/nodes
-        rm -rf /var/log/saorsa
+        rm -rf /var/lib/ant/nodes
+        rm -rf /var/log/ant
 
         echo "Cleanup complete"
         ;;

--- a/deploy/scripts/spawn-nodes.sh
+++ b/deploy/scripts/spawn-nodes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Saorsa Node Spawner - Deploy multiple nodes on a single host
+# Autonomi Node Spawner - Deploy multiple nodes on a single host
 # Usage: ./spawn-nodes.sh [count] [bootstrap1] [bootstrap2] ...
-# Env: SAORSA_VERSION=0.1.0 to download a specific version from GitHub
+# Env: ANT_VERSION=0.1.0 to download a specific version from GitHub
 set -euo pipefail
 
 # Configuration
@@ -10,11 +10,11 @@ shift || true
 BOOTSTRAP_NODES=("${@:-165.22.4.178:12000 164.92.111.156:12000}")
 
 # Directories
-BASE_DIR="/var/lib/saorsa/nodes"
-LOG_DIR="/var/log/saorsa"
-BINARY_PATH="${SAORSA_BINARY:-/usr/local/bin/saorsa-node}"
+BASE_DIR="/var/lib/ant/nodes"
+LOG_DIR="/var/log/ant"
+BINARY_PATH="${ANT_BINARY:-/usr/local/bin/ant-node}"
 METRICS_BASE_PORT="${METRICS_BASE_PORT:-9100}"
-SAORSA_VERSION="${SAORSA_VERSION:-}"
+ANT_VERSION="${ANT_VERSION:-}"
 
 # Resource limits per node
 MEMORY_LIMIT="350M"
@@ -32,22 +32,22 @@ download_binary() {
         *) echo "Unsupported architecture: $arch"; exit 1 ;;
     esac
 
-    local url="https://github.com/saorsa-labs/saorsa-node/releases/download/v${version}/saorsa-node-cli-${PLATFORM}.tar.gz"
+    local url="https://github.com/WithAutonomi/ant-node/releases/download/v${version}/ant-node-cli-${PLATFORM}.tar.gz"
 
-    echo "Downloading saorsa-node v${version} for ${PLATFORM}..."
-    curl -L -o /tmp/saorsa-node.tar.gz "$url"
+    echo "Downloading ant-node v${version} for ${PLATFORM}..."
+    curl -L -o /tmp/ant-node.tar.gz "$url"
 
     echo "Extracting..."
-    tar -xzf /tmp/saorsa-node.tar.gz -C /tmp
-    mv /tmp/saorsa-node "$BINARY_PATH"
-    mv /tmp/saorsa-keygen /usr/local/bin/saorsa-keygen 2>/dev/null || true
+    tar -xzf /tmp/ant-node.tar.gz -C /tmp
+    mv /tmp/ant-node "$BINARY_PATH"
+    mv /tmp/ant-keygen /usr/local/bin/ant-keygen 2>/dev/null || true
     chmod +x "$BINARY_PATH"
-    rm -f /tmp/saorsa-node.tar.gz
+    rm -f /tmp/ant-node.tar.gz
 
-    echo "Installed saorsa-node v${version} to $BINARY_PATH"
+    echo "Installed ant-node v${version} to $BINARY_PATH"
 }
 
-echo "=== Saorsa Multi-Node Spawner ==="
+echo "=== Autonomi Multi-Node Spawner ==="
 echo "Nodes to spawn: $NODE_COUNT"
 echo "Bootstrap nodes: ${BOOTSTRAP_NODES[*]}"
 echo "Binary: $BINARY_PATH"
@@ -55,23 +55,23 @@ echo "Base directory: $BASE_DIR"
 echo ""
 
 # Download if version specified and binary missing
-if [[ -n "$SAORSA_VERSION" ]] && [[ ! -x "$BINARY_PATH" ]]; then
-    download_binary "$SAORSA_VERSION"
+if [[ -n "$ANT_VERSION" ]] && [[ ! -x "$BINARY_PATH" ]]; then
+    download_binary "$ANT_VERSION"
 fi
 
 # Check binary exists
 if [[ ! -x "$BINARY_PATH" ]]; then
-    echo "ERROR: saorsa-node binary not found at $BINARY_PATH"
-    echo "Set SAORSA_VERSION to download, or SAORSA_BINARY to use an existing binary"
+    echo "ERROR: ant-node binary not found at $BINARY_PATH"
+    echo "Set ANT_VERSION to download, or ANT_BINARY to use an existing binary"
     exit 1
 fi
 
 # Create directories
 mkdir -p "$BASE_DIR" "$LOG_DIR"
 
-# Create saorsa user if not exists
-if ! id -u saorsa &>/dev/null; then
-    useradd -r -s /bin/false saorsa || true
+# Create ant user if not exists
+if ! id -u ant &>/dev/null; then
+    useradd -r -s /bin/false ant || true
 fi
 
 # Build bootstrap args
@@ -84,25 +84,25 @@ done
 for i in $(seq 0 $((NODE_COUNT - 1))); do
     NODE_DIR="$BASE_DIR/node-$i"
     METRICS_PORT=$((METRICS_BASE_PORT + i))
-    SERVICE_NAME="saorsa-node-$i"
+    SERVICE_NAME="ant-node-$i"
 
     echo "Creating node $i..."
 
     # Create node directory
     mkdir -p "$NODE_DIR"
-    chown saorsa:saorsa "$NODE_DIR"
+    chown ant:ant "$NODE_DIR"
 
     # Create systemd service
     cat > "/etc/systemd/system/$SERVICE_NAME.service" <<EOF
 [Unit]
-Description=Saorsa Node $i
+Description=Autonomi Node $i
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=simple
-User=saorsa
-Group=saorsa
+User=ant
+Group=ant
 ExecStart=$BINARY_PATH \\
     --root-dir $NODE_DIR \\
     --port 0 \\
@@ -152,9 +152,9 @@ echo "=== Deployment Complete ==="
 echo "Spawned $NODE_COUNT nodes"
 echo ""
 echo "Check status with:"
-echo "  systemctl status 'saorsa-node-*'"
+echo "  systemctl status 'ant-node-*'"
 echo "  ./manage-nodes.sh status"
 echo ""
 echo "View logs:"
-echo "  journalctl -u saorsa-node-0 -f"
+echo "  journalctl -u ant-node-0 -f"
 echo "  tail -f $LOG_DIR/node-0.log"

--- a/deploy/scripts/validate-network.sh
+++ b/deploy/scripts/validate-network.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# Saorsa Network Validator - Checks health of entire testnet
+# Autonomi Network Validator - Checks health of entire testnet
 # Usage: ./validate-network.sh [worker_ips_file]
 set -euo pipefail
 
-WORKERS_FILE="${1:-/etc/saorsa/workers.json}"
+WORKERS_FILE="${1:-/etc/ant/workers.json}"
 NODES_PER_WORKER="${NODES_PER_WORKER:-100}"
 METRICS_BASE_PORT="${METRICS_BASE_PORT:-9100}"
 
@@ -12,7 +12,7 @@ MIN_PEERS=3
 MIN_DHT_SIZE=20
 HEALTH_THRESHOLD=0.99  # 99% nodes healthy
 
-echo "=== Saorsa Testnet Validator ==="
+echo "=== Autonomi Testnet Validator ==="
 echo "Nodes per worker: $NODES_PER_WORKER"
 echo "Min peers: $MIN_PEERS"
 echo "Min DHT size: $MIN_DHT_SIZE"

--- a/deploy/terraform/cloud-init/monitoring.yml
+++ b/deploy/terraform/cloud-init/monitoring.yml
@@ -1,5 +1,5 @@
 #cloud-config
-# Saorsa Monitoring Server - Prometheus + Grafana
+# Autonomi Monitoring Server - Prometheus + Grafana
 
 package_update: true
 package_upgrade: true
@@ -12,7 +12,7 @@ packages:
   - docker-compose
 
 write_files:
-  - path: /etc/saorsa/workers.json
+  - path: /etc/ant/workers.json
     permissions: '0644'
     content: |
       ${worker_ips}
@@ -48,7 +48,7 @@ write_files:
             - ./grafana/dashboards:/var/lib/grafana/dashboards
             - grafana_data:/var/lib/grafana
           environment:
-            - GF_SECURITY_ADMIN_PASSWORD=saorsa-testnet
+            - GF_SECURITY_ADMIN_PASSWORD=ant-testnet
             - GF_USERS_ALLOW_SIGN_UP=false
             - GF_INSTALL_PLUGINS=grafana-piechart-panel
           restart: always
@@ -82,11 +82,11 @@ write_files:
         # Worker nodes - dynamically generated
         # WORKER_SCRAPE_CONFIGS_PLACEHOLDER
 
-  - path: /opt/monitoring/prometheus/rules/saorsa-alerts.yml
+  - path: /opt/monitoring/prometheus/rules/ant-alerts.yml
     permissions: '0644'
     content: |
       groups:
-        - name: saorsa-alerts
+        - name: ant-alerts
           rules:
             - alert: NodeDown
               expr: up == 0
@@ -94,7 +94,7 @@ write_files:
               labels:
                 severity: critical
               annotations:
-                summary: "Saorsa node down"
+                summary: "Autonomi node down"
                 description: "Node {{ $labels.instance }} has been down for more than 2 minutes"
 
             - alert: LowPeerCount
@@ -141,7 +141,7 @@ write_files:
     content: |
       apiVersion: 1
       providers:
-        - name: 'Saorsa Testnet'
+        - name: 'Autonomi Testnet'
           orgId: 1
           folder: ''
           type: file
@@ -156,7 +156,7 @@ write_files:
       #!/bin/bash
       set -euo pipefail
 
-      WORKERS_JSON="/etc/saorsa/workers.json"
+      WORKERS_JSON="/etc/ant/workers.json"
       PROMETHEUS_CONFIG="/opt/monitoring/prometheus/prometheus.yml"
       NODES_PER_WORKER=${nodes_per_worker}
       METRICS_BASE_PORT=${metrics_base_port}
@@ -180,7 +180,7 @@ write_files:
         done
 
         SCRAPE_CONFIGS="$SCRAPE_CONFIGS
-        - job_name: 'saorsa-worker-$ip'
+        - job_name: 'ant-worker-$ip'
           static_configs:
             - targets: [$TARGETS]
               labels:
@@ -211,9 +211,9 @@ runcmd:
   - /usr/local/bin/generate-prometheus-config.sh
 
   # Copy dashboard (will be provided separately)
-  # - curl -o /opt/monitoring/grafana/dashboards/saorsa-testnet.json <dashboard-url>
+  # - curl -o /opt/monitoring/grafana/dashboards/ant-testnet.json <dashboard-url>
 
   # Start monitoring stack
   - cd /opt/monitoring && docker-compose up -d
 
-final_message: "Saorsa monitoring server ready - Grafana at :3000, Prometheus at :9090"
+final_message: "Autonomi monitoring server ready - Grafana at :3000, Prometheus at :9090"

--- a/deploy/terraform/cloud-init/worker.yml
+++ b/deploy/terraform/cloud-init/worker.yml
@@ -1,5 +1,5 @@
 #cloud-config
-# Saorsa Worker Node - Runs ${nodes_per_worker} nodes
+# Autonomi Worker Node - Runs ${nodes_per_worker} nodes
 
 package_update: true
 package_upgrade: true
@@ -11,22 +11,22 @@ packages:
   - iotop
 
 write_files:
-  - path: /etc/saorsa/config.env
+  - path: /etc/ant/config.env
     permissions: '0644'
     content: |
       REGION=${region}
       NODES_PER_WORKER=${nodes_per_worker}
       METRICS_BASE_PORT=${metrics_base_port}
-      SAORSA_VERSION=${saorsa_version}
+      ANT_VERSION=${ant_version}
       BOOTSTRAP_NODES=${bootstrap_nodes}
 
-  - path: /usr/local/bin/spawn-saorsa-nodes.sh
+  - path: /usr/local/bin/spawn-ant-nodes.sh
     permissions: '0755'
     content: |
       #!/bin/bash
       set -euo pipefail
 
-      source /etc/saorsa/config.env
+      source /etc/ant/config.env
 
       ARCH=$(uname -m)
       case "$${ARCH}" in
@@ -35,24 +35,24 @@ write_files:
         *) echo "Unsupported architecture: $${ARCH}"; exit 1 ;;
       esac
 
-      ARCHIVE_URL="https://github.com/saorsa-labs/saorsa-node/releases/download/v$${SAORSA_VERSION}/saorsa-node-cli-$${PLATFORM}.tar.gz"
+      ARCHIVE_URL="https://github.com/WithAutonomi/ant-node/releases/download/v$${ANT_VERSION}/ant-node-cli-$${PLATFORM}.tar.gz"
       SIG_URL="$${ARCHIVE_URL}.sig"
-      BINARY_PATH="/usr/local/bin/saorsa-node"
-      KEYGEN_PATH="/usr/local/bin/saorsa-keygen"
+      BINARY_PATH="/usr/local/bin/ant-node"
+      KEYGEN_PATH="/usr/local/bin/ant-keygen"
 
-      echo "Downloading saorsa-node v$${SAORSA_VERSION} for $${PLATFORM}..."
+      echo "Downloading ant-node v$${ANT_VERSION} for $${PLATFORM}..."
       cd /tmp
-      curl -L -o saorsa-node.tar.gz "$${ARCHIVE_URL}"
-      curl -L -o saorsa-node.tar.gz.sig "$${SIG_URL}" || echo "No signature file (dev release)"
+      curl -L -o ant-node.tar.gz "$${ARCHIVE_URL}"
+      curl -L -o ant-node.tar.gz.sig "$${SIG_URL}" || echo "No signature file (dev release)"
 
       # Extract binaries
-      tar -xzf saorsa-node.tar.gz
-      mv saorsa-node "$${BINARY_PATH}"
-      mv saorsa-keygen "$${KEYGEN_PATH}" || true
+      tar -xzf ant-node.tar.gz
+      mv ant-node "$${BINARY_PATH}"
+      mv ant-keygen "$${KEYGEN_PATH}" || true
       chmod +x "$${BINARY_PATH}" "$${KEYGEN_PATH}" 2>/dev/null || true
-      rm -f saorsa-node.tar.gz saorsa-node.tar.gz.sig
+      rm -f ant-node.tar.gz ant-node.tar.gz.sig
 
-      echo "Installed saorsa-node v$${SAORSA_VERSION}"
+      echo "Installed ant-node v$${ANT_VERSION}"
 
       # Parse bootstrap nodes
       IFS=',' read -ra BOOTSTRAPS <<< "$${BOOTSTRAP_NODES}"
@@ -64,23 +64,23 @@ write_files:
       echo "Spawning $${NODES_PER_WORKER} nodes..."
 
       for i in $(seq 0 $(($${NODES_PER_WORKER} - 1))); do
-        NODE_DIR="/var/lib/saorsa/nodes/node-$${i}"
+        NODE_DIR="/var/lib/ant/nodes/node-$${i}"
         METRICS_PORT=$(($${METRICS_BASE_PORT} + $${i}))
-        SERVICE_NAME="saorsa-node-$${i}"
+        SERVICE_NAME="ant-node-$${i}"
 
         mkdir -p "$${NODE_DIR}"
 
         # Create systemd service
         cat > /etc/systemd/system/$${SERVICE_NAME}.service <<EOF
       [Unit]
-      Description=Saorsa Node $${i} (Region: $${REGION})
+      Description=Autonomi Node $${i} (Region: $${REGION})
       After=network-online.target
       Wants=network-online.target
 
       [Service]
       Type=simple
-      User=saorsa
-      Group=saorsa
+      User=ant
+      Group=ant
       ExecStart=$${BINARY_PATH} --root-dir $${NODE_DIR} --port 0 --metrics-port $${METRICS_PORT} $${BOOTSTRAP_ARGS}
       Restart=always
       RestartSec=10
@@ -110,32 +110,32 @@ write_files:
 
       echo "All $${NODES_PER_WORKER} nodes started successfully"
 
-  - path: /usr/local/bin/manage-saorsa-nodes.sh
+  - path: /usr/local/bin/manage-ant-nodes.sh
     permissions: '0755'
     content: |
       #!/bin/bash
       set -euo pipefail
 
-      source /etc/saorsa/config.env
+      source /etc/ant/config.env
 
       ACTION="$${1:-status}"
 
       case "$${ACTION}" in
         start)
           for i in $(seq 0 $(($${NODES_PER_WORKER} - 1))); do
-            systemctl start "saorsa-node-$${i}" || true
+            systemctl start "ant-node-$${i}" || true
           done
           echo "Started all nodes"
           ;;
         stop)
           for i in $(seq 0 $(($${NODES_PER_WORKER} - 1))); do
-            systemctl stop "saorsa-node-$${i}" || true
+            systemctl stop "ant-node-$${i}" || true
           done
           echo "Stopped all nodes"
           ;;
         restart)
           for i in $(seq 0 $(($${NODES_PER_WORKER} - 1))); do
-            systemctl restart "saorsa-node-$${i}" || true
+            systemctl restart "ant-node-$${i}" || true
             sleep 0.2
           done
           echo "Restarted all nodes"
@@ -144,7 +144,7 @@ write_files:
           RUNNING=0
           FAILED=0
           for i in $(seq 0 $(($${NODES_PER_WORKER} - 1))); do
-            if systemctl is-active --quiet "saorsa-node-$${i}"; then
+            if systemctl is-active --quiet "ant-node-$${i}"; then
               ((RUNNING++)) || true
             else
               ((FAILED++)) || true
@@ -171,12 +171,12 @@ write_files:
       esac
 
 runcmd:
-  # Create saorsa user
-  - useradd -r -s /bin/false saorsa || true
+  # Create ant user
+  - useradd -r -s /bin/false ant || true
 
   # Create data directories
-  - mkdir -p /var/lib/saorsa/nodes
-  - chown -R saorsa:saorsa /var/lib/saorsa
+  - mkdir -p /var/lib/ant/nodes
+  - chown -R ant:ant /var/lib/ant
 
   # Increase file limits
   - echo "* soft nofile 65535" >> /etc/security/limits.conf
@@ -185,6 +185,6 @@ runcmd:
   - sysctl -p
 
   # Start nodes
-  - /usr/local/bin/spawn-saorsa-nodes.sh
+  - /usr/local/bin/spawn-ant-nodes.sh
 
-final_message: "Saorsa worker node ready with ${nodes_per_worker} nodes in region ${region}"
+final_message: "Autonomi worker node ready with ${nodes_per_worker} nodes in region ${region}"

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -1,4 +1,4 @@
-# Saorsa 500-Node Testnet Infrastructure
+# Autonomi 500-Node Testnet Infrastructure
 # Deploys 5 worker droplets (100 nodes each) + 1 monitoring server
 
 terraform {
@@ -21,8 +21,8 @@ variable "ssh_key_fingerprint" {
   type        = string
 }
 
-variable "saorsa_version" {
-  description = "Version of saorsa-node to deploy"
+variable "ant_version" {
+  description = "Version of ant-node to deploy"
   type        = string
   default     = "0.1.0"
 }
@@ -55,19 +55,19 @@ locals {
 resource "digitalocean_droplet" "worker" {
   for_each = local.worker_regions
 
-  name     = "saorsa-worker-${each.key}"
+  name     = "ant-worker-${each.key}"
   region   = each.key
   size     = "s-8vcpu-32gb"  # 8 vCPU, 32GB RAM
   image    = "ubuntu-24-04-x64"
   ssh_keys = [var.ssh_key_fingerprint]
 
-  tags = ["saorsa", "testnet", "worker"]
+  tags = ["ant", "testnet", "worker"]
 
   user_data = templatefile("${path.module}/cloud-init/worker.yml", {
     region           = each.key
     nodes_per_worker = local.nodes_per_worker
     metrics_base_port = local.metrics_base_port
-    saorsa_version   = var.saorsa_version
+    ant_version   = var.ant_version
     bootstrap_nodes  = join(",", var.bootstrap_nodes)
   })
 
@@ -78,13 +78,13 @@ resource "digitalocean_droplet" "worker" {
 
 # Monitoring droplet
 resource "digitalocean_droplet" "monitoring" {
-  name     = "saorsa-monitoring"
+  name     = "ant-monitoring"
   region   = "nyc1"
   size     = "s-4vcpu-8gb"  # 4 vCPU, 8GB RAM
   image    = "ubuntu-24-04-x64"
   ssh_keys = [var.ssh_key_fingerprint]
 
-  tags = ["saorsa", "testnet", "monitoring"]
+  tags = ["ant", "testnet", "monitoring"]
 
   user_data = templatefile("${path.module}/cloud-init/monitoring.yml", {
     worker_ips = jsonencode([for w in digitalocean_droplet.worker : w.ipv4_address])
@@ -97,7 +97,7 @@ resource "digitalocean_droplet" "monitoring" {
 
 # Firewall for workers
 resource "digitalocean_firewall" "worker" {
-  name = "saorsa-worker-firewall"
+  name = "ant-worker-firewall"
 
   droplet_ids = [for w in digitalocean_droplet.worker : w.id]
 
@@ -138,7 +138,7 @@ resource "digitalocean_firewall" "worker" {
 
 # Firewall for monitoring
 resource "digitalocean_firewall" "monitoring" {
-  name = "saorsa-monitoring-firewall"
+  name = "ant-monitoring-firewall"
 
   droplet_ids = [digitalocean_droplet.monitoring.id]
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,11 +1,11 @@
-# saorsa-node Design Document
+# ant-node Design Document
 
 ## Overview
 
-Build a **pure quantum-proof network node** (`saorsa-node`) that:
+Build a **pure quantum-proof network node** (`ant-node`) that:
 1. Uses `saorsa-core` for networking, NAT traversal, and PQC crypto
 2. Stays clean - no legacy protocol dependencies
-3. Auto-migrates local ant-node data on startup
+3. Auto-migrates local legacy ant-node data on startup
 4. Implements auto-upgrade with ML-DSA signature verification
 5. Supports dual IPv4/IPv6 DHT for maximum connectivity
 6. Features geographic routing, Sybil resistance, and trust-based routing
@@ -13,14 +13,14 @@ Build a **pure quantum-proof network node** (`saorsa-node`) that:
 ## Architecture Philosophy
 
 **Clean separation of concerns:**
-- **saorsa-node** = Pure quantum-proof node (no legacy baggage)
-- **saorsa-cli** = Client layer (file/chunk operations with EVM payments)
-- **Auto-migration** = Nodes discover and upload local ant-node data
+- **ant-node** = Pure quantum-proof node (no legacy baggage)
+- **ant-cli** = Client layer (file/chunk operations with EVM payments)
+- **Auto-migration** = Nodes discover and upload local legacy ant-node data
 - **Dual IP DHT** = IPv4 and IPv6 close groups for resilience
 
 This avoids the complexity of bridge nodes by pushing migration logic to:
 1. **Clients** - which naturally access data and can write to new network
-2. **Node startup** - which can scan for local ant-node data and migrate it
+2. **Node startup** - which can scan for local legacy ant-node data and migrate it
 
 ---
 
@@ -29,53 +29,53 @@ This avoids the complexity of bridge nodes by pushing migration logic to:
 ### How Migration Works
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                      TRANSITION PERIOD                          │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                 │
-│   ┌─────────────┐         ┌─────────────────┐                  │
-│   │ ant-network │ ◄─────► │   saorsa-cli    │                  │
-│   │ (classical) │  read   │ (client layer)  │                  │
-│   └─────────────┘         └────────┬────────┘                  │
-│                                    │ write                      │
-│                                    ▼                            │
-│                           ┌─────────────────┐                  │
-│   ┌─────────────┐        │ saorsa-network  │                   │
-│   │ant-node data│ ──────►│ (quantum-proof) │                   │
-│   │   on disk   │ migrate │                 │                   │
-│   └─────────────┘        └─────────────────┘                   │
-│         ▲                         ▲                             │
-│         │ scan                    │                             │
-│   ┌─────┴─────────────────────────┴─────┐                      │
-│   │           saorsa-node               │                      │
-│   │    (pure quantum-proof node)        │                      │
-│   └─────────────────────────────────────┘                      │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
++-------------------------------------------------------------+
+|                      TRANSITION PERIOD                          |
++-------------------------------------------------------------+
+|                                                                 |
+|   +-----------+         +-----------------+                  |
+|   | ant-network | <----> |   ant-cli       |                  |
+|   | (classical) |  read   | (client layer)  |                  |
+|   +-----------+         +--------+--------+                  |
+|                                    | write                      |
+|                                    v                            |
+|                           +-----------------+                  |
+|   +-----------+        | autonomi-network |                   |
+|   |ant-node data| ----->| (quantum-proof) |                   |
+|   |   on disk   | migrate |                 |                   |
+|   +-----------+        +-----------------+                   |
+|         ^                         ^                             |
+|         | scan                    |                             |
+|   +-----+-----------------------+-+                      |
+|   |           ant-node                |                      |
+|   |    (pure quantum-proof node)        |                      |
+|   +-----------------------------------+                      |
+|                                                                 |
++-------------------------------------------------------------+
 ```
 
 ### Client Bridge Behavior
 
 ```rust
-impl SaorsaClient {
+impl AutonomiClient {
     async fn get_data(&self, address: &DataAddress) -> Result<Data> {
-        // 1. Try saorsa-network first (quantum-proof)
-        if let Ok(data) = self.saorsa_network.get(address).await {
+        // 1. Try autonomi-network first (quantum-proof)
+        if let Ok(data) = self.autonomi_network.get(address).await {
             return Ok(data);
         }
 
         // 2. Fall back to ant-network (legacy)
         let data = self.ant_network.get(address).await?;
 
-        // 3. Migrate to saorsa-network (lazy migration)
-        self.saorsa_network.put(&data).await?;
+        // 3. Migrate to autonomi-network (lazy migration)
+        self.autonomi_network.put(&data).await?;
 
         Ok(data)
     }
 
     async fn put_data(&self, data: &Data) -> Result<DataAddress> {
         // New data goes ONLY to quantum-proof network
-        self.saorsa_network.put(data).await
+        self.autonomi_network.put(data).await
     }
 }
 ```
@@ -83,14 +83,14 @@ impl SaorsaClient {
 ### Node Auto-Migration on Startup
 
 ```rust
-impl SaorsaNode {
+impl AntNode {
     async fn startup(&mut self) -> Result<()> {
         // 1. Normal node startup
         self.initialize_network().await?;
 
-        // 2. Scan for local ant-node data directories
+        // 2. Scan for local legacy ant-node data directories
         if let Some(ant_data_dir) = self.find_ant_node_data() {
-            info!("Found ant-node data at {:?}, starting migration", ant_data_dir);
+            info!("Found legacy ant-node data at {:?}, starting migration", ant_data_dir);
             self.migrate_local_ant_data(ant_data_dir).await?;
         }
 
@@ -102,7 +102,7 @@ impl SaorsaNode {
         let mut stats = MigrationStats::default();
 
         for record in reader.read_all_records() {
-            // Store on saorsa-network
+            // Store on autonomi-network
             self.dht_manager.put(record.key, record.value).await?;
             stats.migrated += 1;
         }
@@ -132,12 +132,12 @@ impl SaorsaNode {
 ### Project Structure (Thin Wrapper - Leverages saorsa-core)
 
 ```
-saorsa-node/
+ant-node/
 ├── Cargo.toml
 ├── src/
 │   ├── lib.rs                    # Library exports
 │   ├── bin/
-│   │   └── saorsa-node/
+│   │   └── ant-node/
 │   │       ├── main.rs           # CLI entry point
 │   │       ├── cli.rs            # Command-line parsing (clap)
 │   │       └── rpc_service.rs    # Admin RPC service (optional)
@@ -147,9 +147,9 @@ saorsa-node/
 │   ├── config.rs                 # Configuration (wraps saorsa-core configs)
 │   ├── event.rs                  # NodeEvent system
 │   │
-│   ├── migration/                # ant-node data migration (NEW CODE)
+│   ├── migration/                # Legacy ant-node data migration (NEW CODE)
 │   │   ├── mod.rs
-│   │   ├── scanner.rs            # Find ant-node data directories
+│   │   ├── scanner.rs            # Find legacy ant-node data directories
 │   │   ├── ant_record_reader.rs  # Decrypt AES-256-GCM-SIV records
 │   │   └── uploader.rs           # Upload via NetworkCoordinator
 │   │
@@ -176,9 +176,9 @@ saorsa-node/
 
 ### Core Components
 
-**KEY INSIGHT: saorsa-core already provides ALL security, networking, and DHT features. saorsa-node is a thin wrapper!**
+**KEY INSIGHT: saorsa-core already provides ALL security, networking, and DHT features. ant-node is a thin wrapper!**
 
-#### 1. SaorsaNode (Thin Wrapper Around saorsa-core)
+#### 1. AntNode (Thin Wrapper Around saorsa-core)
 
 ```rust
 use saorsa_core::{
@@ -192,7 +192,7 @@ use saorsa_core::{
 
 pub struct RunningNode {
     shutdown_sender: watch::Sender<bool>,
-    // USE SAORSA-CORE DIRECTLY - NO REIMPLEMENTATION!
+    // USE ANT-CORE DIRECTLY - NO REIMPLEMENTATION!
     node: Arc<P2PNode>,                     // Integrates ALL components
     bootstrap: Arc<BootstrapManager>,       // 30,000 peer cache
     // Events
@@ -208,7 +208,7 @@ pub struct NodeBuilder {
 }
 ```
 
-#### 2. Dual IPv4/IPv6 - ALREADY IN SAORSA-CORE!
+#### 2. Dual IPv4/IPv6 - ALREADY IN ANT-CORE!
 
 **File:** `saorsa-core/src/messaging/network_config.rs`
 
@@ -240,7 +240,7 @@ pub struct DualStackNetworkNode {
 pub async fn connect_happy_eyeballs(&self, targets: &[SocketAddr]) -> Result<PeerId>
 ```
 
-#### 3. Sybil Resistance - ALREADY IN SAORSA-CORE!
+#### 3. Sybil Resistance - ALREADY IN ANT-CORE!
 
 **File:** `saorsa-core/src/security.rs` (1,245 lines)
 
@@ -267,7 +267,7 @@ pub struct IPv6NodeID {
 }
 ```
 
-#### 4. EigenTrust - ALREADY IN SAORSA-CORE!
+#### 4. EigenTrust - ALREADY IN ANT-CORE!
 
 **File:** `saorsa-core/src/adaptive/trust.rs` (825 lines)
 
@@ -287,7 +287,7 @@ let score = node.peer_trust(&peer_id);
 node.report_trust_event(&peer_id, TrustEvent::SuccessfulResponse);
 ```
 
-#### 5. Geographic Routing - ALREADY IN SAORSA-CORE!
+#### 5. Geographic Routing - ALREADY IN ANT-CORE!
 
 **File:** `saorsa-core/src/dht/geographic_routing.rs`
 
@@ -301,7 +301,7 @@ use saorsa_core::dht::geographic_routing::{GeographicRegion, LatencyAwareSelecti
 // ASN diversity enforcement
 ```
 
-#### 6. Security - ALREADY IN SAORSA-CORE!
+#### 6. Security - ALREADY IN ANT-CORE!
 
 ```rust
 // IP diversity enforcement for Sybil resistance
@@ -328,24 +328,24 @@ node.peer_trust(&peer)   // Quick trust score lookup
 node.report_trust_event(&peer, event)  // Report trust signals
 ```
 
-#### 8. What saorsa-node ACTUALLY Needs to Build
+#### 8. What ant-node ACTUALLY Needs to Build
 
 **Only these components are truly new:**
 
 ```rust
 /// Auto-upgrade system (not in saorsa-core)
 pub struct UpgradeMonitor {
-    github_repo: String,                      // "saorsa-labs/saorsa-node"
+    github_repo: String,                      // "WithAutonomi/ant-node"
     release_signing_key: MlDsaPublicKey,      // Embedded in binary
     check_interval: Duration,                 // Default: 1 hour
     rollback_dir: PathBuf,                    // For failed upgrades
 }
 
-/// ant-node data migration (not in saorsa-core)
+/// Legacy ant-node data migration (not in saorsa-core)
 pub struct AntDataMigrator {
     ant_data_dir: PathBuf,
     // Reads AES-256-GCM-SIV encrypted records
-    // Uploads to saorsa-network
+    // Uploads to autonomi-network
 }
 
 /// Node lifecycle and CLI (wrapper around saorsa-core)
@@ -368,15 +368,15 @@ pub struct NodeLifecycle {
 - IP diversity enforcement for Sybil resistance
 - P2PNode that integrates everything
 
-**saorsa-node only needs to build**:
+**ant-node only needs to build**:
 1. Auto-upgrade system (Phase 1 Critical)
-2. ant-node data migration
+2. Legacy ant-node data migration
 3. Node lifecycle/CLI wrapper
 4. Configuration/startup glue
 
 ### Phase 1: Repository Setup & Core Structure
 
-- [ ] Initialize git repo, push to `saorsa-labs/saorsa-node` on GitHub
+- [ ] Initialize git repo, push to `WithAutonomi/ant-node` on GitHub
 - [ ] Create Cargo.toml with saorsa-core, saorsa-pqc dependencies
 - [ ] Create project structure
 - [ ] Implement NodeBuilder that configures and creates NetworkCoordinator
@@ -393,11 +393,11 @@ pub struct NodeLifecycle {
 - [ ] Rollback functionality (backup current binary)
 - [ ] CLI flag: `--upgrade-channel`
 
-### Phase 3: ant-node Data Migration
+### Phase 3: Legacy ant-node Data Migration
 
-**Read and re-encrypt ant-node records for the new network**
+**Read and re-encrypt legacy ant-node records for the new network**
 
-- [ ] Directory scanner for common ant-node paths
+- [ ] Directory scanner for common legacy ant-node paths
 - [ ] AES-256-GCM-SIV decryption (read-only, for migration)
 - [ ] Upload via coordinator.dht.put() or coordinator.storage.store()
 - [ ] Progress tracking and resume capability
@@ -414,7 +414,7 @@ pub struct NodeLifecycle {
 - [ ] Single node startup/shutdown test
 - [ ] Multi-node network test (local)
 - [ ] DHT put/get test via NetworkCoordinator
-- [ ] Migration test (mock ant-node data)
+- [ ] Migration test (mock legacy ant-node data)
 - [ ] Auto-upgrade test (mock release)
 - [ ] Test IPv4-only, IPv6-only, dual-stack scenarios
 
@@ -422,7 +422,7 @@ pub struct NodeLifecycle {
 
 - [ ] README.md with quick start
 - [ ] API documentation
-- [ ] Migration guide from ant-node
+- [ ] Migration guide from legacy ant-node
 - [ ] Release workflow with ML-DSA signing
 - [ ] CI/CD pipeline (GitHub Actions)
 
@@ -431,15 +431,15 @@ pub struct NodeLifecycle {
 ## Key Design Decisions (Finalized)
 
 ### 1. Node Architecture: Pure Quantum-Proof (No Legacy)
-- **No libp2p** - saorsa-node is clean, uses only ant-quic + saorsa-core
-- **Client is the bridge** - saorsa-cli handles reading from ant-network
-- **Node auto-migrates** - scans local ant-node data and uploads to network
+- **No libp2p** - ant-node is clean, uses only ant-quic + saorsa-core
+- **Client is the bridge** - ant-cli handles reading from ant-network
+- **Node auto-migrates** - scans local legacy ant-node data and uploads to network
 - **Rationale**: Simpler node, cleaner security model, easier maintenance
 
 ### 2. Storage Encryption: ChaCha20-Poly1305 (Quantum-Resistant)
-- **Disk**: ChaCha20-Poly1305 (new format, not ant-node compatible)
+- **Disk**: ChaCha20-Poly1305 (new format, not legacy ant-node compatible)
 - **Network**: ML-KEM-768 for key exchange, ChaCha20-Poly1305 for symmetric
-- **Migration**: ant-node data is read and re-encrypted during upload
+- **Migration**: Legacy ant-node data is read and re-encrypted during upload
 - **Rationale**: Full quantum-resistance, clean break from legacy crypto
 
 ### 3. Identity: Fresh ML-DSA-65 Keypairs
@@ -461,8 +461,8 @@ pub struct NodeLifecycle {
 - **Rationale**: Production-grade security
 
 ### 6. Migration Strategy: Client-as-Bridge + Node Auto-Migration
-- Client reads from both networks, writes to saorsa-network only
-- Nodes scan for local ant-node data and upload automatically
+- Client reads from both networks, writes to Autonomi network only
+- Nodes scan for local legacy ant-node data and upload automatically
 - Organic migration through usage
 - **Rationale**: No bridge nodes, smooth transition
 
@@ -482,9 +482,9 @@ pub struct NodeLifecycle {
 saorsa-core = { path = "../saorsa-core" }
 saorsa-pqc = { path = "../saorsa-pqc" }  # ML-DSA for upgrade signature verification
 
-# Migration: Decrypt ant-node data (read-only)
-aes-gcm-siv = "0.11"    # Decrypt existing ant-node records
-hkdf = "0.12"           # Key derivation for ant-node format
+# Migration: Decrypt legacy ant-node data (read-only)
+aes-gcm-siv = "0.11"    # Decrypt existing legacy ant-node records
+hkdf = "0.12"           # Key derivation for legacy ant-node format
 
 # Async runtime
 tokio = { version = "1.35", features = ["full"] }
@@ -524,7 +524,7 @@ tokio-test = "0.4"
 
 ### Migration Speed Risk
 - **Risk**: Data migration may be slow if users don't access old data
-- **Mitigation**: Node auto-migration uploads local ant-node data proactively
+- **Mitigation**: Node auto-migration uploads local legacy ant-node data proactively
 - **Mitigation**: Popular data migrates first through client usage
 - **Mitigation**: Optional bulk migration tool for operators
 

--- a/docs/TESTNET_500_NODE_PLAN.md
+++ b/docs/TESTNET_500_NODE_PLAN.md
@@ -2,7 +2,7 @@
 
 ## Version Information
 
-- **saorsa-node**: v0.1.0
+- **ant-node**: v0.1.0
 - **saorsa-core**: v0.7.6
 - **Target**: 500 nodes across 5 Digital Ocean workers
 
@@ -75,9 +75,9 @@
 | Test | Description | Pass Criteria |
 |------|-------------|---------------|
 | Cloud-init execution | Worker VMs bootstrap correctly | All 100 nodes per worker start |
-| Systemd services | All node services running | `systemctl status saorsa-node-*` shows active |
+| Systemd services | All node services running | `systemctl status ant-node-*` shows active |
 | Resource limits | Memory/CPU limits enforced | < 350MB per node |
-| Log collection | Logs accessible | `/var/log/saorsa/node-*.log` populated |
+| Log collection | Logs accessible | `/var/log/ant/node-*.log` populated |
 
 ---
 
@@ -241,7 +241,7 @@
 | Metric | Healthy Range | Alert Threshold |
 |--------|---------------|-----------------|
 | `ip_diversity_rejections_total` (rate) | < 1/min | > 10/min (possible attack) |
-| Max nodes per IP | ≤ 50 | > 50 (limit breached) |
+| Max nodes per IP | <= 50 | > 50 (limit breached) |
 
 ### 5.9 Geographic Diversity Enforcement (NEW in 0.7.5)
 | Test | Description | Pass Criteria |
@@ -255,7 +255,7 @@
 |--------|---------------|-----------------|
 | `geographic_diversity_rejections_total` (rate) | < 1/min | > 10/min |
 | `nodes_per_region{region="..."}` | Even distribution | Single region > 40% |
-| Regions covered | ≥ 3 | < 3 regions |
+| Regions covered | >= 3 | < 3 regions |
 
 ### 5.10 Trust Enforcement (NEW in 0.7.6)
 | Test | Description | Pass Criteria |
@@ -367,7 +367,7 @@
 | Witness Failures | `dht_security_witness_failures_total` increases |
 | Node Evictions | `dht_security_nodes_evicted_total` increases |
 
-### Dashboard Panels (see grafana-saorsa-complete.json)
+### Dashboard Panels (see grafana-ant-node-complete.json)
 1. **Network Overview** - Total nodes, health status, system status
 2. **Security Dashboard** - Attack scores, BFT mode, evictions
 3. **Trust Metrics** - EigenTrust, witness validation, interactions

--- a/docs/TESTNET_DEPLOYMENT.md
+++ b/docs/TESTNET_DEPLOYMENT.md
@@ -1,10 +1,10 @@
 # Testnet Deployment Guide
 
-This guide covers deploying saorsa-node for network testing, including considerations for cloud providers and anti-Sybil protection.
+This guide covers deploying ant-node for network testing, including considerations for cloud providers and anti-Sybil protection.
 
 ## Overview
 
-The Saorsa network uses multiple anti-Sybil mechanisms that can affect testnet deployments:
+The Autonomi network uses multiple anti-Sybil mechanisms that can affect testnet deployments:
 
 1. **IP Diversity Enforcement**: Limits nodes per subnet and ASN
 2. **Node Age Verification**: Requires time-based trust accumulation
@@ -38,9 +38,9 @@ let diversity_config = IPDiversityConfig::permissive();
 let age_config = NodeAgeConfig::permissive();
 ```
 
-### saorsa-node Configuration
+### ant-node Configuration
 
-In your `saorsa-node` configuration file:
+In your `ant-node` configuration file:
 
 ```toml
 # config.toml for testnet deployment
@@ -71,10 +71,10 @@ enforce_age_requirements = false
 
 ```bash
 # Example deployment script for Digital Ocean
-export SAORSA_TESTNET_MODE=true
-export SAORSA_MAX_NODES_PER_ASN=5000
+export ANT_TESTNET_MODE=true
+export ANT_MAX_NODES_PER_ASN=5000
 
-./saorsa-node --config testnet.toml
+./ant-node --config testnet.toml
 ```
 
 ### AWS
@@ -108,8 +108,8 @@ For realistic network testing, we recommend a multi-cloud deployment:
 # Deploy 5 nodes on DO with testnet config
 for i in $(seq 1 5); do
     doctl compute droplet create \
-        saorsa-node-$i \
-        --image saorsa-node:latest \
+        ant-node-$i \
+        --image ant-node:latest \
         --size s-1vcpu-2gb \
         --region nyc1
 done
@@ -251,9 +251,9 @@ let config = NodeAgeConfig::testnet();
 **Solution**: Add multiple bootstrap nodes across regions:
 ```toml
 bootstrap = [
-    "bootstrap1.testnet.saorsa.io:9000",
-    "bootstrap2.testnet.saorsa.io:9000",
-    "bootstrap3.testnet.saorsa.io:9000"
+    "bootstrap1.testnet.autonomi.io:9000",
+    "bootstrap2.testnet.autonomi.io:9000",
+    "bootstrap3.testnet.autonomi.io:9000"
 ]
 ```
 
@@ -271,11 +271,11 @@ SIZE="s-2vcpu-4gb"
 # Create bootstrap node first
 echo "Creating bootstrap node..."
 BOOTSTRAP_IP=$(doctl compute droplet create \
-    saorsa-bootstrap \
-    --image saorsa-node:latest \
+    ant-bootstrap \
+    --image ant-node:latest \
     --size $SIZE \
     --region $REGION \
-    --user-data "SAORSA_BOOTSTRAP=true" \
+    --user-data "ANT_BOOTSTRAP=true" \
     --wait \
     --format PublicIPv4 --no-header)
 
@@ -285,11 +285,11 @@ echo "Bootstrap node: $BOOTSTRAP_IP"
 for i in $(seq 1 $NUM_NODES); do
     echo "Creating node $i..."
     doctl compute droplet create \
-        saorsa-node-$i \
-        --image saorsa-node:latest \
+        ant-node-$i \
+        --image ant-node:latest \
         --size $SIZE \
         --region $REGION \
-        --user-data "SAORSA_BOOTSTRAP_PEERS=$BOOTSTRAP_IP:9000" \
+        --user-data "ANT_BOOTSTRAP_PEERS=$BOOTSTRAP_IP:9000" \
         --wait
 done
 

--- a/docs/infrastructure/INFRASTRUCTURE.md
+++ b/docs/infrastructure/INFRASTRUCTURE.md
@@ -1,6 +1,6 @@
-# Saorsa Network Infrastructure
+# Autonomi Network Infrastructure
 
-This document describes the VPS infrastructure used for running bootstrap nodes, relay nodes, and test nodes across the Saorsa ecosystem (ant-quic, saorsa-node, communitas).
+This document describes the VPS infrastructure used for running bootstrap nodes, relay nodes, and test nodes across the Autonomi ecosystem (ant-quic, ant-node, communitas).
 
 ## Node Overview
 
@@ -23,7 +23,7 @@ Each network uses a dedicated port RANGE to allow running multiple instances on 
 | Service | UDP Port Range | Default | Description |
 |---------|----------------|---------|-------------|
 | ant-quic | 9000-9999 | 9000 | QUIC transport layer testing |
-| saorsa-node | 10000-10999 | 10000 | Core P2P network nodes |
+| ant-node | 10000-10999 | 10000 | Core P2P network nodes |
 | communitas | 11000-11999 | 11000 | Collaboration platform nodes |
 
 **Important**: Each network MUST stay within its assigned port range. Never use ports from another network's range.
@@ -38,15 +38,15 @@ Additional ports:
 All nodes use the `saorsalabs.com` domain. Configure the following A records:
 
 ```
-saorsa-1.saorsalabs.com  →  77.42.75.115
-saorsa-2.saorsalabs.com  →  142.93.199.50
-saorsa-3.saorsalabs.com  →  147.182.234.192
-saorsa-4.saorsalabs.com  →  206.189.7.117
-saorsa-5.saorsalabs.com  →  144.126.230.161
-saorsa-6.saorsalabs.com  →  65.21.157.229
-saorsa-7.saorsalabs.com  →  116.203.101.172
-saorsa-8.saorsalabs.com  →  149.28.156.231
-saorsa-9.saorsalabs.com  →  45.77.176.184
+saorsa-1.saorsalabs.com  ->  77.42.75.115
+saorsa-2.saorsalabs.com  ->  142.93.199.50
+saorsa-3.saorsalabs.com  ->  147.182.234.192
+saorsa-4.saorsalabs.com  ->  206.189.7.117
+saorsa-5.saorsalabs.com  ->  144.126.230.161
+saorsa-6.saorsalabs.com  ->  65.21.157.229
+saorsa-7.saorsalabs.com  ->  116.203.101.172
+saorsa-8.saorsalabs.com  ->  149.28.156.231
+saorsa-9.saorsalabs.com  ->  45.77.176.184
 ```
 
 ## Bootstrap Endpoints
@@ -57,7 +57,7 @@ saorsa-2.saorsalabs.com:9000
 saorsa-3.saorsalabs.com:9000
 ```
 
-### saorsa-node Bootstrap
+### ant-node Bootstrap
 ```
 saorsa-2.saorsalabs.com:10000
 saorsa-3.saorsalabs.com:10000
@@ -74,7 +74,7 @@ saorsa-3.saorsalabs.com:11000
 ### Dashboard Node (saorsa-1)
 - **IP:** 77.42.75.115
 - **Provider:** Hetzner (Helsinki)
-- Hosts the Saorsa Labs website
+- Hosts the Autonomi Labs website
 - Runs monitoring dashboards
 - Central admin interface
 
@@ -99,7 +99,7 @@ saorsa-3.saorsalabs.com:11000
 ### DigitalOcean
 ```bash
 # Already configured via DIGITALOCEAN_API_TOKEN
-doctl compute droplet list --tag-name saorsa
+doctl compute droplet list --tag-name autonomi
 ```
 
 ### Hetzner
@@ -117,15 +117,15 @@ VULTR_API_KEY="$VULTR_API_TOKEN" vultr-cli instance list
 
 ## Firewall Configuration
 
-### DigitalOcean Firewall (saorsa-p2p-firewall)
-Applied to all nodes tagged with `saorsa`:
+### DigitalOcean Firewall (autonomi-p2p-firewall)
+Applied to all nodes tagged with `autonomi`:
 
 **Inbound Rules:**
 - TCP 22 (SSH)
 - TCP 80 (HTTP)
 - TCP 443 (HTTPS)
 - UDP 9000 (ant-quic)
-- UDP 10000 (saorsa-node)
+- UDP 10000 (ant-node)
 - UDP 11000 (communitas)
 
 **Outbound Rules:**
@@ -133,15 +133,15 @@ Applied to all nodes tagged with `saorsa`:
 - All UDP
 - ICMP
 
-### Hetzner Firewall (saorsa-p2p-firewall)
-Applied to all saorsa servers:
+### Hetzner Firewall (autonomi-p2p-firewall)
+Applied to all Autonomi servers:
 
 **Inbound Rules:**
 - TCP 22 (SSH)
 - TCP 80 (HTTP)
 - TCP 443 (HTTPS)
 - UDP 9000 (ant-quic)
-- UDP 10000 (saorsa-node)
+- UDP 10000 (ant-node)
 - UDP 11000 (communitas)
 - ICMP
 
@@ -169,7 +169,7 @@ doctl compute droplet create saorsa-N \
   --image ubuntu-24-04-x64 \
   --region nyc1 \
   --ssh-keys 48810465,2064413 \
-  --tag-names saorsa,testnode \
+  --tag-names autonomi,testnode \
   --wait
 ```
 
@@ -182,7 +182,7 @@ HCLOUD_TOKEN="$HETZNER_API_KEY" hcloud server create \
   --location hel1 \
   --ssh-key 104686182 \
   --label role=testnode \
-  --label project=saorsa
+  --label project=autonomi
 ```
 
 ### Create New Vultr Node
@@ -204,11 +204,11 @@ cd /opt/ant-quic
 ./ant-quic-node --listen 0.0.0.0:9000 --bootstrap
 ```
 
-### saorsa-node Bootstrap
+### ant-node Bootstrap
 ```bash
 # On saorsa-2 or saorsa-3
-cd /opt/saorsa-node
-./saorsa-node --listen 0.0.0.0:10000 --bootstrap
+cd /opt/ant-node
+./ant-node --listen 0.0.0.0:10000 --bootstrap
 ```
 
 ### communitas Bootstrap
@@ -220,12 +220,12 @@ cd /opt/communitas
 
 ## Production Configuration
 
-Before deploying, create `/etc/saorsa/production.toml` based on the template in `config/production.toml`:
+Before deploying, create `/etc/autonomi/production.toml` based on the template in `config/production.toml`:
 
 ```bash
-sudo mkdir -p /etc/saorsa
-sudo cp config/production.toml /etc/saorsa/production.toml
-sudo nano /etc/saorsa/production.toml  # Set your rewards_address
+sudo mkdir -p /etc/autonomi
+sudo cp config/production.toml /etc/autonomi/production.toml
+sudo nano /etc/autonomi/production.toml  # Set your rewards_address
 ```
 
 **CRITICAL**: Ensure `payment.enabled = true` in the config file.
@@ -250,17 +250,17 @@ RestartSec=10
 WantedBy=multi-user.target
 ```
 
-### saorsa-node Bootstrap Service
+### ant-node Bootstrap Service
 ```ini
-# /etc/systemd/system/saorsa-node-bootstrap.service
+# /etc/systemd/system/ant-node-bootstrap.service
 [Unit]
-Description=saorsa-node Bootstrap Node
+Description=Ant Node Bootstrap Node
 After=network.target
 
 [Service]
 Type=simple
 User=root
-ExecStart=/opt/saorsa-node/saorsa-node --config /etc/saorsa/production.toml --listen 0.0.0.0:10000 --bootstrap
+ExecStart=/opt/ant-node/ant-node --config /etc/autonomi/production.toml --listen 0.0.0.0:10000 --bootstrap
 # CRITICAL: DO NOT add --disable-payment-verification flag in production
 Restart=always
 RestartSec=10
@@ -292,7 +292,7 @@ WantedBy=multi-user.target
 ### Check Node Status
 ```bash
 # DigitalOcean
-doctl compute droplet list --tag-name saorsa --format Name,Status,PublicIPv4
+doctl compute droplet list --tag-name autonomi --format Name,Status,PublicIPv4
 
 # Hetzner
 HCLOUD_TOKEN="$HETZNER_API_KEY" hcloud server list
@@ -312,7 +312,7 @@ nc -vzu saorsa-2.saorsalabs.com 11000
 ### Check Service Status (on node)
 ```bash
 systemctl status ant-quic-bootstrap
-systemctl status saorsa-node-bootstrap
+systemctl status ant-node-bootstrap
 systemctl status communitas-bootstrap
 ```
 
@@ -330,23 +330,23 @@ systemctl status communitas-bootstrap
 
 ```bash
 # Dashboard
-export SAORSA_DASHBOARD="77.42.75.115"
+export ANT_DASHBOARD="77.42.75.115"
 
 # Bootstrap nodes
-export SAORSA_BOOTSTRAP_1="142.93.199.50"
-export SAORSA_BOOTSTRAP_2="147.182.234.192"
+export ANT_BOOTSTRAP_1="142.93.199.50"
+export ANT_BOOTSTRAP_2="147.182.234.192"
 
 # Test nodes - DigitalOcean
-export SAORSA_TEST_DO_1="206.189.7.117"
-export SAORSA_TEST_DO_2="144.126.230.161"
+export ANT_TEST_DO_1="206.189.7.117"
+export ANT_TEST_DO_2="144.126.230.161"
 
 # Test nodes - Hetzner
-export SAORSA_TEST_HZ_1="65.21.157.229"
-export SAORSA_TEST_HZ_2="116.203.101.172"
+export ANT_TEST_HZ_1="65.21.157.229"
+export ANT_TEST_HZ_2="116.203.101.172"
 
 # Test nodes - Vultr
-export SAORSA_TEST_VL_1="149.28.156.231"
-export SAORSA_TEST_VL_2="45.77.176.184"
+export ANT_TEST_VL_1="149.28.156.231"
+export ANT_TEST_VL_2="45.77.176.184"
 ```
 
 ## Maintenance
@@ -360,7 +360,7 @@ apt update && apt upgrade -y
 ### Restart Services
 ```bash
 systemctl restart ant-quic-bootstrap
-systemctl restart saorsa-node-bootstrap
+systemctl restart ant-node-bootstrap
 systemctl restart communitas-bootstrap
 ```
 
@@ -400,6 +400,6 @@ ssh root@saorsa-2.saorsalabs.com "systemctl restart ant-quic-bootstrap"
 ## Related Documentation
 
 - [ant-quic README](https://github.com/maidsafe/ant-quic)
-- [saorsa-gossip](../../../saorsa-gossip/README.md)
+- [ant-gossip](../../../ant-gossip/README.md)
 - [communitas Architecture](../architecture/README.md)
 - [Port Allocation](./PORTS.md)

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# End-to-end integration test for saorsa-node file upload/download with EVM payments.
+# End-to-end integration test for ant-node file upload/download with EVM payments.
 #
 # This script:
 # 1. Builds release binaries
@@ -20,11 +20,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 UGLY_FILES_DIR="${PROJECT_DIR}/ugly_files"
 TEST_RUN_ID="$$_$(date +%s)"
-MANIFEST_FILE="/tmp/saorsa_e2e_manifest_${TEST_RUN_ID}.json"
-DOWNLOAD_DIR="/tmp/saorsa_e2e_download_${TEST_RUN_ID}"
-LOG_FILE="/tmp/saorsa_e2e_devnet_${TEST_RUN_ID}.log"
-CLI_LOG="/tmp/saorsa_e2e_cli_${TEST_RUN_ID}.log"
-CLI_STDOUT="/tmp/saorsa_e2e_cli_stdout_${TEST_RUN_ID}.txt"
+MANIFEST_FILE="/tmp/ant_e2e_manifest_${TEST_RUN_ID}.json"
+DOWNLOAD_DIR="/tmp/ant_e2e_download_${TEST_RUN_ID}"
+LOG_FILE="/tmp/ant_e2e_devnet_${TEST_RUN_ID}.log"
+CLI_LOG="/tmp/ant_e2e_cli_${TEST_RUN_ID}.log"
+CLI_STDOUT="/tmp/ant_e2e_cli_stdout_${TEST_RUN_ID}.txt"
 
 DEVNET_PID=""
 PASS_COUNT=0
@@ -77,7 +77,7 @@ parse_field() {
 }
 
 echo "=============================================="
-echo "  saorsa-node E2E Integration Test"
+echo "  ant-node E2E Integration Test"
 echo "=============================================="
 echo ""
 
@@ -88,25 +88,25 @@ cargo build --release 2>&1 | tail -3
 echo "Build complete."
 echo ""
 
-SAORSA_DEVNET="${PROJECT_DIR}/target/release/saorsa-devnet"
-SAORSA_CLI="${PROJECT_DIR}/target/release/saorsa-cli"
+ANT_DEVNET="${PROJECT_DIR}/target/release/ant-devnet"
+ANT_CLI="${PROJECT_DIR}/target/release/ant-cli"
 
-if [ ! -f "${SAORSA_DEVNET}" ]; then
-    echo "ERROR: saorsa-devnet binary not found at ${SAORSA_DEVNET}"
+if [ ! -f "${ANT_DEVNET}" ]; then
+    echo "ERROR: ant-devnet binary not found at ${ANT_DEVNET}"
     exit 1
 fi
-if [ ! -f "${SAORSA_CLI}" ]; then
-    echo "ERROR: saorsa-cli binary not found at ${SAORSA_CLI}"
+if [ ! -f "${ANT_CLI}" ]; then
+    echo "ERROR: ant-cli binary not found at ${ANT_CLI}"
     exit 1
 fi
 
 # Step 2: Start devnet with EVM
-DEVNET_NODES="${SAORSA_TEST_DEVNET_NODES:-5}"
-BOOTSTRAP_COUNT="${SAORSA_TEST_BOOTSTRAP_COUNT:-2}"
+DEVNET_NODES="${ANT_TEST_DEVNET_NODES:-5}"
+BOOTSTRAP_COUNT="${ANT_TEST_BOOTSTRAP_COUNT:-2}"
 echo "=== Step 2: Starting devnet with EVM (${DEVNET_NODES} nodes, ${BOOTSTRAP_COUNT} bootstrap) ==="
 mkdir -p "${DOWNLOAD_DIR}"
 
-RUST_LOG=warn "${SAORSA_DEVNET}" \
+RUST_LOG=warn "${ANT_DEVNET}" \
     --nodes "${DEVNET_NODES}" \
     --bootstrap-count "${BOOTSTRAP_COUNT}" \
     --enable-evm \
@@ -167,7 +167,7 @@ else
 fi
 
 # Wait for network to stabilize
-STABILIZE_SECS="${SAORSA_TEST_STABILIZE_SECS:-15}"
+STABILIZE_SECS="${ANT_TEST_STABILIZE_SECS:-15}"
 echo "Waiting ${STABILIZE_SECS} seconds for network stabilization..."
 sleep "${STABILIZE_SECS}"
 echo ""
@@ -178,8 +178,8 @@ ALL_TX_HASHES=""
 # Step 3 & 4: Upload and download each file in ugly_files/
 echo "=== Step 3: File upload/download tests ==="
 
-# Max file size for E2E tests (default 1MB; override with SAORSA_TEST_MAX_FILE_SIZE)
-MAX_FILE_SIZE="${SAORSA_TEST_MAX_FILE_SIZE:-1048576}"
+# Max file size for E2E tests (default 1MB; override with ANT_TEST_MAX_FILE_SIZE)
+MAX_FILE_SIZE="${ANT_TEST_MAX_FILE_SIZE:-1048576}"
 
 # Find test files (skip directories, .DS_Store, and files larger than MAX_FILE_SIZE)
 TEST_FILES=()
@@ -198,8 +198,8 @@ fi
 # If no ugly_files found, create a synthetic test file
 if [ ${#TEST_FILES[@]} -eq 0 ]; then
     echo "No test files in ${UGLY_FILES_DIR}, creating synthetic test file..."
-    SYNTHETIC_FILE="/tmp/saorsa_e2e_synthetic_${TEST_RUN_ID}.txt"
-    echo "saorsa E2E test payload: $(date -u +%Y-%m-%dT%H:%M:%SZ) run=${TEST_RUN_ID}" > "${SYNTHETIC_FILE}"
+    SYNTHETIC_FILE="/tmp/ant_e2e_synthetic_${TEST_RUN_ID}.txt"
+    echo "ant E2E test payload: $(date -u +%Y-%m-%dT%H:%M:%SZ) run=${TEST_RUN_ID}" > "${SYNTHETIC_FILE}"
     TEST_FILES+=("${SYNTHETIC_FILE}")
 fi
 
@@ -211,7 +211,7 @@ for filepath in "${TEST_FILES[@]}"; do
 
     # Upload with payment - write stdout to file to avoid terminal ANSI leakage
     echo "  Uploading..."
-    SECRET_KEY="${WALLET_KEY}" "${SAORSA_CLI}" \
+    SECRET_KEY="${WALLET_KEY}" "${ANT_CLI}" \
         --devnet-manifest "${MANIFEST_FILE}" \
         --evm-network local \
         --timeout-secs 120 \
@@ -257,7 +257,7 @@ for filepath in "${TEST_FILES[@]}"; do
     # Download and verify
     DOWNLOAD_PATH="${DOWNLOAD_DIR}/${filename}"
     echo "  Downloading..."
-    SECRET_KEY="${WALLET_KEY}" "${SAORSA_CLI}" \
+    SECRET_KEY="${WALLET_KEY}" "${ANT_CLI}" \
         --devnet-manifest "${MANIFEST_FILE}" \
         --evm-network local \
         --timeout-secs 120 \
@@ -345,7 +345,7 @@ done
 
 if [ -n "${REJECTION_FILE}" ]; then
     echo "  Attempting upload WITHOUT SECRET_KEY (should fail at client)..."
-    REJECTION_OUTPUT=$("${SAORSA_CLI}" \
+    REJECTION_OUTPUT=$("${ANT_CLI}" \
         --devnet-manifest "${MANIFEST_FILE}" \
         --evm-network local \
         --timeout-secs 10 \
@@ -370,13 +370,13 @@ echo ""
 # Step 7: Test chunk put rejection without wallet
 echo "=== Step 7: Chunk put rejection without wallet ==="
 echo "  Attempting chunk put WITHOUT SECRET_KEY (should fail at client)..."
-echo "test data for rejection e2e" > /tmp/saorsa_rejection_test_${TEST_RUN_ID}.txt
-CHUNK_REJECT_OUTPUT=$("${SAORSA_CLI}" \
+echo "test data for rejection e2e" > /tmp/ant_rejection_test_${TEST_RUN_ID}.txt
+CHUNK_REJECT_OUTPUT=$("${ANT_CLI}" \
     --devnet-manifest "${MANIFEST_FILE}" \
     --evm-network local \
     --timeout-secs 10 \
     --log-level error \
-    chunk put /tmp/saorsa_rejection_test_${TEST_RUN_ID}.txt 2>&1 || true)
+    chunk put /tmp/ant_rejection_test_${TEST_RUN_ID}.txt 2>&1 || true)
 
 CLEAN_CHUNK_OUTPUT=$(echo "${CHUNK_REJECT_OUTPUT}" | strip_ansi)
 

--- a/scripts/testnet/build-and-deploy.sh
+++ b/scripts/testnet/build-and-deploy.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
-# Build saorsa-node on a droplet and deploy to all workers
+# Build ant-node on a droplet and deploy to all workers
 # This avoids glibc compatibility issues by building on the target OS
 
 set -e
 
 # Droplet IPs
 WORKERS=(
-    "142.93.52.129"   # saorsa-worker-1
-    "24.199.82.114"   # saorsa-worker-2
-    "192.34.62.192"   # saorsa-worker-3
-    "159.223.131.196" # saorsa-worker-4
+    "142.93.52.129"   # ant-worker-1
+    "24.199.82.114"   # ant-worker-2
+    "192.34.62.192"   # ant-worker-3
+    "159.223.131.196" # ant-worker-4
 )
 
 BUILD_HOST="${WORKERS[0]}"  # Build on first worker
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-echo "=== Building saorsa-node on droplet ==="
+echo "=== Building ant-node on droplet ==="
 echo "Build host: $BUILD_HOST"
 echo ""
 
@@ -39,36 +39,36 @@ ssh -o StrictHostKeyChecking=no "root@${BUILD_HOST}" "
 "
 
 # Step 2: Clone and build the project
-echo "=== Building saorsa-node ==="
+echo "=== Building ant-node ==="
 ssh -o StrictHostKeyChecking=no "root@${BUILD_HOST}" "
     set -e
     source ~/.cargo/env
 
     # Clone or update the repo
-    if [ -d /root/saorsa-node ]; then
-        cd /root/saorsa-node
+    if [ -d /root/ant-node ]; then
+        cd /root/ant-node
         git fetch origin
         git reset --hard origin/main
     else
-        git clone https://github.com/saorsa-labs/saorsa-node.git /root/saorsa-node
-        cd /root/saorsa-node
+        git clone https://github.com/WithAutonomi/ant-node.git /root/ant-node
+        cd /root/ant-node
     fi
 
     # Build release binary
     cargo build --release
 
     # Verify binary
-    ls -la target/release/saorsa-node
-    ./target/release/saorsa-node --version
+    ls -la target/release/ant-node
+    ./target/release/ant-node --version
 "
 
 # Step 3: Copy binary to /usr/local/bin on build host
 echo "=== Installing on build host ==="
 ssh -o StrictHostKeyChecking=no "root@${BUILD_HOST}" "
-    cp /root/saorsa-node/target/release/saorsa-node /usr/local/bin/
-    cp /root/saorsa-node/target/release/saorsa-keygen /usr/local/bin/ 2>/dev/null || true
-    chmod +x /usr/local/bin/saorsa-node
-    /usr/local/bin/saorsa-node --version
+    cp /root/ant-node/target/release/ant-node /usr/local/bin/
+    cp /root/ant-node/target/release/ant-keygen /usr/local/bin/ 2>/dev/null || true
+    chmod +x /usr/local/bin/ant-node
+    /usr/local/bin/ant-node --version
 "
 
 # Step 4: Copy scripts and configure build host
@@ -93,11 +93,11 @@ for i in 1 2 3; do
     WORKER_NUM=$((i + 1))
     START_INDEX=$((i * 50))
 
-    echo "Deploying to saorsa-worker-${WORKER_NUM} ($IP)..."
+    echo "Deploying to ant-worker-${WORKER_NUM} ($IP)..."
 
     # Copy binary from build host
     ssh -o StrictHostKeyChecking=no "root@${BUILD_HOST}" \
-        "scp -o StrictHostKeyChecking=no /usr/local/bin/saorsa-node root@${IP}:/usr/local/bin/"
+        "scp -o StrictHostKeyChecking=no /usr/local/bin/ant-node root@${IP}:/usr/local/bin/"
 
     # Copy scripts
     scp -o StrictHostKeyChecking=no \
@@ -110,7 +110,7 @@ for i in 1 2 3; do
     # Configure worker
     ssh -o StrictHostKeyChecking=no "root@${IP}" "
         chmod +x /usr/local/bin/*.sh
-        chmod +x /usr/local/bin/saorsa-node
+        chmod +x /usr/local/bin/ant-node
         /usr/local/bin/setup-limits.sh
         /usr/local/bin/spawn-nodes.sh ${START_INDEX}
     "

--- a/scripts/testnet/check-all.sh
+++ b/scripts/testnet/check-all.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
-# Check health of all saorsa nodes across all testnet droplets
+# Check health of all ant nodes across all testnet droplets
 # Run from local machine
 
 WORKERS=(
-    "142.93.52.129"   # saorsa-worker-1
-    "24.199.82.114"   # saorsa-worker-2
-    "192.34.62.192"   # saorsa-worker-3
-    "159.223.131.196" # saorsa-worker-4
+    "142.93.52.129"   # ant-worker-1
+    "24.199.82.114"   # ant-worker-2
+    "192.34.62.192"   # ant-worker-3
+    "159.223.131.196" # ant-worker-4
 )
 
 TOTAL_HEALTHY=0
 TOTAL_UNHEALTHY=0
 TOTAL_UNREACHABLE=0
 
-echo "=== Saorsa Testnet Health Check ==="
+echo "=== Autonomi Testnet Health Check ==="
 echo ""
 
 for i in "${!WORKERS[@]}"; do
@@ -21,7 +21,7 @@ for i in "${!WORKERS[@]}"; do
     WORKER_NUM=$((i + 1))
     START_INDEX=$((i * 50))
 
-    echo "--- saorsa-worker-${WORKER_NUM} ($IP) ---"
+    echo "--- ant-worker-${WORKER_NUM} ($IP) ---"
 
     # Run health check remotely
     RESULT=$(ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 "root@${IP}" \

--- a/scripts/testnet/check-health.sh
+++ b/scripts/testnet/check-health.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Check health of all saorsa nodes on this droplet
+# Check health of all ant nodes on this droplet
 # Usage: ./check-health.sh [start_index] [count]
 
 START_INDEX=${1:-0}
@@ -10,7 +10,7 @@ HEALTHY=0
 UNHEALTHY=0
 UNREACHABLE=0
 
-echo "=== Saorsa Node Health Check ==="
+echo "=== Autonomi Node Health Check ==="
 echo "Checking nodes ${START_INDEX} to ${END_INDEX}"
 echo ""
 
@@ -18,7 +18,7 @@ for i in $(seq $START_INDEX $END_INDEX); do
     PORT=$((9100 + i - START_INDEX))
 
     # Check if service is running
-    if ! systemctl is-active --quiet saorsa-node-${i}; then
+    if ! systemctl is-active --quiet ant-node-${i}; then
         echo "Node $i: SERVICE NOT RUNNING"
         ((UNREACHABLE++))
         continue
@@ -37,7 +37,7 @@ for i in $(seq $START_INDEX $END_INDEX); do
     HEALTH=$(echo "$RESPONSE" | grep "p2p_health_status" | awk '{print $2}' | head -1)
     PEERS=$(echo "$RESPONSE" | grep "peer_count" | awk '{print $2}' | head -1)
     ROUTING=$(echo "$RESPONSE" | grep "routing_table_size" | awk '{print $2}' | head -1)
-    VERSION=$(echo "$RESPONSE" | grep "saorsa_version" | head -1)
+    VERSION=$(echo "$RESPONSE" | grep "ant_version" | head -1)
 
     if [ "$HEALTH" = "1" ]; then
         echo "Node $i: HEALTHY (peers: ${PEERS:-?}, routing: ${ROUTING:-?})"

--- a/scripts/testnet/churn-test.sh
+++ b/scripts/testnet/churn-test.sh
@@ -33,7 +33,7 @@ log() {
 get_node_count() {
     local TOTAL=0
     for IP in "${WORKERS[@]}"; do
-        COUNT=$(ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 root@$IP "pgrep -c saorsa-node 2>/dev/null" 2>/dev/null || echo "0")
+        COUNT=$(ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 root@$IP "pgrep -c ant-node 2>/dev/null" 2>/dev/null || echo "0")
         TOTAL=$((TOTAL + COUNT))
     done
     echo $TOTAL
@@ -47,9 +47,9 @@ get_worker_nodes() {
 
     # Get list of running node indices on this worker
     ssh -o StrictHostKeyChecking=no root@$IP "
-        for svc in /etc/systemd/system/saorsa-node-*.service; do
+        for svc in /etc/systemd/system/ant-node-*.service; do
             NAME=\$(basename \$svc .service)
-            IDX=\$(echo \$NAME | grep -oP 'saorsa-node-\K[0-9]+')
+            IDX=\$(echo \$NAME | grep -oP 'ant-node-\K[0-9]+')
             if systemctl is-active --quiet \$NAME 2>/dev/null; then
                 echo \$IDX
             fi
@@ -72,7 +72,7 @@ kill_random_nodes() {
         # Get running nodes on this worker
         local RUNNING_NODES=$(ssh -o StrictHostKeyChecking=no root@$IP "
             for i in \$(seq $START_IDX $((START_IDX + NODES_PER_WORKER - 1))); do
-                if systemctl is-active --quiet saorsa-node-\$i 2>/dev/null; then
+                if systemctl is-active --quiet ant-node-\$i 2>/dev/null; then
                     echo \$i
                 fi
             done
@@ -84,7 +84,7 @@ kill_random_nodes() {
             local NODE_IDX=${NODE_ARRAY[$((RANDOM % ${#NODE_ARRAY[@]}))]}
 
             # Kill it
-            ssh -o StrictHostKeyChecking=no root@$IP "systemctl stop saorsa-node-$NODE_IDX" 2>/dev/null || true
+            ssh -o StrictHostKeyChecking=no root@$IP "systemctl stop ant-node-$NODE_IDX" 2>/dev/null || true
             log "  Killed node $NODE_IDX on $IP"
             KILLED=$((KILLED + 1))
         fi
@@ -106,7 +106,7 @@ restart_random_nodes() {
         # Get stopped nodes on this worker
         local STOPPED_NODES=$(ssh -o StrictHostKeyChecking=no root@$IP "
             for i in \$(seq $START_IDX $((START_IDX + NODES_PER_WORKER - 1))); do
-                if ! systemctl is-active --quiet saorsa-node-\$i 2>/dev/null; then
+                if ! systemctl is-active --quiet ant-node-\$i 2>/dev/null; then
                     echo \$i
                 fi
             done
@@ -118,7 +118,7 @@ restart_random_nodes() {
             local NODE_IDX=${NODE_ARRAY[$((RANDOM % ${#NODE_ARRAY[@]}))]}
 
             # Restart it
-            ssh -o StrictHostKeyChecking=no root@$IP "systemctl start saorsa-node-$NODE_IDX" 2>/dev/null || true
+            ssh -o StrictHostKeyChecking=no root@$IP "systemctl start ant-node-$NODE_IDX" 2>/dev/null || true
             log "  Restarted node $NODE_IDX on $IP"
             RESTARTED=$((RESTARTED + 1))
         fi
@@ -146,14 +146,14 @@ verify_data() {
     # Check per-worker status
     for i in "${!WORKERS[@]}"; do
         local IP="${WORKERS[$i]}"
-        local COUNT=$(ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 root@$IP "pgrep -c saorsa-node 2>/dev/null" 2>/dev/null || echo "0")
+        local COUNT=$(ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 root@$IP "pgrep -c ant-node 2>/dev/null" 2>/dev/null || echo "0")
         log "  Worker $((i+1)) ($IP): $COUNT nodes"
     done
 }
 
 # Main test loop
 main() {
-    log "=== Saorsa Churn Test ==="
+    log "=== Autonomi Churn Test ==="
     log "Duration: $DURATION_MINUTES minutes"
     log "Churn rate: $CHURN_RATE% ($((TOTAL_NODES * CHURN_RATE / 100)) nodes per cycle)"
     log "Churn interval: $CHURN_INTERVAL seconds"

--- a/scripts/testnet/churn-verify.sh
+++ b/scripts/testnet/churn-verify.sh
@@ -26,8 +26,8 @@ TOTAL_NODES=200
 LOG_FILE="$LOG_DIR/churn-verify-$(date +%Y%m%d-%H%M%S).log"
 
 # Testnet configuration
-export SAORSA_TEST_BOOTSTRAP="142.93.52.129:12000,24.199.82.114:12000"
-export SAORSA_TEST_EXTERNAL=true
+export ANT_TEST_BOOTSTRAP="142.93.52.129:12000,24.199.82.114:12000"
+export ANT_TEST_EXTERNAL=true
 export RUST_LOG=info
 
 log() {
@@ -39,7 +39,7 @@ log() {
 get_node_count() {
     local TOTAL=0
     for IP in "${WORKERS[@]}"; do
-        COUNT=$(ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 root@$IP "pgrep -c saorsa-node 2>/dev/null" 2>/dev/null || echo "0")
+        COUNT=$(ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 root@$IP "pgrep -c ant-node 2>/dev/null" 2>/dev/null || echo "0")
         TOTAL=$((TOTAL + COUNT))
     done
     echo $TOTAL
@@ -59,7 +59,7 @@ kill_random_nodes() {
         # Get running nodes on this worker
         local RUNNING_NODES=$(ssh -o StrictHostKeyChecking=no root@$IP "
             for i in \$(seq $START_IDX $((START_IDX + NODES_PER_WORKER - 1))); do
-                if systemctl is-active --quiet saorsa-node-\$i 2>/dev/null; then
+                if systemctl is-active --quiet ant-node-\$i 2>/dev/null; then
                     echo \$i
                 fi
             done
@@ -69,7 +69,7 @@ kill_random_nodes() {
             local NODE_ARRAY=($RUNNING_NODES)
             local NODE_IDX=${NODE_ARRAY[$((RANDOM % ${#NODE_ARRAY[@]}))]}
 
-            ssh -o StrictHostKeyChecking=no root@$IP "systemctl stop saorsa-node-$NODE_IDX" 2>/dev/null || true
+            ssh -o StrictHostKeyChecking=no root@$IP "systemctl stop ant-node-$NODE_IDX" 2>/dev/null || true
             log "    Killed node $NODE_IDX on $IP"
             KILLED=$((KILLED + 1))
         fi
@@ -90,7 +90,7 @@ restart_random_nodes() {
         # Get stopped nodes on this worker
         local STOPPED_NODES=$(ssh -o StrictHostKeyChecking=no root@$IP "
             for i in \$(seq $START_IDX $((START_IDX + NODES_PER_WORKER - 1))); do
-                if ! systemctl is-active --quiet saorsa-node-\$i 2>/dev/null; then
+                if ! systemctl is-active --quiet ant-node-\$i 2>/dev/null; then
                     echo \$i
                 fi
             done
@@ -100,7 +100,7 @@ restart_random_nodes() {
             local NODE_ARRAY=($STOPPED_NODES)
             local NODE_IDX=${NODE_ARRAY[$((RANDOM % ${#NODE_ARRAY[@]}))]}
 
-            ssh -o StrictHostKeyChecking=no root@$IP "systemctl start saorsa-node-$NODE_IDX" 2>/dev/null || true
+            ssh -o StrictHostKeyChecking=no root@$IP "systemctl start ant-node-$NODE_IDX" 2>/dev/null || true
             log "    Restarted node $NODE_IDX on $IP"
             RESTARTED=$((RESTARTED + 1))
         fi
@@ -130,7 +130,7 @@ verify_data() {
 
     # Run verification test
     cd "$PROJECT_ROOT"
-    export SAORSA_TEST_ADDRESSES_FILE="$ADDRESSES_FILE"
+    export ANT_TEST_ADDRESSES_FILE="$ADDRESSES_FILE"
 
     # Run quick verification (sample of chunks)
     local RESULT=$(cargo test --release --test e2e run_verify_chunks -- --ignored --nocapture 2>&1)
@@ -149,7 +149,7 @@ verify_data() {
 
 # Main test
 main() {
-    log "=== Saorsa Churn + Verification Test ==="
+    log "=== Autonomi Churn + Verification Test ==="
     log "Addresses file: $ADDRESSES_FILE"
     log "Duration: $DURATION_MINUTES minutes"
     log "Churn rate: $CHURN_RATE%"

--- a/scripts/testnet/deploy-all.sh
+++ b/scripts/testnet/deploy-all.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
-# Deploy saorsa-node to all testnet droplets
+# Deploy ant-node to all testnet droplets
 # Run from local machine with SSH access to droplets
 
 set -e
 
 # Droplet IPs
 WORKERS=(
-    "142.93.52.129"   # saorsa-worker-1
-    "24.199.82.114"   # saorsa-worker-2
-    "192.34.62.192"   # saorsa-worker-3
-    "159.223.131.196" # saorsa-worker-4
+    "142.93.52.129"   # ant-worker-1
+    "24.199.82.114"   # ant-worker-2
+    "192.34.62.192"   # ant-worker-3
+    "159.223.131.196" # ant-worker-4
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BINARY_URL="https://github.com/saorsa-labs/saorsa-node/releases/download/v0.2.0/saorsa-node-cli-linux-x64.tar.gz"
+BINARY_URL="https://github.com/WithAutonomi/ant-node/releases/download/v0.2.0/ant-node-cli-linux-x64.tar.gz"
 
-echo "=== Saorsa Testnet Deployment ==="
+echo "=== Autonomi Testnet Deployment ==="
 echo "Deploying to ${#WORKERS[@]} droplets"
 echo ""
 
@@ -23,7 +23,7 @@ for i in "${!WORKERS[@]}"; do
     IP="${WORKERS[$i]}"
     WORKER_NUM=$((i + 1))
 
-    echo "=== Deploying to saorsa-worker-${WORKER_NUM} ($IP) ==="
+    echo "=== Deploying to ant-worker-${WORKER_NUM} ($IP) ==="
 
     # Copy scripts
     echo "Copying scripts..."
@@ -38,16 +38,16 @@ for i in "${!WORKERS[@]}"; do
     ssh -o StrictHostKeyChecking=no "root@${IP}" "chmod +x /usr/local/bin/*.sh"
 
     # Download and install binary
-    echo "Downloading and installing saorsa-node..."
+    echo "Downloading and installing ant-node..."
     ssh -o StrictHostKeyChecking=no "root@${IP}" "
         cd /tmp
-        curl -sL '${BINARY_URL}' -o saorsa-node.tar.gz
-        tar xzf saorsa-node.tar.gz
-        mv saorsa-node /usr/local/bin/
-        mv saorsa-keygen /usr/local/bin/ 2>/dev/null || true
-        chmod +x /usr/local/bin/saorsa-node
-        rm -f saorsa-node.tar.gz
-        /usr/local/bin/saorsa-node --version
+        curl -sL '${BINARY_URL}' -o ant-node.tar.gz
+        tar xzf ant-node.tar.gz
+        mv ant-node /usr/local/bin/
+        mv ant-keygen /usr/local/bin/ 2>/dev/null || true
+        chmod +x /usr/local/bin/ant-node
+        rm -f ant-node.tar.gz
+        /usr/local/bin/ant-node --version
     "
 
     # Configure system limits

--- a/scripts/testnet/load-test.sh
+++ b/scripts/testnet/load-test.sh
@@ -16,11 +16,11 @@ CHUNK_SIZE_KB=${2:-1}  # Default 1KB chunks
 CONCURRENCY=${3:-10}   # Concurrent operations
 
 # Testnet configuration
-export SAORSA_TEST_BOOTSTRAP="142.93.52.129:12000,24.199.82.114:12000"
-export SAORSA_TEST_EXTERNAL=true
-export SAORSA_TEST_CHUNK_COUNT="$CHUNK_COUNT"
-export SAORSA_TEST_CHUNK_SIZE_KB="$CHUNK_SIZE_KB"
-export SAORSA_TEST_CONCURRENCY="$CONCURRENCY"
+export ANT_TEST_BOOTSTRAP="142.93.52.129:12000,24.199.82.114:12000"
+export ANT_TEST_EXTERNAL=true
+export ANT_TEST_CHUNK_COUNT="$CHUNK_COUNT"
+export ANT_TEST_CHUNK_SIZE_KB="$CHUNK_SIZE_KB"
+export ANT_TEST_CONCURRENCY="$CONCURRENCY"
 export RUST_LOG=info
 
 LOG_FILE="$LOG_DIR/load-test-$(date +%Y%m%d-%H%M%S).log"
@@ -36,7 +36,7 @@ check_health() {
     log "--- Checking Cluster Health ---"
     local TOTAL=0
     for IP in 142.93.52.129 24.199.82.114 192.34.62.192 159.223.131.196; do
-        COUNT=$(ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 root@$IP "pgrep -c saorsa-node 2>/dev/null" 2>/dev/null || echo "0")
+        COUNT=$(ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 root@$IP "pgrep -c ant-node 2>/dev/null" 2>/dev/null || echo "0")
         log "$IP: $COUNT nodes running"
         TOTAL=$((TOTAL + COUNT))
     done
@@ -48,7 +48,7 @@ check_health() {
 }
 
 main() {
-    log "=== Saorsa Load Test ==="
+    log "=== Autonomi Load Test ==="
     log "Chunk count: $CHUNK_COUNT"
     log "Chunk size: ${CHUNK_SIZE_KB}KB"
     log "Concurrency: $CONCURRENCY"
@@ -64,7 +64,7 @@ main() {
     log "--- Starting Load Test ---"
     START_TIME=$(date +%s)
 
-    export SAORSA_TEST_ADDRESSES_FILE="$ADDRESSES_FILE"
+    export ANT_TEST_ADDRESSES_FILE="$ADDRESSES_FILE"
     cargo test --release --test e2e run_load_test -- --ignored --nocapture 2>&1 | tee -a "$LOG_FILE"
 
     END_TIME=$(date +%s)

--- a/scripts/testnet/run-data-tests.sh
+++ b/scripts/testnet/run-data-tests.sh
@@ -9,18 +9,18 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$PROJECT_ROOT"
 
 # Testnet bootstrap nodes
-export SAORSA_TEST_BOOTSTRAP="142.93.52.129:12000,24.199.82.114:12000"
-export SAORSA_TEST_EXTERNAL=true
+export ANT_TEST_BOOTSTRAP="142.93.52.129:12000,24.199.82.114:12000"
+export ANT_TEST_EXTERNAL=true
 export RUST_LOG=info
 
-echo "=== Saorsa Testnet Data Type Tests ==="
-echo "Bootstrap: $SAORSA_TEST_BOOTSTRAP"
+echo "=== Autonomi Testnet Data Type Tests ==="
+echo "Bootstrap: $ANT_TEST_BOOTSTRAP"
 echo ""
 
 # Check cluster health first
 echo "--- Checking Cluster Health ---"
 for IP in 142.93.52.129 24.199.82.114 192.34.62.192 159.223.131.196; do
-    RUNNING=$(ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 root@$IP "pgrep -c saorsa-node 2>/dev/null" 2>/dev/null || echo "0")
+    RUNNING=$(ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 root@$IP "pgrep -c ant-node 2>/dev/null" 2>/dev/null || echo "0")
     echo "$IP: $RUNNING nodes running"
 done
 echo ""

--- a/scripts/testnet/setup-limits.sh
+++ b/scripts/testnet/setup-limits.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Configure system limits for running 50 saorsa nodes
+# Configure system limits for running 50 ant nodes
 # Run this once on each droplet before spawning nodes
 
 set -e
@@ -22,7 +22,7 @@ sysctl -p
 
 # Create data directories
 echo "Creating data directories..."
-mkdir -p /var/lib/saorsa/nodes
+mkdir -p /var/lib/ant/nodes
 
 # Set ulimit for current session
 ulimit -n 65535 2>/dev/null || true

--- a/scripts/testnet/spawn-nodes.sh
+++ b/scripts/testnet/spawn-nodes.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Spawn 50 saorsa nodes on a single droplet
+# Spawn 50 ant nodes on a single droplet
 # Usage: ./spawn-nodes.sh [start_index]
 #
 # start_index: Optional starting index for node numbering (default: 0)
@@ -15,16 +15,16 @@ BOOTSTRAP1="142.93.52.129:12000"
 BOOTSTRAP2="24.199.82.114:12000"
 START_INDEX=${1:-0}
 
-echo "=== Saorsa Node Spawner ==="
+echo "=== Autonomi Node Spawner ==="
 echo "Creating $NODE_COUNT nodes starting at index $START_INDEX"
 echo "Bootstrap nodes: $BOOTSTRAP1, $BOOTSTRAP2"
 
 # Create data directory
-mkdir -p /var/lib/saorsa/nodes
+mkdir -p /var/lib/ant/nodes
 
 for i in $(seq 0 $((NODE_COUNT - 1))); do
     NODE_INDEX=$((START_INDEX + i))
-    NODE_DIR="/var/lib/saorsa/nodes/node-${NODE_INDEX}"
+    NODE_DIR="/var/lib/ant/nodes/node-${NODE_INDEX}"
     PORT=$((BASE_PORT + i))
     METRICS=$((METRICS_BASE + i))
 
@@ -48,14 +48,14 @@ for i in $(seq 0 $((NODE_COUNT - 1))); do
         BOOTSTRAP_FLAGS="-b ${BOOTSTRAP1} -b ${BOOTSTRAP2}"
     fi
 
-    cat > /etc/systemd/system/saorsa-node-${NODE_INDEX}.service <<EOF
+    cat > /etc/systemd/system/ant-node-${NODE_INDEX}.service <<EOF
 [Unit]
-Description=Saorsa Node ${NODE_INDEX}
+Description=Autonomi Node ${NODE_INDEX}
 After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/saorsa-node \\
+ExecStart=/usr/local/bin/ant-node \\
     --root-dir ${NODE_DIR} \\
     --port ${PORT} \\
     --ip-version ipv4 \\

--- a/scripts/testnet/start-all.sh
+++ b/scripts/testnet/start-all.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
-# Start all saorsa nodes across all testnet droplets
+# Start all ant nodes across all testnet droplets
 # Run from local machine
 
 set -e
 
 WORKERS=(
-    "142.93.52.129"   # saorsa-worker-1
-    "24.199.82.114"   # saorsa-worker-2
-    "192.34.62.192"   # saorsa-worker-3
-    "159.223.131.196" # saorsa-worker-4
+    "142.93.52.129"   # ant-worker-1
+    "24.199.82.114"   # ant-worker-2
+    "192.34.62.192"   # ant-worker-3
+    "159.223.131.196" # ant-worker-4
 )
 
 echo "=== Starting All Testnet Nodes ==="
@@ -18,7 +18,7 @@ for i in "${!WORKERS[@]}"; do
     WORKER_NUM=$((i + 1))
     START_INDEX=$((i * 50))
 
-    echo "Starting nodes on saorsa-worker-${WORKER_NUM} ($IP)..."
+    echo "Starting nodes on ant-worker-${WORKER_NUM} ($IP)..."
     ssh -o StrictHostKeyChecking=no "root@${IP}" "/usr/local/bin/start-nodes.sh ${START_INDEX} 50" &
 done
 

--- a/scripts/testnet/start-genesis.sh
+++ b/scripts/testnet/start-genesis.sh
@@ -12,16 +12,16 @@ echo "=== Starting Genesis Bootstrap Nodes ==="
 # Create genesis node-0 on worker-1 (no bootstrap peers needed)
 echo "Creating genesis node-0 on worker-1..."
 ssh -o StrictHostKeyChecking=no root@${WORKER1} "
-    mkdir -p /var/lib/saorsa/nodes/node-0
-    cat > /etc/systemd/system/saorsa-node-0.service <<'EOF'
+    mkdir -p /var/lib/ant/nodes/node-0
+    cat > /etc/systemd/system/ant-node-0.service <<'EOF'
 [Unit]
-Description=Saorsa Genesis Node 0
+Description=Autonomi Genesis Node 0
 After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/saorsa-node \
-    --root-dir /var/lib/saorsa/nodes/node-0 \
+ExecStart=/usr/local/bin/ant-node \
+    --root-dir /var/lib/ant/nodes/node-0 \
     --port 12000 \
     --ip-version ipv4 \
     --metrics-port 9100 \
@@ -38,8 +38,8 @@ CPUQuota=15%
 WantedBy=multi-user.target
 EOF
     systemctl daemon-reload
-    systemctl enable saorsa-node-0
-    systemctl start saorsa-node-0
+    systemctl enable ant-node-0
+    systemctl start ant-node-0
 "
 
 # Wait for node-0 to start
@@ -48,21 +48,21 @@ sleep 10
 
 # Check if node-0 is running
 echo "Checking node-0 status..."
-ssh -o StrictHostKeyChecking=no root@${WORKER1} "systemctl is-active saorsa-node-0 && echo 'Node-0 is running!' || echo 'Node-0 failed to start'"
+ssh -o StrictHostKeyChecking=no root@${WORKER1} "systemctl is-active ant-node-0 && echo 'Node-0 is running!' || echo 'Node-0 failed to start'"
 
 # Create genesis node-50 on worker-2 (bootstrap to node-0)
 echo "Creating genesis node-50 on worker-2..."
 ssh -o StrictHostKeyChecking=no root@${WORKER2} "
-    mkdir -p /var/lib/saorsa/nodes/node-50
-    cat > /etc/systemd/system/saorsa-node-50.service <<'EOF'
+    mkdir -p /var/lib/ant/nodes/node-50
+    cat > /etc/systemd/system/ant-node-50.service <<'EOF'
 [Unit]
-Description=Saorsa Genesis Node 50
+Description=Autonomi Genesis Node 50
 After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/saorsa-node \
-    --root-dir /var/lib/saorsa/nodes/node-50 \
+ExecStart=/usr/local/bin/ant-node \
+    --root-dir /var/lib/ant/nodes/node-50 \
     --port 12000 \
     --ip-version ipv4 \
     -b 142.93.52.129:12000 \
@@ -80,8 +80,8 @@ CPUQuota=15%
 WantedBy=multi-user.target
 EOF
     systemctl daemon-reload
-    systemctl enable saorsa-node-50
-    systemctl start saorsa-node-50
+    systemctl enable ant-node-50
+    systemctl start ant-node-50
 "
 
 # Wait for node-50 to start
@@ -90,7 +90,7 @@ sleep 10
 
 # Check if node-50 is running
 echo "Checking node-50 status..."
-ssh -o StrictHostKeyChecking=no root@${WORKER2} "systemctl is-active saorsa-node-50 && echo 'Node-50 is running!' || echo 'Node-50 failed to start'"
+ssh -o StrictHostKeyChecking=no root@${WORKER2} "systemctl is-active ant-node-50 && echo 'Node-50 is running!' || echo 'Node-50 failed to start'"
 
 echo ""
 echo "=== Genesis Bootstrap Complete ==="

--- a/scripts/testnet/start-nodes.sh
+++ b/scripts/testnet/start-nodes.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Start all saorsa nodes with staggered timing to avoid thundering herd
+# Start all ant nodes with staggered timing to avoid thundering herd
 # Usage: ./start-nodes.sh [start_index] [count]
 
 set -e
@@ -8,12 +8,12 @@ START_INDEX=${1:-0}
 COUNT=${2:-50}
 END_INDEX=$((START_INDEX + COUNT - 1))
 
-echo "=== Starting Saorsa Nodes ==="
+echo "=== Starting Autonomi Nodes ==="
 echo "Starting nodes ${START_INDEX} to ${END_INDEX}"
 
 for i in $(seq $START_INDEX $END_INDEX); do
-    echo "Starting saorsa-node-${i}..."
-    systemctl enable --now saorsa-node-${i}
+    echo "Starting ant-node-${i}..."
+    systemctl enable --now ant-node-${i}
     sleep 0.5  # Stagger to avoid thundering herd
 done
 

--- a/scripts/testnet/start-remaining.sh
+++ b/scripts/testnet/start-remaining.sh
@@ -5,10 +5,10 @@
 set -e
 
 WORKERS=(
-    "142.93.52.129"   # saorsa-worker-1 (nodes 1-49)
-    "24.199.82.114"   # saorsa-worker-2 (nodes 51-99)
-    "192.34.62.192"   # saorsa-worker-3 (nodes 100-149)
-    "159.223.131.196" # saorsa-worker-4 (nodes 150-199)
+    "142.93.52.129"   # ant-worker-1 (nodes 1-49)
+    "24.199.82.114"   # ant-worker-2 (nodes 51-99)
+    "192.34.62.192"   # ant-worker-3 (nodes 100-149)
+    "159.223.131.196" # ant-worker-4 (nodes 150-199)
 )
 
 echo "=== Starting Remaining Nodes ==="
@@ -17,7 +17,7 @@ echo "=== Starting Remaining Nodes ==="
 echo "Starting nodes 1-49 on worker-1..."
 ssh -o StrictHostKeyChecking=no root@${WORKERS[0]} "
     for i in \$(seq 1 49); do
-        systemctl start saorsa-node-\${i} 2>/dev/null || true
+        systemctl start ant-node-\${i} 2>/dev/null || true
         sleep 0.5
     done
     echo 'Worker-1 nodes started'
@@ -27,7 +27,7 @@ ssh -o StrictHostKeyChecking=no root@${WORKERS[0]} "
 echo "Starting nodes 51-99 on worker-2..."
 ssh -o StrictHostKeyChecking=no root@${WORKERS[1]} "
     for i in \$(seq 51 99); do
-        systemctl start saorsa-node-\${i} 2>/dev/null || true
+        systemctl start ant-node-\${i} 2>/dev/null || true
         sleep 0.5
     done
     echo 'Worker-2 nodes started'
@@ -37,7 +37,7 @@ ssh -o StrictHostKeyChecking=no root@${WORKERS[1]} "
 echo "Starting nodes 100-149 on worker-3..."
 ssh -o StrictHostKeyChecking=no root@${WORKERS[2]} "
     for i in \$(seq 100 149); do
-        systemctl start saorsa-node-\${i} 2>/dev/null || true
+        systemctl start ant-node-\${i} 2>/dev/null || true
         sleep 0.5
     done
     echo 'Worker-3 nodes started'
@@ -47,7 +47,7 @@ ssh -o StrictHostKeyChecking=no root@${WORKERS[2]} "
 echo "Starting nodes 150-199 on worker-4..."
 ssh -o StrictHostKeyChecking=no root@${WORKERS[3]} "
     for i in \$(seq 150 199); do
-        systemctl start saorsa-node-\${i} 2>/dev/null || true
+        systemctl start ant-node-\${i} 2>/dev/null || true
         sleep 0.5
     done
     echo 'Worker-4 nodes started'

--- a/scripts/testnet/stop-all.sh
+++ b/scripts/testnet/stop-all.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-# Stop all saorsa nodes across all testnet droplets
+# Stop all ant nodes across all testnet droplets
 # Run from local machine
 
 WORKERS=(
-    "142.93.52.129"   # saorsa-worker-1
-    "24.199.82.114"   # saorsa-worker-2
-    "192.34.62.192"   # saorsa-worker-3
-    "159.223.131.196" # saorsa-worker-4
+    "142.93.52.129"   # ant-worker-1
+    "24.199.82.114"   # ant-worker-2
+    "192.34.62.192"   # ant-worker-3
+    "159.223.131.196" # ant-worker-4
 )
 
 echo "=== Stopping All Testnet Nodes ==="
@@ -16,11 +16,11 @@ for i in "${!WORKERS[@]}"; do
     WORKER_NUM=$((i + 1))
     START_INDEX=$((i * 50))
 
-    echo "Stopping nodes on saorsa-worker-${WORKER_NUM} ($IP)..."
+    echo "Stopping nodes on ant-worker-${WORKER_NUM} ($IP)..."
     ssh -o StrictHostKeyChecking=no "root@${IP}" "
         for j in \$(seq ${START_INDEX} $((START_INDEX + 49))); do
-            systemctl stop saorsa-node-\${j} 2>/dev/null || true
-            systemctl disable saorsa-node-\${j} 2>/dev/null || true
+            systemctl stop ant-node-\${j} 2>/dev/null || true
+            systemctl disable ant-node-\${j} 2>/dev/null || true
         done
         echo 'All nodes stopped on this worker'
     " &

--- a/scripts/testnet/testnet-endurance.sh
+++ b/scripts/testnet/testnet-endurance.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Testnet endurance test - runs data type tests in a loop for 12-24 hours
-# Run from the saorsa-node project root
+# Run from the ant-node project root
 # Usage: ./scripts/testnet/testnet-endurance.sh [duration_hours]
 
 set -e
@@ -23,7 +23,7 @@ cd "$PROJECT_ROOT"
 
 mkdir -p "$LOG_DIR"
 
-echo "=== Saorsa Testnet Endurance Test ===" | tee -a "$LOG_FILE"
+echo "=== Autonomi Testnet Endurance Test ===" | tee -a "$LOG_FILE"
 echo "Duration: ${DURATION_HOURS} hours" | tee -a "$LOG_FILE"
 echo "Bootstrap: ${BOOTSTRAP}" | tee -a "$LOG_FILE"
 echo "Log file: ${LOG_FILE}" | tee -a "$LOG_FILE"
@@ -35,8 +35,8 @@ echo "Building test binary..." | tee -a "$LOG_FILE"
 cargo build --release 2>&1 | tee -a "$LOG_FILE"
 
 # Export test configuration
-export SAORSA_TEST_BOOTSTRAP="$BOOTSTRAP"
-export SAORSA_TEST_EXTERNAL=true
+export ANT_TEST_BOOTSTRAP="$BOOTSTRAP"
+export ANT_TEST_EXTERNAL=true
 export RUST_LOG=info
 
 while [ $(date +%s) -lt $END ]; do
@@ -63,7 +63,7 @@ while [ $(date +%s) -lt $END ]; do
     for PORT in 9100 9101 9102; do
         METRICS=$(curl -s --connect-timeout 5 "http://165.22.4.178:${PORT}/metrics" 2>/dev/null | head -50)
         if [ -n "$METRICS" ]; then
-            echo "$METRICS" | grep -E "^(saorsa_|p2p_|peer_|routing_)" >> "$LOG_FILE"
+            echo "$METRICS" | grep -E "^(ant_|p2p_|peer_|routing_)" >> "$LOG_FILE"
             break
         fi
     done

--- a/scripts/testnet/upgrade-test.sh
+++ b/scripts/testnet/upgrade-test.sh
@@ -12,7 +12,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 WORKERS=("142.93.52.129" "24.199.82.114" "192.34.62.192" "159.223.131.196")
 START_INDICES=(0 50 100 150)
 
-echo "=== Saorsa Upgrade Test ==="
+echo "=== Autonomi Upgrade Test ==="
 echo "Testing auto-upgrade functionality across 200-node testnet"
 echo ""
 
@@ -21,8 +21,8 @@ get_all_versions() {
     echo "--- Current Versions ---"
     for i in "${!WORKERS[@]}"; do
         IP="${WORKERS[$i]}"
-        VERSION=$(ssh -o StrictHostKeyChecking=no root@$IP "/usr/local/bin/saorsa-node --version 2>/dev/null | head -1" || echo "unknown")
-        RUNNING=$(ssh -o StrictHostKeyChecking=no root@$IP "pgrep -c saorsa-node 2>/dev/null" || echo "0")
+        VERSION=$(ssh -o StrictHostKeyChecking=no root@$IP "/usr/local/bin/ant-node --version 2>/dev/null | head -1" || echo "unknown")
+        RUNNING=$(ssh -o StrictHostKeyChecking=no root@$IP "pgrep -c ant-node 2>/dev/null" || echo "0")
         echo "Worker $((i+1)) ($IP): $VERSION - $RUNNING nodes running"
     done
     echo ""
@@ -34,7 +34,7 @@ check_upgrade_config() {
     for i in "${!WORKERS[@]}"; do
         IP="${WORKERS[$i]}"
         echo -n "Worker $((i+1)) ($IP): "
-        RUNNING=$(ssh -o StrictHostKeyChecking=no root@$IP "pgrep -c saorsa-node 2>/dev/null" || echo "0")
+        RUNNING=$(ssh -o StrictHostKeyChecking=no root@$IP "pgrep -c ant-node 2>/dev/null" || echo "0")
         echo "$RUNNING nodes running (auto-upgrade always enabled)"
     done
     echo ""
@@ -65,11 +65,11 @@ monitor_upgrade() {
             IP="${WORKERS[$i]}"
 
             # Count nodes on target version (check logs for version)
-            RUNNING=$(ssh -o StrictHostKeyChecking=no root@$IP "pgrep -c saorsa-node 2>/dev/null" || echo "0")
+            RUNNING=$(ssh -o StrictHostKeyChecking=no root@$IP "pgrep -c ant-node 2>/dev/null" || echo "0")
             TOTAL_NODES=$((TOTAL_NODES + RUNNING))
 
             # Check if binary is updated
-            CURRENT_VER=$(ssh -o StrictHostKeyChecking=no root@$IP "/usr/local/bin/saorsa-node --version 2>/dev/null | grep -oP 'saorsa-node \K[0-9.]+'" || echo "0")
+            CURRENT_VER=$(ssh -o StrictHostKeyChecking=no root@$IP "/usr/local/bin/ant-node --version 2>/dev/null | grep -oP 'ant-node \K[0-9.]+'" || echo "0")
             if [ "$CURRENT_VER" = "$TARGET_VERSION" ]; then
                 TOTAL_UPGRADED=$((TOTAL_UPGRADED + RUNNING))
             fi
@@ -101,7 +101,7 @@ get_latest_release
 
 echo ""
 echo "=== Phase 2: Check for Pending Upgrade ==="
-CURRENT_VER=$(ssh -o StrictHostKeyChecking=no root@${WORKERS[0]} "/usr/local/bin/saorsa-node --version 2>/dev/null | grep -oP 'saorsa-node \K[0-9.]+'" || echo "0")
+CURRENT_VER=$(ssh -o StrictHostKeyChecking=no root@${WORKERS[0]} "/usr/local/bin/ant-node --version 2>/dev/null | grep -oP 'ant-node \K[0-9.]+'" || echo "0")
 LATEST_VER=$(gh release view --json tagName -q '.tagName' 2>/dev/null | sed 's/v//' || echo "unknown")
 
 echo "Current version: $CURRENT_VER"

--- a/src/ant_protocol/chunk.rs
+++ b/src/ant_protocol/chunk.rs
@@ -9,7 +9,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Protocol identifier for chunk operations.
-pub const CHUNK_PROTOCOL_ID: &str = "saorsa/ant/chunk/v1";
+pub const CHUNK_PROTOCOL_ID: &str = "autonomi/ant/chunk/v1";
 
 /// Current protocol version.
 pub const PROTOCOL_VERSION: u16 = 1;
@@ -519,7 +519,7 @@ mod tests {
 
     #[test]
     fn test_constants() {
-        assert_eq!(CHUNK_PROTOCOL_ID, "saorsa/ant/chunk/v1");
+        assert_eq!(CHUNK_PROTOCOL_ID, "autonomi/ant/chunk/v1");
         assert_eq!(PROTOCOL_VERSION, 1);
         assert_eq!(MAX_CHUNK_SIZE, 4 * 1024 * 1024);
         assert_eq!(DATA_TYPE_CHUNK, 0);

--- a/src/ant_protocol/mod.rs
+++ b/src/ant_protocol/mod.rs
@@ -1,7 +1,7 @@
-//! ANT protocol implementation for the saorsa network.
+//! ANT protocol implementation for the Autonomi network.
 //!
 //! This module implements the wire protocol for storing and retrieving
-//! data on the saorsa network, compatible with the autonomi network protocol.
+//! data on the Autonomi network.
 //!
 //! # Data Types
 //!
@@ -31,7 +31,7 @@
 //! # Example
 //!
 //! ```rust,ignore
-//! use saorsa_node::ant_protocol::{ChunkMessage, ChunkPutRequest, ChunkGetRequest};
+//! use ant_node::ant_protocol::{ChunkMessage, ChunkPutRequest, ChunkGetRequest};
 //!
 //! // Create a PUT request
 //! let address = compute_address(&data);

--- a/src/bin/ant-devnet/cli.rs
+++ b/src/bin/ant-devnet/cli.rs
@@ -1,11 +1,11 @@
-//! CLI definition for saorsa-devnet.
+//! CLI definition for ant-devnet.
 
 use clap::Parser;
 use std::path::PathBuf;
 
-/// Local devnet runner for saorsa-node.
+/// Local devnet runner for ant-node.
 #[derive(Parser, Debug)]
-#[command(name = "saorsa-devnet")]
+#[command(name = "ant-devnet")]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
     /// Node count to spawn.

--- a/src/bin/ant-devnet/main.rs
+++ b/src/bin/ant-devnet/main.rs
@@ -1,10 +1,10 @@
-//! saorsa-devnet CLI entry point.
+//! ant-devnet CLI entry point.
 
 mod cli;
 
+use ant_node::devnet::{Devnet, DevnetConfig, DevnetEvmInfo, DevnetManifest};
 use clap::Parser;
 use cli::Cli;
-use saorsa_node::devnet::{Devnet, DevnetConfig, DevnetEvmInfo, DevnetManifest};
 use tracing::info;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
@@ -22,7 +22,7 @@ async fn main() -> color_eyre::Result<()> {
         .with(filter)
         .init();
 
-    info!("saorsa-devnet v{}", env!("CARGO_PKG_VERSION"));
+    info!("ant-devnet v{}", env!("CARGO_PKG_VERSION"));
 
     let mut config =
         cli.preset

--- a/src/bin/ant-node/cli.rs
+++ b/src/bin/ant-node/cli.rs
@@ -1,32 +1,32 @@
 //! Command-line interface definition.
 
-use clap::{Parser, ValueEnum};
-use saorsa_node::config::{
+use ant_node::config::{
     BootstrapCacheConfig, EvmNetworkConfig, IpVersion, NetworkMode, NodeConfig, PaymentConfig,
     UpgradeChannel,
 };
+use clap::{Parser, ValueEnum};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
-/// Pure quantum-proof network node for the Saorsa decentralized network.
+/// Pure quantum-proof network node for the Autonomi decentralized network.
 #[derive(Parser, Debug)]
-#[command(name = "saorsa-node")]
+#[command(name = "ant-node")]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
     /// Root directory for node data.
-    #[arg(long, env = "SAORSA_ROOT_DIR")]
+    #[arg(long, env = "ANT_ROOT_DIR")]
     pub root_dir: Option<PathBuf>,
 
     /// Listening port (0 for auto-select).
-    #[arg(long, short, default_value = "0", env = "SAORSA_PORT")]
+    #[arg(long, short, default_value = "0", env = "ANT_PORT")]
     pub port: u16,
 
     /// IP version to use.
-    #[arg(long, value_enum, default_value = "dual", env = "SAORSA_IP_VERSION")]
+    #[arg(long, value_enum, default_value = "dual", env = "ANT_IP_VERSION")]
     pub ip_version: CliIpVersion,
 
     /// Bootstrap peer addresses.
-    #[arg(long, short, env = "SAORSA_BOOTSTRAP")]
+    #[arg(long, short, env = "ANT_BOOTSTRAP")]
     pub bootstrap: Vec<SocketAddr>,
 
     /// Release channel for upgrades.
@@ -34,16 +34,16 @@ pub struct Cli {
         long,
         value_enum,
         default_value = "stable",
-        env = "SAORSA_UPGRADE_CHANNEL"
+        env = "ANT_UPGRADE_CHANNEL"
     )]
     pub upgrade_channel: CliUpgradeChannel,
 
     /// Cache capacity for verified `XorName` values.
-    #[arg(long, default_value = "100000", env = "SAORSA_CACHE_CAPACITY")]
+    #[arg(long, default_value = "100000", env = "ANT_CACHE_CAPACITY")]
     pub cache_capacity: usize,
 
     /// EVM wallet address for receiving payments (e.g., "0x...").
-    #[arg(long, env = "SAORSA_REWARDS_ADDRESS")]
+    #[arg(long, env = "ANT_REWARDS_ADDRESS")]
     pub rewards_address: Option<String>,
 
     /// EVM network for payment processing.
@@ -51,12 +51,12 @@ pub struct Cli {
         long,
         value_enum,
         default_value = "arbitrum-one",
-        env = "SAORSA_EVM_NETWORK"
+        env = "ANT_EVM_NETWORK"
     )]
     pub evm_network: CliEvmNetwork,
 
     /// Metrics port for Prometheus scraping (0 to disable).
-    #[arg(long, default_value = "9100", env = "SAORSA_METRICS_PORT")]
+    #[arg(long, default_value = "9100", env = "ANT_METRICS_PORT")]
     pub metrics_port: u16,
 
     /// Log level.
@@ -64,18 +64,18 @@ pub struct Cli {
     pub log_level: CliLogLevel,
 
     /// Log output format.
-    #[arg(long, value_enum, default_value = "text", env = "SAORSA_LOG_FORMAT")]
+    #[arg(long, value_enum, default_value = "text", env = "ANT_LOG_FORMAT")]
     pub log_format: CliLogFormat,
 
     /// Directory for log file output.
     /// When set, logs are written to files in this directory instead of stdout.
-    /// Files rotate daily and are named saorsa-node.YYYY-MM-DD.log.
-    #[arg(long, env = "SAORSA_LOG_DIR")]
+    /// Files rotate daily and are named ant-node.YYYY-MM-DD.log.
+    #[arg(long, env = "ANT_LOG_DIR")]
     pub log_dir: Option<PathBuf>,
 
     /// Maximum number of rotated log files to retain (only used with --log-dir).
     /// Oldest files are deleted when this limit is reached. Rotation is daily.
-    #[arg(long, default_value = "7", env = "SAORSA_LOG_MAX_FILES")]
+    #[arg(long, default_value = "7", env = "ANT_LOG_MAX_FILES")]
     pub log_max_files: usize,
 
     /// Network mode (production, testnet, or development).
@@ -85,7 +85,7 @@ pub struct Cli {
         long,
         value_enum,
         default_value = "production",
-        env = "SAORSA_NETWORK_MODE"
+        env = "ANT_NETWORK_MODE"
     )]
     pub network_mode: CliNetworkMode,
 
@@ -104,11 +104,11 @@ pub struct Cli {
     pub disable_bootstrap_cache: bool,
 
     /// Directory for bootstrap cache files.
-    #[arg(long, env = "SAORSA_BOOTSTRAP_CACHE_DIR")]
+    #[arg(long, env = "ANT_BOOTSTRAP_CACHE_DIR")]
     pub bootstrap_cache_dir: Option<PathBuf>,
 
     /// Maximum peers to cache in the bootstrap cache.
-    #[arg(long, default_value = "10000", env = "SAORSA_BOOTSTRAP_CACHE_CAPACITY")]
+    #[arg(long, default_value = "10000", env = "ANT_BOOTSTRAP_CACHE_CAPACITY")]
     pub bootstrap_cache_capacity: usize,
 }
 

--- a/src/bin/ant-node/main.rs
+++ b/src/bin/ant-node/main.rs
@@ -1,11 +1,11 @@
-//! saorsa-node CLI entry point.
+//! ant-node CLI entry point.
 
 mod cli;
 mod platform;
 
+use ant_node::NodeBuilder;
 use clap::Parser;
 use cli::{Cli, CliLogFormat};
-use saorsa_node::NodeBuilder;
 use tracing::{info, warn};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter, Layer};
@@ -45,7 +45,7 @@ async fn main() -> color_eyre::Result<()> {
             let file_appender = tracing_appender::rolling::Builder::new()
                 .rotation(tracing_appender::rolling::Rotation::DAILY)
                 .max_log_files(log_max_files)
-                .filename_prefix("saorsa-node")
+                .filename_prefix("ant-node")
                 .filename_suffix("log")
                 .build(dir)?;
             let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
@@ -56,7 +56,7 @@ async fn main() -> color_eyre::Result<()> {
             let file_appender = tracing_appender::rolling::Builder::new()
                 .rotation(tracing_appender::rolling::Rotation::DAILY)
                 .max_log_files(log_max_files)
-                .filename_prefix("saorsa-node")
+                .filename_prefix("ant-node")
                 .filename_suffix("log")
                 .build(dir)?;
             let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
@@ -78,8 +78,8 @@ async fn main() -> color_eyre::Result<()> {
 
     info!(
         version = env!("CARGO_PKG_VERSION"),
-        commit = env!("SAORSA_GIT_COMMIT"),
-        "saorsa-node starting"
+        commit = env!("ANT_GIT_COMMIT"),
+        "ant-node starting"
     );
 
     // Prevent macOS App Nap from throttling background timer operations.

--- a/src/bin/ant-node/platform.rs
+++ b/src/bin/ant-node/platform.rs
@@ -40,7 +40,7 @@ pub fn disable_app_nap() -> Result<AppNapActivity, String> {
         let options: u64 = 0x00FF_FFFF;
 
         let reason =
-            NSString::from_str("saorsa-node: P2P network daemon performing background operations");
+            NSString::from_str("ant-node: P2P network daemon performing background operations");
 
         let activity: AppNapActivity = msg_send![
             &process_info,

--- a/src/bin/keygen.rs
+++ b/src/bin/keygen.rs
@@ -1,4 +1,4 @@
-//! ML-DSA-65 key management utility for saorsa-node release signing.
+//! ML-DSA-65 key management utility for ant-node release signing.
 //!
 //! This utility provides:
 //! - Keypair generation for release signing
@@ -8,9 +8,9 @@
 //! # Usage
 //!
 //! ```text
-//! saorsa-keygen generate [output-dir]    Generate a new keypair
-//! saorsa-keygen sign --key <key> --input <file> --output <sig>
-//! saorsa-keygen verify --key <key> --input <file> --signature <sig>
+//! ant-keygen generate [output-dir]    Generate a new keypair
+//! ant-keygen sign --key <key> --input <file> --output <sig>
+//! ant-keygen verify --key <key> --input <file> --signature <sig>
 //! ```
 
 // This is a standalone CLI tool that exits on any error, so expect/unwrap is acceptable
@@ -26,11 +26,11 @@ use std::path::PathBuf;
 use std::process;
 
 /// Signing context for domain separation (prevents cross-protocol attacks).
-const SIGNING_CONTEXT: &[u8] = b"saorsa-node-release-v1";
+const SIGNING_CONTEXT: &[u8] = b"ant-node-release-v1";
 
 #[derive(Parser)]
-#[command(name = "saorsa-keygen")]
-#[command(about = "ML-DSA-65 key management for saorsa-node releases")]
+#[command(name = "ant-keygen")]
+#[command(about = "ML-DSA-65 key management for ant-node releases")]
 #[command(version)]
 struct Cli {
     #[command(subcommand)]
@@ -86,7 +86,7 @@ fn main() {
 }
 
 fn generate_keypair(output_dir: &PathBuf) {
-    println!("ML-DSA-65 Keypair Generator for saorsa-node releases\n");
+    println!("ML-DSA-65 Keypair Generator for ant-node releases\n");
 
     // Create output directory if it doesn't exist
     fs::create_dir_all(output_dir).expect("Failed to create output directory");

--- a/src/client/data_types.rs
+++ b/src/client/data_types.rs
@@ -1,7 +1,7 @@
 //! Data type definitions for chunk storage.
 //!
 //! This module provides the core data types for content-addressed chunk storage
-//! on the saorsa network. Chunks are immutable, content-addressed blobs where
+//! on the Autonomi network. Chunks are immutable, content-addressed blobs where
 //! the address is the BLAKE3 hash of the content.
 
 use bytes::Bytes;
@@ -41,7 +41,7 @@ pub type XorName = [u8; 32];
 
 /// A chunk of data with its content-addressed identifier.
 ///
-/// Chunks are the fundamental storage unit in saorsa. They are:
+/// Chunks are the fundamental storage unit in Autonomi. They are:
 /// - **Immutable**: Content cannot be changed after storage
 /// - **Content-addressed**: Address = BLAKE3(content)
 /// - **Paid**: Storage requires EVM payment on Arbitrum

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,7 +1,7 @@
-//! Protocol helpers for saorsa-node client operations.
+//! Protocol helpers for ant-node client operations.
 //!
 //! This module provides low-level protocol support for client-node communication.
-//! For high-level client operations, use the `saorsa-client` crate instead.
+//! For high-level client operations, use the `ant-client` crate instead.
 //!
 //! # Architecture
 //!
@@ -12,13 +12,13 @@
 //!
 //! # Migration Note
 //!
-//! The `QuantumClient` has been deprecated and consolidated into `saorsa-client::Client`.
-//! Use `saorsa-client` for all client operations.
+//! The `QuantumClient` has been deprecated and consolidated into `ant-client::Client`.
+//! Use `ant-client` for all client operations.
 //!
 //! # Example
 //!
 //! ```rust,ignore
-//! use saorsa_client::Client; // Use saorsa-client instead of QuantumClient
+//! use ant_client::Client; // Use ant-client instead of QuantumClient
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -50,9 +50,9 @@ use ant_evm::EncodedPeerId;
 /// Identity multihash code (stores raw bytes without hashing).
 const MULTIHASH_IDENTITY_CODE: u64 = 0x00;
 
-/// Convert a hex-encoded 32-byte saorsa-core node ID to an [`EncodedPeerId`].
+/// Convert a hex-encoded 32-byte node ID to an [`EncodedPeerId`].
 ///
-/// Saorsa-core peer IDs are 64-character hex strings representing 32 raw bytes.
+/// Peer IDs are 64-character hex strings representing 32 raw bytes.
 /// libp2p `PeerId` expects a multihash-encoded identity. This function bridges the two
 /// formats by wrapping the raw bytes in an identity multihash (code 0x00) and then
 /// converting to `EncodedPeerId` via `From<PeerId>`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-//! Configuration for saorsa-node.
+//! Configuration for ant-node.
 
 use serde::{Deserialize, Serialize};
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
@@ -265,7 +265,7 @@ impl NodeConfig {
     ///
     /// This is a convenience method for setting up a testnet node with
     /// relaxed anti-Sybil protection, suitable for single-provider deployments.
-    /// Includes default bootstrap nodes for the Saorsa testnet.
+    /// Includes default bootstrap nodes for the Autonomi testnet.
     #[must_use]
     pub fn testnet() -> Self {
         Self {
@@ -335,14 +335,14 @@ impl Default for UpgradeConfig {
 }
 
 fn default_github_repo() -> String {
-    "saorsa-labs/saorsa-node".to_string()
+    "WithAutonomi/ant-node".to_string()
 }
 
-/// Default base directory for node data (platform data dir for "saorsa").
+/// Default base directory for node data (platform data dir for "ant").
 #[must_use]
 pub fn default_root_dir() -> PathBuf {
-    directories::ProjectDirs::from("", "", "saorsa").map_or_else(
-        || PathBuf::from(".saorsa"),
+    directories::ProjectDirs::from("", "", "ant").map_or_else(
+        || PathBuf::from(".ant"),
         |dirs| dirs.data_dir().to_path_buf(),
     )
 }
@@ -484,14 +484,14 @@ const fn default_storage_verify_on_read() -> bool {
 
 /// Default testnet bootstrap nodes.
 ///
-/// These are well-known bootstrap nodes for the Saorsa testnet.
-/// - saorsa-bootstrap-1 (NYC): 165.22.4.178:12000
-/// - saorsa-bootstrap-2 (SFO): 164.92.111.156:12000
+/// These are well-known bootstrap nodes for the Autonomi testnet.
+/// - ant-bootstrap-1 (NYC): 165.22.4.178:12000
+/// - ant-bootstrap-2 (SFO): 164.92.111.156:12000
 fn default_testnet_bootstrap() -> Vec<SocketAddr> {
     vec![
-        // saorsa-bootstrap-1 (Digital Ocean NYC1)
+        // ant-bootstrap-1 (Digital Ocean NYC1)
         SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(165, 22, 4, 178), 12000)),
-        // saorsa-bootstrap-2 (Digital Ocean SFO3)
+        // ant-bootstrap-2 (Digital Ocean SFO3)
         SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(164, 92, 111, 156), 12000)),
     ]
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,11 @@
-//! Error types for saorsa-node.
+//! Error types for ant-node.
 
 use thiserror::Error;
 
 /// Result type alias using the crate's Error type.
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Errors that can occur in saorsa-node.
+/// Errors that can occur in ant-node.
 #[derive(Error, Debug)]
 pub enum Error {
     /// Configuration error.
@@ -16,7 +16,7 @@ pub enum Error {
     #[error("node startup failed: {0}")]
     Startup(String),
 
-    /// Network error from saorsa-core.
+    /// Network error from the core networking layer.
     #[error("network error: {0}")]
     Network(String),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-//! # saorsa-node
+//! # ant-node
 //!
-//! A pure quantum-proof network node for the Saorsa decentralized network.
+//! A pure quantum-proof network node for the Autonomi decentralized network.
 //!
 //! This crate provides a thin wrapper around `saorsa-core` that adds:
 //! - Auto-upgrade system with ML-DSA signature verification
@@ -9,7 +9,7 @@
 //!
 //! ## Architecture
 //!
-//! `saorsa-node` delegates all core functionality to `saorsa-core`:
+//! `ant-node` delegates all core functionality to `saorsa-core`:
 //! - Networking via `P2PNode`
 //! - DHT via `AdaptiveDHT`
 //! - Trust via `TrustEngine`
@@ -23,7 +23,7 @@
 //! ## Example
 //!
 //! ```rust,no_run
-//! use saorsa_node::{NodeBuilder, NodeConfig};
+//! use ant_node::{NodeBuilder, NodeConfig};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -66,8 +66,8 @@ pub use node::{NodeBuilder, RunningNode};
 pub use payment::{PaymentStatus, PaymentVerifier, PaymentVerifierConfig};
 pub use storage::{AntProtocol, LmdbStorage, LmdbStorageConfig};
 
-/// Re-exports from `saorsa-core` so downstream crates (e.g. `saorsa-client`)
-/// can depend on `saorsa-node` alone without a direct `saorsa-core` dependency.
+/// Re-exports from `saorsa-core` so downstream crates (e.g. `ant-client`)
+/// can depend on `ant-node` alone without a direct `saorsa-core` dependency.
 pub mod core {
     pub use saorsa_core::identity::{NodeIdentity, PeerId};
     pub use saorsa_core::{

--- a/src/node.rs
+++ b/src/node.rs
@@ -41,7 +41,7 @@ pub const NODE_STORAGE_LIMIT_BYTES: u64 = 5 * 1024 * 1024 * 1024;
 #[cfg(unix)]
 use tokio::signal::unix::{signal, SignalKind};
 
-/// Builder for constructing a saorsa node.
+/// Builder for constructing an Ant node.
 pub struct NodeBuilder {
     config: NodeConfig,
 }
@@ -59,7 +59,7 @@ impl NodeBuilder {
     ///
     /// Returns an error if the node fails to start.
     pub async fn build(mut self) -> Result<RunningNode> {
-        info!("Building saorsa-node with config: {:?}", self.config);
+        info!("Building ant-node with config: {:?}", self.config);
 
         // Validate rewards address in production
         if self.config.network_mode == NetworkMode::Production {
@@ -424,7 +424,7 @@ impl NodeBuilder {
     }
 }
 
-/// A running saorsa node.
+/// A running Ant node.
 pub struct RunningNode {
     config: NodeConfig,
     p2p_node: Arc<P2PNode>,

--- a/src/payment/metrics.rs
+++ b/src/payment/metrics.rs
@@ -1,4 +1,4 @@
-//! Quoting metrics tracking for saorsa-node.
+//! Quoting metrics tracking for ant-node.
 //!
 //! Tracks metrics used for quote generation, including:
 //! - `received_payment_count` - number of payments received

--- a/src/payment/mod.rs
+++ b/src/payment/mod.rs
@@ -1,4 +1,4 @@
-//! Payment verification system for saorsa-node.
+//! Payment verification system for ant-node.
 //!
 //! This module implements the payment verification strategy:
 //! 1. Check LRU cache for already-verified data

--- a/src/payment/pricing.rs
+++ b/src/payment/pricing.rs
@@ -1,4 +1,4 @@
-//! Local fullness-based pricing algorithm for saorsa-node.
+//! Local fullness-based pricing algorithm for ant-node.
 //!
 //! Mirrors the logarithmic pricing curve from autonomi's `MerklePaymentVault` contract:
 //! - Empty node → price ≈ `MIN_PRICE` (floor)

--- a/src/payment/quote.rs
+++ b/src/payment/quote.rs
@@ -1,7 +1,7 @@
-//! Payment quote generation for saorsa-node.
+//! Payment quote generation for ant-node.
 //!
 //! Generates `PaymentQuote` values that clients use to pay for data storage.
-//! Compatible with the autonomi payment system.
+//! Compatible with the Autonomi payment system.
 //!
 //! NOTE: Quote generation requires integration with the node's signing
 //! capabilities from saorsa-core. This module provides the interface
@@ -88,7 +88,7 @@ impl QuoteGenerator {
             .sign_fn
             .as_ref()
             .ok_or_else(|| Error::Payment("Signer not set".to_string()))?;
-        let test_msg = b"saorsa-signing-probe";
+        let test_msg = b"ant-signing-probe";
         let test_sig = sign_fn(test_msg);
         if test_sig.is_empty() {
             return Err(Error::Payment(
@@ -276,7 +276,7 @@ pub fn verify_quote_content(quote: &PaymentQuote, expected_content: &XorName) ->
 /// Verify that a payment quote has a valid ML-DSA-65 signature.
 ///
 /// This replaces ant-evm's `check_is_signed_by_claimed_peer()` which only
-/// handles Ed25519/libp2p signatures. Saorsa uses ML-DSA-65 post-quantum
+/// handles Ed25519/libp2p signatures. Autonomi uses ML-DSA-65 post-quantum
 /// signatures for quote signing.
 ///
 /// # Arguments
@@ -309,7 +309,7 @@ pub fn verify_quote_signature(quote: &PaymentQuote) -> bool {
     // Get the bytes that were signed
     let bytes = quote.bytes_for_sig();
 
-    // Verify using saorsa's ML-DSA-65 implementation
+    // Verify using ML-DSA-65 implementation
     let ml_dsa = MlDsa65::new();
     match ml_dsa.verify(&pub_key, &bytes, &signature) {
         Ok(valid) => {
@@ -327,7 +327,7 @@ pub fn verify_quote_signature(quote: &PaymentQuote) -> bool {
 
 /// Verify a `MerklePaymentCandidateNode` signature using ML-DSA-65.
 ///
-/// Saorsa uses ML-DSA-65 post-quantum signatures for merkle candidate signing,
+/// Autonomi uses ML-DSA-65 post-quantum signatures for merkle candidate signing,
 /// rather than the ed25519 signatures used by the upstream `ant-evm` library.
 /// The `pub_key` field contains the raw ML-DSA-65 public key bytes, and
 /// `signature` contains the ML-DSA-65 signature over `bytes_to_sign()`.

--- a/src/payment/single_node.rs
+++ b/src/payment/single_node.rs
@@ -1,4 +1,4 @@
-//! `SingleNode` payment mode implementation for saorsa-node.
+//! `SingleNode` payment mode implementation for ant-node.
 //!
 //! This module implements the `SingleNode` payment strategy from autonomi:
 //! - Client gets 5 quotes from network (`CLOSE_GROUP_SIZE`)

--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -1,6 +1,6 @@
 //! Payment verifier with LRU cache and EVM verification.
 //!
-//! This is the core payment verification logic for saorsa-node.
+//! This is the core payment verification logic for ant-node.
 //! All new data requires EVM payment on Arbitrum (no free tier).
 
 use crate::error::{Error, Result};
@@ -105,7 +105,7 @@ impl PaymentStatus {
 /// Default capacity for the merkle pool cache (number of pool hashes to cache).
 const DEFAULT_POOL_CACHE_CAPACITY: usize = 1_000;
 
-/// Main payment verifier for saorsa-node.
+/// Main payment verifier for ant-node.
 ///
 /// Uses:
 /// 1. LRU cache for fast lookups of previously verified `XorName` values
@@ -1267,9 +1267,9 @@ mod tests {
 
     /// Helper: build an `EncodedPeerId` that matches the BLAKE3 hash of an ML-DSA public key.
     fn encoded_peer_id_for_pub_key(pub_key: &[u8]) -> ant_evm::EncodedPeerId {
-        let saorsa_peer_id = peer_id_from_public_key_bytes(pub_key).expect("valid ML-DSA pub key");
+        let ant_peer_id = peer_id_from_public_key_bytes(pub_key).expect("valid ML-DSA pub key");
         // Wrap raw 32-byte peer ID in identity multihash format: [0x00, length, ...bytes]
-        let raw = saorsa_peer_id.as_bytes();
+        let raw = ant_peer_id.as_bytes();
         let mut multihash_bytes = Vec::with_capacity(2 + raw.len());
         multihash_bytes.push(0x00); // identity multihash code
                                     // PeerId is always 32 bytes, safely fits in u8

--- a/src/storage/handler.rs
+++ b/src/storage/handler.rs
@@ -9,7 +9,7 @@
 //! ┌─────────────────────────────────────────────────────────┐
 //! │                    AntProtocol                        │
 //! ├─────────────────────────────────────────────────────────┤
-//! │  protocol_id() = "saorsa/ant/chunk/v1"                  │
+//! │  protocol_id() = "autonomi/ant/chunk/v1"                  │
 //! │                                                         │
 //! │  handle_message(data) ──▶ decode ChunkMessage  │
 //! │                                   │                     │

--- a/src/storage/lmdb.rs
+++ b/src/storage/lmdb.rs
@@ -36,7 +36,7 @@ pub struct LmdbStorageConfig {
 impl Default for LmdbStorageConfig {
     fn default() -> Self {
         Self {
-            root_dir: PathBuf::from(".saorsa/chunks"),
+            root_dir: PathBuf::from(".ant/chunks"),
             verify_on_read: true,
             max_chunks: 0,
             max_map_size: 0,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -10,7 +10,7 @@
 //! ┌─────────────────────────────────────────────────────────┐
 //! │        AntProtocol (implements Protocol trait)        │
 //! ├─────────────────────────────────────────────────────────┤
-//! │  protocol_id() = "saorsa/ant/chunk/v1"                  │
+//! │  protocol_id() = "autonomi/ant/chunk/v1"                  │
 //! │                                                         │
 //! │  handle(peer_id, data) ──▶ decode AntProtocolMessage │
 //! │                                   │                     │
@@ -31,7 +31,7 @@
 //!
 //! ```rust,ignore
 //! use std::sync::Arc;
-//! use saorsa_node::storage::{AntProtocol, LmdbStorage, LmdbStorageConfig};
+//! use ant_node::storage::{AntProtocol, LmdbStorage, LmdbStorageConfig};
 //!
 //! // Create storage
 //! let config = LmdbStorageConfig::default();

--- a/src/upgrade/apply.rs
+++ b/src/upgrade/apply.rs
@@ -51,7 +51,7 @@ impl AutoApplyUpgrader {
         Self {
             current_version,
             client: reqwest::Client::builder()
-                .user_agent(concat!("saorsa-node/", env!("CARGO_PKG_VERSION")))
+                .user_agent(concat!("ant-node/", env!("CARGO_PKG_VERSION")))
                 .timeout(std::time::Duration::from_secs(300))
                 .build()
                 .unwrap_or_else(|_| reqwest::Client::new()),
@@ -178,7 +178,7 @@ impl AutoApplyUpgrader {
 
         // Create temp directory for upgrade
         let temp_dir = tempfile::Builder::new()
-            .prefix("saorsa-upgrade-")
+            .prefix("ant-upgrade-")
             .tempdir_in(binary_dir)
             .map_err(|e| Error::Upgrade(format!("Failed to create temp dir: {e}")))?;
 
@@ -220,7 +220,7 @@ impl AutoApplyUpgrader {
             "{}.backup",
             current_binary
                 .file_name()
-                .map_or_else(|| "saorsa-node".into(), |s| s.to_string_lossy())
+                .map_or_else(|| "ant-node".into(), |s| s.to_string_lossy())
         ));
         info!("Creating backup at {}...", backup_path.display());
         if let Err(e) = fs::copy(&current_binary, &backup_path) {
@@ -323,7 +323,7 @@ impl AutoApplyUpgrader {
                 let dest = dest_dir.join(
                     cached_path
                         .file_name()
-                        .unwrap_or_else(|| std::ffi::OsStr::new("saorsa-node")),
+                        .unwrap_or_else(|| std::ffi::OsStr::new("ant-node")),
                 );
                 if let Err(e) = fs::copy(&cached_path, &dest) {
                     warn!("Failed to copy from cache, will re-download: {e}");
@@ -354,7 +354,7 @@ impl AutoApplyUpgrader {
                 let dest = dest_dir.join(
                     cached_path
                         .file_name()
-                        .unwrap_or_else(|| std::ffi::OsStr::new("saorsa-node")),
+                        .unwrap_or_else(|| std::ffi::OsStr::new("ant-node")),
                 );
                 fs::copy(&cached_path, &dest)?;
                 return Ok(dest);
@@ -388,7 +388,7 @@ impl AutoApplyUpgrader {
         let sig_path = dest_dir.join("signature");
 
         // Step 1: Download archive
-        info!("Downloading saorsa-node binary...");
+        info!("Downloading ant-node binary...");
         self.download(&info.download_url, &archive_path).await?;
 
         // Step 2: Download signature
@@ -415,7 +415,7 @@ impl AutoApplyUpgrader {
         Ok(extracted_binary)
     }
 
-    /// Extract the saorsa-node binary from an archive (tar.gz or zip).
+    /// Extract the ant-node binary from an archive (tar.gz or zip).
     ///
     /// The archive format is detected by magic bytes:
     /// - `1f 8b` → gzip (tar.gz)
@@ -437,16 +437,16 @@ impl AutoApplyUpgrader {
         }
     }
 
-    /// Extract the saorsa-node binary from a tar.gz archive.
+    /// Extract the ant-node binary from a tar.gz archive.
     fn extract_from_tar_gz(archive_path: &Path, dest_dir: &Path) -> Result<PathBuf> {
         let file = File::open(archive_path)?;
         let decoder = GzDecoder::new(file);
         let mut archive = Archive::new(decoder);
 
         let binary_name = if cfg!(windows) {
-            "saorsa-node.exe"
+            "ant-node.exe"
         } else {
-            "saorsa-node"
+            "ant-node"
         };
         let extracted_binary = dest_dir.join(binary_name);
 
@@ -460,10 +460,10 @@ impl AutoApplyUpgrader {
                 .path()
                 .map_err(|e| Error::Upgrade(format!("Invalid path in archive: {e}")))?;
 
-            // Look for the saorsa-node binary
+            // Look for the ant-node binary
             if let Some(name) = path.file_name() {
                 let name_str = name.to_string_lossy();
-                if name_str == "saorsa-node" || name_str == "saorsa-node.exe" {
+                if name_str == "ant-node" || name_str == "ant-node.exe" {
                     debug!("Found binary in tar.gz archive: {}", path.display());
 
                     // Stream directly to disk to avoid large heap allocations
@@ -486,20 +486,20 @@ impl AutoApplyUpgrader {
         }
 
         Err(Error::Upgrade(
-            "saorsa-node binary not found in tar.gz archive".to_string(),
+            "ant-node binary not found in tar.gz archive".to_string(),
         ))
     }
 
-    /// Extract the saorsa-node binary from a zip archive.
+    /// Extract the ant-node binary from a zip archive.
     fn extract_from_zip(archive_path: &Path, dest_dir: &Path) -> Result<PathBuf> {
         let file = File::open(archive_path)?;
         let mut archive = zip::ZipArchive::new(file)
             .map_err(|e| Error::Upgrade(format!("Failed to open zip archive: {e}")))?;
 
         let binary_name = if cfg!(windows) {
-            "saorsa-node.exe"
+            "ant-node.exe"
         } else {
-            "saorsa-node"
+            "ant-node"
         };
         let extracted_binary = dest_dir.join(binary_name);
 
@@ -515,7 +515,7 @@ impl AutoApplyUpgrader {
 
             if let Some(name) = path.file_name() {
                 let name_str = name.to_string_lossy();
-                if name_str == "saorsa-node" || name_str == "saorsa-node.exe" {
+                if name_str == "ant-node" || name_str == "ant-node.exe" {
                     debug!("Found binary in zip archive: {}", path.display());
 
                     // Stream directly to disk to avoid large heap allocations
@@ -538,7 +538,7 @@ impl AutoApplyUpgrader {
         }
 
         Err(Error::Upgrade(
-            "saorsa-node binary not found in zip archive".to_string(),
+            "ant-node binary not found in zip archive".to_string(),
         ))
     }
 
@@ -659,7 +659,7 @@ impl AutoApplyUpgrader {
 /// cannot be parsed.  Uses `tokio::process::Command` with a 5-second timeout
 /// to avoid blocking the async runtime.
 ///
-/// Output format is expected to be "saorsa-node X.Y.Z" or "saorsa-node X.Y.Z-rc.N".
+/// Output format is expected to be "ant-node X.Y.Z" or "ant-node X.Y.Z-rc.N".
 async fn on_disk_version(binary_path: &Path) -> Option<Version> {
     let output = tokio::time::timeout(
         std::time::Duration::from_secs(5),
@@ -671,7 +671,7 @@ async fn on_disk_version(binary_path: &Path) -> Option<Version> {
     .ok()?
     .ok()?;
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let version_str = stdout.trim().strip_prefix("saorsa-node ")?;
+    let version_str = stdout.trim().strip_prefix("ant-node ")?;
     Version::parse(version_str).ok()
 }
 
@@ -748,7 +748,7 @@ mod tests {
     fn test_extract_binary_from_tar_gz() {
         let dir = tempfile::tempdir().unwrap();
         let content = b"fake-binary-content";
-        let archive = create_tar_gz_archive(dir.path(), "saorsa-node", content);
+        let archive = create_tar_gz_archive(dir.path(), "ant-node", content);
 
         let dest = tempfile::tempdir().unwrap();
         let result = AutoApplyUpgrader::extract_binary(&archive, dest.path());
@@ -763,7 +763,7 @@ mod tests {
     fn test_extract_binary_from_zip() {
         let dir = tempfile::tempdir().unwrap();
         let content = b"fake-binary-content";
-        let archive = create_zip_archive(dir.path(), "saorsa-node", content);
+        let archive = create_zip_archive(dir.path(), "ant-node", content);
 
         let dest = tempfile::tempdir().unwrap();
         let result = AutoApplyUpgrader::extract_binary(&archive, dest.path());
@@ -778,7 +778,7 @@ mod tests {
     fn test_extract_binary_from_zip_with_exe() {
         let dir = tempfile::tempdir().unwrap();
         let content = b"fake-windows-binary";
-        let archive = create_zip_archive(dir.path(), "saorsa-node.exe", content);
+        let archive = create_zip_archive(dir.path(), "ant-node.exe", content);
 
         let dest = tempfile::tempdir().unwrap();
         let result = AutoApplyUpgrader::extract_binary(&archive, dest.path());
@@ -793,7 +793,7 @@ mod tests {
     fn test_extract_binary_from_tar_gz_nested_path() {
         let dir = tempfile::tempdir().unwrap();
         let content = b"nested-binary";
-        let archive = create_tar_gz_archive(dir.path(), "some/nested/path/saorsa-node", content);
+        let archive = create_tar_gz_archive(dir.path(), "some/nested/path/ant-node", content);
 
         let dest = tempfile::tempdir().unwrap();
         let result = AutoApplyUpgrader::extract_binary(&archive, dest.path());

--- a/src/upgrade/binary_cache.rs
+++ b/src/upgrade/binary_cache.rs
@@ -1,6 +1,6 @@
 //! Disk cache for downloaded upgrade binaries.
 //!
-//! When multiple saorsa-node instances detect the same upgrade, only the first
+//! When multiple ant-node instances detect the same upgrade, only the first
 //! one needs to download and verify the archive.  `BinaryCache` stores the
 //! extracted binary alongside a SHA-256 integrity metadata file so that
 //! subsequent nodes can copy it directly.
@@ -47,9 +47,9 @@ impl BinaryCache {
     #[must_use]
     pub fn cached_binary_path(&self, version: &str) -> PathBuf {
         let name = if cfg!(windows) {
-            format!("saorsa-node-{version}.exe")
+            format!("ant-node-{version}.exe")
         } else {
-            format!("saorsa-node-{version}")
+            format!("ant-node-{version}")
         };
         self.cache_dir.join(name)
     }
@@ -99,7 +99,7 @@ impl BinaryCache {
 
         // Write binary to a temp file then rename into place.
         // Remove dest first on Windows where rename fails if it exists.
-        let tmp_bin = self.cache_dir.join(format!(".saorsa-node-{version}.tmp"));
+        let tmp_bin = self.cache_dir.join(format!(".ant-node-{version}.tmp"));
         fs::copy(source_path, &tmp_bin)?;
         let _ = fs::remove_file(&dest);
         fs::rename(&tmp_bin, &dest)?;
@@ -119,9 +119,7 @@ impl BinaryCache {
             .map_err(|e| Error::Upgrade(format!("Failed to serialize binary cache meta: {e}")))?;
 
         // Write metadata to a temp file then rename into place
-        let tmp_meta = self
-            .cache_dir
-            .join(format!(".saorsa-node-{version}.meta.tmp"));
+        let tmp_meta = self.cache_dir.join(format!(".ant-node-{version}.meta.tmp"));
         let mut f = File::create(&tmp_meta)?;
         f.write_all(meta_json.as_bytes())?;
         f.sync_all()?;
@@ -160,9 +158,9 @@ impl BinaryCache {
 
     fn meta_path(&self, version: &str) -> PathBuf {
         let name = if cfg!(windows) {
-            format!("saorsa-node-{version}.exe.meta.json")
+            format!("ant-node-{version}.exe.meta.json")
         } else {
-            format!("saorsa-node-{version}.meta.json")
+            format!("ant-node-{version}.meta.json")
         };
         self.cache_dir.join(name)
     }

--- a/src/upgrade/cache_dir.rs
+++ b/src/upgrade/cache_dir.rs
@@ -1,6 +1,6 @@
 //! Shared cache directory for upgrade artifacts.
 //!
-//! Multiple saorsa-node instances on the same machine share a single cache
+//! Multiple ant-node instances on the same machine share a single cache
 //! directory so that release metadata and downloaded binaries are fetched only
 //! once, reducing GitHub API calls and bandwidth.
 
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 /// Return the shared upgrade cache directory, creating it on demand.
 ///
 /// The path is `{data_dir}/upgrades/` where `data_dir` comes from
-/// `directories::ProjectDirs` (e.g. `~/.local/share/saorsa/upgrades/` on
+/// `directories::ProjectDirs` (e.g. `~/.local/share/ant/upgrades/` on
 /// Linux).
 ///
 /// # Errors
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 /// Returns an error if the platform data directory cannot be determined or
 /// the directory cannot be created.
 pub fn upgrade_cache_dir() -> Result<PathBuf> {
-    let project_dirs = directories::ProjectDirs::from("", "", "saorsa").ok_or_else(|| {
+    let project_dirs = directories::ProjectDirs::from("", "", "ant").ok_or_else(|| {
         Error::Upgrade("Cannot determine platform data directory for upgrade cache".to_string())
     })?;
 

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -260,7 +260,7 @@ impl Upgrader {
             .ok_or_else(|| Error::Upgrade("Current binary has no parent directory".to_string()))?;
 
         tempfile::Builder::new()
-            .prefix("saorsa-upgrade-")
+            .prefix("ant-upgrade-")
             .tempdir_in(target_dir)
             .map_err(|e| Error::Upgrade(format!("Failed to create temp dir: {e}")))
     }
@@ -585,7 +585,7 @@ mod tests {
     #[test]
     fn test_backup_special_filename() {
         let temp = TempDir::new().unwrap();
-        let current = temp.path().join("saorsa-node-v1.0.0");
+        let current = temp.path().join("ant-node-v1.0.0");
         let rollback_dir = temp.path().join("rollback");
         fs::create_dir(&rollback_dir).unwrap();
 
@@ -595,7 +595,7 @@ mod tests {
         let result = upgrader.create_backup(&current, &rollback_dir);
         assert!(result.is_ok());
 
-        let backup_path = rollback_dir.join("saorsa-node-v1.0.0.backup");
+        let backup_path = rollback_dir.join("ant-node-v1.0.0.backup");
         assert!(backup_path.exists());
     }
 

--- a/src/upgrade/monitor.rs
+++ b/src/upgrade/monitor.rs
@@ -77,7 +77,7 @@ impl UpgradeMonitor {
             Version::parse(env!("CARGO_PKG_VERSION")).unwrap_or_else(|_| Version::new(0, 0, 0));
 
         let client = reqwest::Client::builder()
-            .user_agent(concat!("saorsa-node/", env!("CARGO_PKG_VERSION")))
+            .user_agent(concat!("ant-node/", env!("CARGO_PKG_VERSION")))
             .timeout(Duration::from_secs(30))
             .build()
             .unwrap_or_else(|e| {
@@ -134,7 +134,7 @@ impl UpgradeMonitor {
         current_version: Version,
     ) -> Self {
         let client = reqwest::Client::builder()
-            .user_agent(concat!("saorsa-node/", env!("CARGO_PKG_VERSION")))
+            .user_agent(concat!("ant-node/", env!("CARGO_PKG_VERSION")))
             .timeout(Duration::from_secs(30))
             .build()
             .unwrap_or_else(|e| {
@@ -645,7 +645,7 @@ mod tests {
     #[test]
     fn test_stable_channel_filters_beta() {
         let monitor = UpgradeMonitor::new(
-            "saorsa-labs/saorsa-node".to_string(),
+            "WithAutonomi/ant-node".to_string(),
             UpgradeChannel::Stable,
             24,
         );
@@ -661,7 +661,7 @@ mod tests {
     #[test]
     fn test_beta_channel_accepts_beta() {
         let monitor = UpgradeMonitor::new(
-            "saorsa-labs/saorsa-node".to_string(),
+            "WithAutonomi/ant-node".to_string(),
             UpgradeChannel::Beta,
             24,
         );
@@ -680,11 +680,11 @@ mod tests {
             "prerelease": false,
             "assets": [
                 {
-                    "name": "saorsa-node-x86_64-unknown-linux-gnu",
+                    "name": "ant-node-x86_64-unknown-linux-gnu",
                     "browser_download_url": "https://example.com/binary"
                 },
                 {
-                    "name": "saorsa-node-x86_64-unknown-linux-gnu.sig",
+                    "name": "ant-node-x86_64-unknown-linux-gnu.sig",
                     "browser_download_url": "https://example.com/binary.sig"
                 }
             ]
@@ -717,27 +717,27 @@ mod tests {
         // Test with archive format (CLI releases)
         let assets = vec![
             Asset {
-                name: "saorsa-node-cli-linux-x64.tar.gz".to_string(),
+                name: "ant-node-cli-linux-x64.tar.gz".to_string(),
                 browser_download_url: "https://example.com/linux".to_string(),
             },
             Asset {
-                name: "saorsa-node-cli-linux-x64.tar.gz.sig".to_string(),
+                name: "ant-node-cli-linux-x64.tar.gz.sig".to_string(),
                 browser_download_url: "https://example.com/linux.sig".to_string(),
             },
             Asset {
-                name: "saorsa-node-cli-macos-arm64.tar.gz".to_string(),
+                name: "ant-node-cli-macos-arm64.tar.gz".to_string(),
                 browser_download_url: "https://example.com/macos".to_string(),
             },
             Asset {
-                name: "saorsa-node-cli-macos-arm64.tar.gz.sig".to_string(),
+                name: "ant-node-cli-macos-arm64.tar.gz.sig".to_string(),
                 browser_download_url: "https://example.com/macos.sig".to_string(),
             },
             Asset {
-                name: "saorsa-node-cli-windows-x64.zip".to_string(),
+                name: "ant-node-cli-windows-x64.zip".to_string(),
                 browser_download_url: "https://example.com/windows".to_string(),
             },
             Asset {
-                name: "saorsa-node-cli-windows-x64.zip.sig".to_string(),
+                name: "ant-node-cli-windows-x64.zip.sig".to_string(),
                 browser_download_url: "https://example.com/windows.sig".to_string(),
             },
         ];
@@ -759,21 +759,21 @@ mod tests {
     #[test]
     fn test_is_binary_asset() {
         // Archive formats should be identified (CLI releases)
-        assert!(is_binary_asset("saorsa-node-cli-linux-x64.tar.gz"));
-        assert!(is_binary_asset("saorsa-node-cli-macos-arm64.tar.gz"));
-        assert!(is_binary_asset("saorsa-node-cli-windows-x64.zip"));
+        assert!(is_binary_asset("ant-node-cli-linux-x64.tar.gz"));
+        assert!(is_binary_asset("ant-node-cli-macos-arm64.tar.gz"));
+        assert!(is_binary_asset("ant-node-cli-windows-x64.zip"));
 
         // Signature and metadata files should be excluded
-        assert!(!is_binary_asset("saorsa-node.sig"));
-        assert!(!is_binary_asset("saorsa-node.sha256"));
-        assert!(!is_binary_asset("saorsa-node.md5"));
+        assert!(!is_binary_asset("ant-node.sig"));
+        assert!(!is_binary_asset("ant-node.sha256"));
+        assert!(!is_binary_asset("ant-node.md5"));
         assert!(!is_binary_asset("RELEASE_NOTES.txt"));
         assert!(!is_binary_asset("README.md"));
 
         // Installer packages should be excluded (handled separately)
-        assert!(!is_binary_asset("saorsa-node.deb"));
-        assert!(!is_binary_asset("saorsa-node.rpm"));
-        assert!(!is_binary_asset("saorsa-node.msi"));
+        assert!(!is_binary_asset("ant-node.deb"));
+        assert!(!is_binary_asset("ant-node.rpm"));
+        assert!(!is_binary_asset("ant-node.msi"));
     }
 
     /// Test 10: Monitor check interval
@@ -808,7 +808,7 @@ mod tests {
             "aarch64" => "arm64",
             _ => std::env::consts::ARCH,
         };
-        let archive_name = format!("saorsa-node-cli-{friendly_os}-{friendly_arch}.{archive_ext}");
+        let archive_name = format!("ant-node-cli-{friendly_os}-{friendly_arch}.{archive_ext}");
 
         let release = GitHubRelease {
             tag_name: "v1.1.0".to_string(),
@@ -910,11 +910,11 @@ mod tests {
     #[test]
     fn test_monitor_repo() {
         let monitor = UpgradeMonitor::new(
-            "saorsa-labs/saorsa-node".to_string(),
+            "WithAutonomi/ant-node".to_string(),
             UpgradeChannel::Stable,
             24,
         );
-        assert_eq!(monitor.repo(), "saorsa-labs/saorsa-node");
+        assert_eq!(monitor.repo(), "WithAutonomi/ant-node");
     }
 
     /// Test 16: Current version getter
@@ -975,9 +975,9 @@ mod tests {
         let os = std::env::consts::OS;
         // On Windows, binary assets require .exe extension
         #[cfg(windows)]
-        let bin_name = format!("saorsa-node-{arch}-{os}.exe");
+        let bin_name = format!("ant-node-{arch}-{os}.exe");
         #[cfg(not(windows))]
-        let bin_name = format!("saorsa-node-{arch}-{os}");
+        let bin_name = format!("ant-node-{arch}-{os}");
         let releases = vec![
             GitHubRelease {
                 tag_name: "v1.1.0-beta.1".to_string(),
@@ -1026,9 +1026,9 @@ mod tests {
         let os = std::env::consts::OS;
         // On Windows, binary assets require .exe extension
         #[cfg(windows)]
-        let bin_name = format!("saorsa-node-{arch}-{os}.exe");
+        let bin_name = format!("ant-node-{arch}-{os}.exe");
         #[cfg(not(windows))]
-        let bin_name = format!("saorsa-node-{arch}-{os}");
+        let bin_name = format!("ant-node-{arch}-{os}");
         let releases = vec![
             GitHubRelease {
                 tag_name: "v1.1.0".to_string(),

--- a/src/upgrade/release_cache.rs
+++ b/src/upgrade/release_cache.rs
@@ -1,6 +1,6 @@
 //! Disk cache for GitHub release metadata.
 //!
-//! When multiple saorsa-node instances run on the same machine, each would
+//! When multiple ant-node instances run on the same machine, each would
 //! otherwise poll the GitHub API independently.  `ReleaseCache` stores the
 //! most recent API response on disk with a configurable TTL so that only the
 //! first node to hit a stale cache actually contacts GitHub.
@@ -280,7 +280,7 @@ mod tests {
             body: "Notes".to_string(),
             prerelease: false,
             assets: vec![Asset {
-                name: "saorsa-node-x86_64-linux.tar.gz".to_string(),
+                name: "ant-node-x86_64-linux.tar.gz".to_string(),
                 browser_download_url: "https://example.com/bin".to_string(),
             }],
         }]
@@ -297,7 +297,7 @@ mod tests {
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].tag_name, "v1.2.0");
         assert_eq!(loaded[0].assets.len(), 1);
-        assert_eq!(loaded[0].assets[0].name, "saorsa-node-x86_64-linux.tar.gz");
+        assert_eq!(loaded[0].assets[0].name, "ant-node-x86_64-linux.tar.gz");
     }
 
     #[test]

--- a/src/upgrade/signature.rs
+++ b/src/upgrade/signature.rs
@@ -24,7 +24,7 @@ use std::path::Path;
 use tracing::debug;
 
 /// Signing context for domain separation (prevents cross-protocol attacks).
-pub const SIGNING_CONTEXT: &[u8] = b"saorsa-node-release-v1";
+pub const SIGNING_CONTEXT: &[u8] = b"ant-node-release-v1";
 
 /// ML-DSA-65 signature size in bytes.
 pub const SIGNATURE_SIZE: usize = 3309;

--- a/systemd/ant-node.service
+++ b/systemd/ant-node.service
@@ -1,14 +1,14 @@
 [Unit]
-Description=Saorsa Node - Quantum-proof decentralized network node
-Documentation=https://github.com/saorsa-labs/saorsa-node
+Description=Ant Node - Quantum-proof decentralized network node
+Documentation=https://github.com/WithAutonomi/ant-node
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=simple
-User=saorsa
-Group=saorsa
-ExecStart=/usr/bin/saorsa-node --config /etc/saorsa/config.toml --stop-on-upgrade
+User=ant
+Group=ant
+ExecStart=/usr/bin/ant-node --config /etc/ant/config.toml --stop-on-upgrade
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=5s
@@ -23,7 +23,7 @@ PrivateDevices=yes
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
 ProtectControlGroups=yes
-ReadWritePaths=/var/lib/saorsa /var/log/saorsa
+ReadWritePaths=/var/lib/ant /var/log/ant
 
 # Resource limits
 LimitNOFILE=65536

--- a/tests/e2e/complete_payment_e2e.rs
+++ b/tests/e2e/complete_payment_e2e.rs
@@ -1,12 +1,12 @@
 //! Complete E2E test proving the payment protocol works on live nodes.
 //!
 //! **All payment tests in this file previously used `QuantumClient` which has been
-//! removed.** Tests will be re-implemented using `saorsa-client::Client` once
+//! removed.** Tests will be re-implemented using `ant-client::Client` once
 //! the migration is complete.
 //!
 //! ## Original Test Flow
 //!
-//! 1. **Network Setup**: Spawn 10 live saorsa nodes + Anvil EVM testnet
+//! 1. **Network Setup**: Spawn 10 live ant nodes + Anvil EVM testnet
 //! 2. **Quote Collection**: Client requests quotes from 5 closest DHT peers
 //! 3. **Price Calculation**: Sort quotes by price, select median
 //! 4. **Payment**: Make on-chain payment (median node 3x, others 0 atto)

--- a/tests/e2e/data_types/chunk.rs
+++ b/tests/e2e/data_types/chunk.rs
@@ -53,7 +53,7 @@ impl ChunkTestFixture {
     /// Compute content address for data (BLAKE3 hash).
     #[must_use]
     pub fn compute_address(data: &[u8]) -> [u8; 32] {
-        saorsa_node::compute_address(data)
+        ant_node::compute_address(data)
     }
 }
 
@@ -64,13 +64,13 @@ mod tests {
 
     use crate::{TestHarness, TestNetwork};
     use ant_evm::RewardsAddress;
-    use evmlib::testnet::Testnet;
-    use rand::seq::SliceRandom;
-    use saorsa_node::payment::{
+    use ant_node::payment::{
         EvmVerifierConfig, PaymentVerifier, PaymentVerifierConfig, QuoteGenerator,
         QuotingMetricsTracker,
     };
-    use saorsa_node::storage::{AntProtocol, LmdbStorage, LmdbStorageConfig};
+    use ant_node::storage::{AntProtocol, LmdbStorage, LmdbStorageConfig};
+    use evmlib::testnet::Testnet;
+    use rand::seq::SliceRandom;
     use serial_test::serial;
 
     /// Test 1: Content address computation is deterministic
@@ -463,7 +463,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn test_chunk_rejected_without_payment() -> color_eyre::Result<()> {
-        use saorsa_node::ant_protocol::{
+        use ant_node::ant_protocol::{
             ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkMessageBody, ChunkPutRequest,
             ChunkPutResponse,
         };

--- a/tests/e2e/data_types/mod.rs
+++ b/tests/e2e/data_types/mod.rs
@@ -1,4 +1,4 @@
-//! Data type E2E tests for saorsa-node.
+//! Data type E2E tests for ant-node.
 //!
 //! This module contains tests for the chunk data type:
 //! - **Chunk**: Immutable, content-addressed data (up to 4MB)

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -1,13 +1,13 @@
 //! Test harness that orchestrates the test network and EVM testnet.
 //!
 //! The `TestHarness` provides a unified interface for E2E tests, managing
-//! both the saorsa node network and optional Anvil EVM testnet.
+//! both the ant node network and optional Anvil EVM testnet.
 
 use super::anvil::TestAnvil;
 use super::testnet::{TestNetwork, TestNetworkConfig, TestNode};
+use ant_node::client::XorName;
 use evmlib::common::TxHash;
 use saorsa_core::P2PNode;
-use saorsa_node::client::XorName;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tracing::info;
@@ -153,7 +153,7 @@ impl PaymentTracker {
 /// Test harness that manages the complete test environment.
 ///
 /// The harness coordinates:
-/// - A network of 25 saorsa nodes
+/// - A network of 25 ant nodes
 /// - Optional Anvil EVM testnet for payment verification
 /// - Payment tracking for verifying cache behavior
 /// - Helper methods for common test operations

--- a/tests/e2e/live_testnet.rs
+++ b/tests/e2e/live_testnet.rs
@@ -1,6 +1,6 @@
 //! Live testnet tests for load testing and data verification.
 //!
-//! These tests connect to the live saorsa testnet for comprehensive testing.
+//! These tests connect to the live Autonomi testnet for comprehensive testing.
 //! They are designed to be run via shell scripts that set environment variables.
 //! When environment variables are not set, the tests skip gracefully.
 //!
@@ -23,7 +23,7 @@ use std::time::Duration;
 
 /// Get bootstrap addresses from environment or use defaults.
 fn get_bootstrap_addrs() -> Vec<SocketAddr> {
-    let bootstrap_str = env::var("SAORSA_TEST_BOOTSTRAP")
+    let bootstrap_str = env::var("ANT_TEST_BOOTSTRAP")
         .unwrap_or_else(|_| "142.93.52.129:12000,24.199.82.114:12000".to_string());
 
     bootstrap_str

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -1,7 +1,7 @@
-//! E2E test infrastructure for saorsa-node.
+//! E2E test infrastructure for ant-node.
 //!
 //! This module provides a complete testing framework for running E2E tests
-//! against a local testnet of 25 saorsa nodes with optional EVM payment
+//! against a local testnet of 25 ant nodes with optional EVM payment
 //! verification via a local Anvil testnet.
 //!
 //! ## Architecture
@@ -18,7 +18,7 @@
 //! ## Usage
 //!
 //! ```rust,no_run
-//! use saorsa_node::tests::e2e::TestHarness;
+//! use ant_node::tests::e2e::TestHarness;
 //!
 //! #[tokio::test]
 //! async fn test_chunk_storage() {

--- a/tests/e2e/payment_flow.rs
+++ b/tests/e2e/payment_flow.rs
@@ -32,7 +32,7 @@ use tracing::info;
 
 /// Test environment containing both the test network and EVM testnet.
 struct PaymentTestEnv {
-    /// Test harness managing the saorsa node network
+    /// Test harness managing the ant node network
     harness: TestHarness,
     /// Anvil EVM testnet for payment testing
     testnet: Testnet,
@@ -61,7 +61,7 @@ impl PaymentTestEnv {
 ///
 /// This sets up:
 /// - Anvil EVM testnet FIRST (so nodes can verify on the same chain)
-/// - 10-node saorsa test network with `payment_enforcement: true`
+/// - 10-node ant test network with `payment_enforcement: true`
 /// - Network stabilization wait (5 seconds for 10 nodes)
 ///
 /// All nodes share the SAME Anvil instance as the client wallet,

--- a/tests/e2e/security_attacks.rs
+++ b/tests/e2e/security_attacks.rs
@@ -1,7 +1,7 @@
 //! Security attack tests: adversarial payment bypass attempts.
 //!
 //! These tests simulate a malicious attacker trying to store data on the
-//! saorsa network WITHOUT paying. Every test uses `payment_enforcement: true`
+//! Autonomi network WITHOUT paying. Every test uses `payment_enforcement: true`
 //! on all nodes. Every test MUST verify the attack is REJECTED.
 //!
 //! The attacker cannot modify source code -- only craft malicious messages.
@@ -11,13 +11,13 @@
 use super::harness::TestHarness;
 use super::testnet::TestNetworkConfig;
 use ant_evm::ProofOfPayment;
-use evmlib::testnet::Testnet;
-use rand::Rng;
-use saorsa_node::ant_protocol::{
+use ant_node::ant_protocol::{
     ChunkMessage, ChunkMessageBody, ChunkPutRequest, ChunkPutResponse, ProtocolError,
 };
-use saorsa_node::compute_address;
-use saorsa_node::payment::PaymentProof;
+use ant_node::compute_address;
+use ant_node::payment::PaymentProof;
+use evmlib::testnet::Testnet;
+use rand::Rng;
 use serial_test::serial;
 use std::time::Duration;
 use tokio::time::sleep;

--- a/tests/e2e/testnet.rs
+++ b/tests/e2e/testnet.rs
@@ -1,7 +1,7 @@
 //! Test network infrastructure for spawning and managing multiple nodes.
 //!
 //! This module provides the core infrastructure for creating a local testnet
-//! of 25 saorsa nodes for E2E testing.
+//! of 25 ant nodes for E2E testing.
 //!
 //! ## Protocol-Based Testing
 //!
@@ -14,6 +14,16 @@
 //! - LMDB storage persistence
 
 use ant_evm::RewardsAddress;
+use ant_node::ant_protocol::{
+    ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkMessageBody, ChunkPutRequest,
+    ChunkPutResponse, CHUNK_PROTOCOL_ID,
+};
+use ant_node::client::{send_and_await_chunk_response, DataChunk, XorName};
+use ant_node::payment::{
+    EvmVerifierConfig, PaymentVerifier, PaymentVerifierConfig, QuoteGenerator,
+    QuotingMetricsTracker,
+};
+use ant_node::storage::{AntProtocol, LmdbStorage, LmdbStorageConfig};
 use bytes::Bytes;
 use evmlib::Network as EvmNetwork;
 use futures::future::join_all;
@@ -23,16 +33,6 @@ use saorsa_core::{
     identity::NodeIdentity, IPDiversityConfig as CoreDiversityConfig, MultiAddr,
     NodeConfig as CoreNodeConfig, P2PEvent, P2PNode,
 };
-use saorsa_node::ant_protocol::{
-    ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkMessageBody, ChunkPutRequest,
-    ChunkPutResponse, CHUNK_PROTOCOL_ID,
-};
-use saorsa_node::client::{send_and_await_chunk_response, DataChunk, XorName};
-use saorsa_node::payment::{
-    EvmVerifierConfig, PaymentVerifier, PaymentVerifierConfig, QuoteGenerator,
-    QuotingMetricsTracker,
-};
-use saorsa_node::storage::{AntProtocol, LmdbStorage, LmdbStorageConfig};
 use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -46,18 +46,18 @@ use tracing::{debug, info, warn};
 // Test Isolation Constants
 // =============================================================================
 //
-// NOTE: E2E tests use a SEPARATE port range from production saorsa-node.
+// NOTE: E2E tests use a SEPARATE port range from production ant-node.
 //
-// - Production saorsa-node: 10000-10999 (see CLAUDE.md)
+// - Production ant-node: 10000-10999 (see CLAUDE.md)
 // - E2E tests: 20000-60000 (this file)
 //
 // This separation prevents test conflicts with:
 // 1. Running local development nodes (which use 10000-10999)
 // 2. Parallel test execution (via random port allocation)
-// 3. Other Saorsa services (ant-quic: 9000-9999, communitas: 11000-11999)
+// 3. Other Autonomi services (ant-quic: 9000-9999, communitas: 11000-11999)
 
 /// Minimum port for random test allocation.
-/// Avoids well-known ports, production ranges, and other Saorsa services.
+/// Avoids well-known ports, production ranges, and other Autonomi services.
 pub const TEST_PORT_RANGE_MIN: u16 = 20_000;
 
 /// Maximum port for random test allocation.
@@ -233,7 +233,7 @@ impl Default for TestNetworkConfig {
 
         // Random suffix for unique temp directory
         let suffix: u64 = rng.gen();
-        let test_data_dir = std::env::temp_dir().join(format!("saorsa_test_{suffix:x}"));
+        let test_data_dir = std::env::temp_dir().join(format!("ant_test_{suffix:x}"));
 
         Self {
             node_count: DEFAULT_NODE_COUNT,
@@ -790,7 +790,7 @@ impl TestNode {
     /// Compute content address for chunk data (BLAKE3 hash).
     #[must_use]
     pub fn compute_chunk_address(data: &[u8]) -> XorName {
-        saorsa_node::compute_address(data)
+        ant_node::compute_address(data)
     }
 }
 
@@ -1107,13 +1107,13 @@ impl TestNetwork {
         debug!("Starting node {} on port {}", node.index, node.port);
         *node.state.write().await = NodeState::Starting;
 
-        // Build configuration for saorsa-core P2PNode.
+        // Build configuration for saorsa-core P2PNode (saorsa-core is an external crate).
         // .local(true) auto-enables allow_loopback for test nodes on 127.0.0.1.
         let mut core_config = CoreNodeConfig::builder()
             .port(node.port)
             .local(true)
             .connection_timeout(Duration::from_secs(TEST_CORE_CONNECTION_TIMEOUT_SECS))
-            .max_message_size(saorsa_node::ant_protocol::MAX_WIRE_MESSAGE_SIZE)
+            .max_message_size(ant_node::ant_protocol::MAX_WIRE_MESSAGE_SIZE)
             .build()
             .map_err(|e| TestnetError::Core(format!("Failed to create core config: {e}")))?;
 
@@ -1565,10 +1565,7 @@ mod tests {
         // Port is randomly generated in range 20000-60000
         assert!(config.base_port >= 20000 && config.base_port < 60000);
         // Data dir has unique suffix
-        assert!(config
-            .test_data_dir
-            .to_string_lossy()
-            .contains("saorsa_test_"));
+        assert!(config.test_data_dir.to_string_lossy().contains("ant_test_"));
     }
 
     #[test]

--- a/wix/license.rtf
+++ b/wix/license.rtf
@@ -2,9 +2,9 @@
 {\fonttbl{\f0\fswiss\fcharset0 Arial;}}
 \viewkind4\uc1\pard\lang1033\f0\fs20
 
-\b Saorsa Node License\b0\par
+\b Ant Node License\b0\par
 \par
-Copyright (c) 2024-2025 Saorsa Labs\par
+Copyright (c) 2024-2025 Autonomi\par
 \par
 This software is dual-licensed under MIT OR Apache-2.0.\par
 \par

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -2,10 +2,10 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product
         Id="*"
-        Name="Saorsa Node"
+        Name="Ant Node"
         Language="1033"
         Version="$(var.ProductVersion)"
-        Manufacturer="Saorsa Labs"
+        Manufacturer="Autonomi"
         UpgradeCode="E8A7B5F2-3C9D-4E1A-B2F8-7D6C5A4E3B2D">
 
         <Package
@@ -13,20 +13,20 @@
             Compressed="yes"
             InstallScope="perMachine"
             Platform="x64"
-            Description="Saorsa Node - Quantum-proof decentralized network node"
+            Description="Ant Node - Quantum-proof decentralized network node"
             Comments="Pure post-quantum cryptography network node"/>
 
         <MajorUpgrade
-            DowngradeErrorMessage="A newer version of Saorsa Node is already installed."/>
+            DowngradeErrorMessage="A newer version of Ant Node is already installed."/>
 
         <MediaTemplate EmbedCab="yes"/>
 
-        <Icon Id="SaorsaIcon" SourceFile="wix\saorsa.ico"/>
-        <Property Id="ARPPRODUCTICON" Value="SaorsaIcon"/>
-        <Property Id="ARPHELPLINK" Value="https://github.com/saorsa-labs/saorsa-node"/>
-        <Property Id="ARPURLINFOABOUT" Value="https://github.com/saorsa-labs/saorsa-node"/>
+        <Icon Id="AntIcon" SourceFile="wix\ant.ico"/>
+        <Property Id="ARPPRODUCTICON" Value="AntIcon"/>
+        <Property Id="ARPHELPLINK" Value="https://github.com/WithAutonomi/ant-node"/>
+        <Property Id="ARPURLINFOABOUT" Value="https://github.com/WithAutonomi/ant-node"/>
 
-        <Feature Id="MainFeature" Title="Saorsa Node" Level="1">
+        <Feature Id="MainFeature" Title="Ant Node" Level="1">
             <ComponentGroupRef Id="BinariesGroup"/>
             <ComponentRef Id="PathEnvComponent"/>
         </Feature>
@@ -42,7 +42,7 @@
     <Fragment>
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="ProgramFiles64Folder">
-                <Directory Id="INSTALLFOLDER" Name="Saorsa">
+                <Directory Id="INSTALLFOLDER" Name="Autonomi">
                     <Directory Id="BinFolder" Name="bin"/>
                 </Directory>
             </Directory>
@@ -51,14 +51,14 @@
 
     <Fragment>
         <ComponentGroup Id="BinariesGroup" Directory="BinFolder">
-            <Component Id="SaorsaNodeComponent" Guid="*" Win64="yes">
-                <File Id="SaorsaNodeExe"
-                      Source="target\x86_64-pc-windows-msvc\release\saorsa-node.exe"
+            <Component Id="AntNodeComponent" Guid="*" Win64="yes">
+                <File Id="AntNodeExe"
+                      Source="target\x86_64-pc-windows-msvc\release\ant-node.exe"
                       KeyPath="yes"/>
             </Component>
-            <Component Id="SaorsaKeygenComponent" Guid="*" Win64="yes">
-                <File Id="SaorsaKeygenExe"
-                      Source="target\x86_64-pc-windows-msvc\release\saorsa-keygen.exe"
+            <Component Id="AntKeygenComponent" Guid="*" Win64="yes">
+                <File Id="AntKeygenExe"
+                      Source="target\x86_64-pc-windows-msvc\release\ant-keygen.exe"
                       KeyPath="yes"/>
             </Component>
         </ComponentGroup>


### PR DESCRIPTION
## Summary
- Full rebrand of the crate from `saorsa-node` to `ant-node` across 86 files
- Package, lib, and binary names: `ant-node`, `ant-keygen`, `ant-devnet`
- All `SAORSA_*` environment variables renamed to `ANT_*`
- Source directories, systemd service, shell scripts, CI workflows, Terraform, monitoring configs, Windows installer, and documentation all updated
- "Saorsa" in prose replaced with "Autonomi"
- External dependencies (`saorsa-core`, `saorsa-pqc`) and DNS hostnames (`saorsa-*.saorsalabs.com`) are unchanged

## Test plan
- [x] `cargo build --release` succeeds
- [x] `cargo test` passes (272 passed, 0 failed)
- [x] `cargo clippy --all-features -- -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used` clean
- [x] `cargo fmt --all --check` clean
- [x] Verified no stale `saorsa-node`/`saorsa_node` references remain (only external deps + DNS hostnames)

🤖 Generated with [Claude Code](https://claude.com/claude-code)