### PR TITLE
refactor!: remove deprecated handle_message from AntProtocol

### DIFF
--- a/src/storage/handler.rs
+++ b/src/storage/handler.rs
@@ -22,7 +22,8 @@
 //! │         │                         │                 │  │
 //! │         └─────────────────────────┴─────────────────┘  │
 //! │                           │                             │
-//! │                 return Ok(response_bytes)               │
+//! │           return Ok(Some(response_bytes))              │
+//! │           return Ok(None) for response messages       │
 //! └─────────────────────────────────────────────────────────┘
 //! ```
 

--- a/src/storage/handler.rs
+++ b/src/storage/handler.rs
@@ -11,7 +11,7 @@
 //! ├─────────────────────────────────────────────────────────┤
 //! │  protocol_id() = "autonomi/ant/chunk/v1"                  │
 //! │                                                         │
-//! │  handle_message(data) ──▶ decode ChunkMessage  │
+//! │  try_handle_request(data) ──▶ decode ChunkMessage  │
 //! │                                   │                     │
 //! │         ┌─────────────────────────┼─────────────────┐  │
 //! │         ▼                         ▼                 ▼  │
@@ -130,57 +130,6 @@ impl AntProtocol {
         response
             .encode()
             .map(|b| Some(Bytes::from(b)))
-            .map_err(|e| Error::Protocol(format!("Failed to encode response: {e}")))
-    }
-
-    /// Handle an incoming protocol message.
-    ///
-    /// **Deprecated**: Use [`try_handle_request`](Self::try_handle_request)
-    /// instead. This method always returns response bytes — even for
-    /// response messages that should be ignored — which can create an
-    /// infinite ping-pong loop if the caller blindly sends the result back.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if message decoding or handling fails.
-    pub async fn handle_message(&self, data: &[u8]) -> Result<Bytes> {
-        let message = ChunkMessage::decode(data)
-            .map_err(|e| Error::Protocol(format!("Failed to decode message: {e}")))?;
-
-        let request_id = message.request_id;
-
-        let response_body = match message.body {
-            ChunkMessageBody::PutRequest(req) => {
-                ChunkMessageBody::PutResponse(self.handle_put(req).await)
-            }
-            ChunkMessageBody::GetRequest(req) => {
-                ChunkMessageBody::GetResponse(self.handle_get(req).await)
-            }
-            ChunkMessageBody::QuoteRequest(ref req) => {
-                ChunkMessageBody::QuoteResponse(self.handle_quote(req))
-            }
-            ChunkMessageBody::MerkleCandidateQuoteRequest(ref req) => {
-                ChunkMessageBody::MerkleCandidateQuoteResponse(
-                    self.handle_merkle_candidate_quote(req),
-                )
-            }
-            ChunkMessageBody::PutResponse(_)
-            | ChunkMessageBody::GetResponse(_)
-            | ChunkMessageBody::QuoteResponse(_)
-            | ChunkMessageBody::MerkleCandidateQuoteResponse(_) => {
-                let error = ProtocolError::Internal("Unexpected response message".to_string());
-                ChunkMessageBody::PutResponse(ChunkPutResponse::Error(error))
-            }
-        };
-
-        let response = ChunkMessage {
-            request_id,
-            body: response_body,
-        };
-
-        response
-            .encode()
-            .map(Bytes::from)
             .map_err(|e| Error::Protocol(format!("Failed to encode response: {e}")))
     }
 
@@ -507,9 +456,10 @@ mod tests {
 
         // Handle PUT
         let response_bytes = protocol
-            .handle_message(&put_bytes)
+            .try_handle_request(&put_bytes)
             .await
-            .expect("handle put");
+            .expect("handle put")
+            .expect("expected response");
         let response = ChunkMessage::decode(&response_bytes).expect("decode response");
 
         assert_eq!(response.request_id, 1);
@@ -531,9 +481,10 @@ mod tests {
 
         // Handle GET
         let response_bytes = protocol
-            .handle_message(&get_bytes)
+            .try_handle_request(&get_bytes)
             .await
-            .expect("handle get");
+            .expect("handle get")
+            .expect("expected response");
         let response = ChunkMessage::decode(&response_bytes).expect("decode response");
 
         assert_eq!(response.request_id, 2);
@@ -562,9 +513,10 @@ mod tests {
         let get_bytes = get_msg.encode().expect("encode get");
 
         let response_bytes = protocol
-            .handle_message(&get_bytes)
+            .try_handle_request(&get_bytes)
             .await
-            .expect("handle get");
+            .expect("handle get")
+            .expect("expected response");
         let response = ChunkMessage::decode(&response_bytes).expect("decode response");
 
         assert_eq!(response.request_id, 10);
@@ -595,9 +547,10 @@ mod tests {
         let put_bytes = put_msg.encode().expect("encode put");
 
         let response_bytes = protocol
-            .handle_message(&put_bytes)
+            .try_handle_request(&put_bytes)
             .await
-            .expect("handle put");
+            .expect("handle put")
+            .expect("expected response");
         let response = ChunkMessage::decode(&response_bytes).expect("decode response");
 
         assert_eq!(response.request_id, 20);
@@ -627,9 +580,10 @@ mod tests {
         let put_bytes = put_msg.encode().expect("encode put");
 
         let response_bytes = protocol
-            .handle_message(&put_bytes)
+            .try_handle_request(&put_bytes)
             .await
-            .expect("handle put");
+            .expect("handle put")
+            .expect("expected response");
         let response = ChunkMessage::decode(&response_bytes).expect("decode response");
 
         assert_eq!(response.request_id, 30);
@@ -661,15 +615,16 @@ mod tests {
         let put_bytes = put_msg.encode().expect("encode put");
 
         let _ = protocol
-            .handle_message(&put_bytes)
+            .try_handle_request(&put_bytes)
             .await
             .expect("handle put");
 
         // Store again - should return AlreadyExists
         let response_bytes = protocol
-            .handle_message(&put_bytes)
+            .try_handle_request(&put_bytes)
             .await
-            .expect("handle put 2");
+            .expect("handle put 2")
+            .expect("expected response");
         let response = ChunkMessage::decode(&response_bytes).expect("decode response");
 
         assert_eq!(response.request_id, 40);
@@ -734,9 +689,10 @@ mod tests {
         };
         let put_bytes = put_msg.encode().expect("encode put");
         let response_bytes = protocol
-            .handle_message(&put_bytes)
+            .try_handle_request(&put_bytes)
             .await
-            .expect("handle put");
+            .expect("handle put")
+            .expect("expected response");
         let response = ChunkMessage::decode(&response_bytes).expect("decode");
 
         if let ChunkMessageBody::PutResponse(ChunkPutResponse::Success { .. }) = response.body {
@@ -764,15 +720,16 @@ mod tests {
         };
         let put_bytes = put_msg.encode().expect("encode put");
         let _ = protocol
-            .handle_message(&put_bytes)
+            .try_handle_request(&put_bytes)
             .await
             .expect("handle put 1");
 
         // Second PUT — should return AlreadyExists (checked in storage before payment)
         let response_bytes = protocol
-            .handle_message(&put_bytes)
+            .try_handle_request(&put_bytes)
             .await
-            .expect("handle put 2");
+            .expect("handle put 2")
+            .expect("expected response");
         let response = ChunkMessage::decode(&response_bytes).expect("decode");
 
         if let ChunkMessageBody::PutResponse(ChunkPutResponse::AlreadyExists { .. }) = response.body
@@ -804,7 +761,7 @@ mod tests {
         };
         let put_bytes = put_msg.encode().expect("encode put");
         let _ = protocol
-            .handle_message(&put_bytes)
+            .try_handle_request(&put_bytes)
             .await
             .expect("handle put");
 
@@ -848,9 +805,10 @@ mod tests {
         let msg_bytes = msg.encode().expect("encode request");
 
         let response_bytes = protocol
-            .handle_message(&msg_bytes)
+            .try_handle_request(&msg_bytes)
             .await
-            .expect("handle merkle candidate quote");
+            .expect("handle merkle candidate quote")
+            .expect("expected response");
         let response = ChunkMessage::decode(&response_bytes).expect("decode response");
 
         assert_eq!(response.request_id, 600);
@@ -879,27 +837,22 @@ mod tests {
     async fn test_handle_unexpected_response_message() {
         let (protocol, _temp) = create_test_protocol().await;
 
-        // Send a PutResponse as if it were a request
+        // Send a PutResponse as if it were a request — should return None
         let msg = ChunkMessage {
             request_id: 200,
             body: ChunkMessageBody::PutResponse(ChunkPutResponse::Success { address: [0u8; 32] }),
         };
         let msg_bytes = msg.encode().expect("encode");
 
-        let response_bytes = protocol
-            .handle_message(&msg_bytes)
+        let result = protocol
+            .try_handle_request(&msg_bytes)
             .await
             .expect("handle msg");
-        let response = ChunkMessage::decode(&response_bytes).expect("decode");
 
-        if let ChunkMessageBody::PutResponse(ChunkPutResponse::Error(ProtocolError::Internal(
-            msg,
-        ))) = response.body
-        {
-            assert!(msg.contains("Unexpected"));
-        } else {
-            panic!("expected Internal error, got: {response:?}");
-        }
+        assert!(
+            result.is_none(),
+            "expected None for response message, got: {result:?}"
+        );
     }
 
     #[tokio::test]
@@ -918,7 +871,7 @@ mod tests {
         };
         let put_bytes = put_msg.encode().expect("encode put");
         let _ = protocol
-            .handle_message(&put_bytes)
+            .try_handle_request(&put_bytes)
             .await
             .expect("handle put");
 
@@ -934,9 +887,10 @@ mod tests {
         };
         let quote_bytes = quote_msg.encode().expect("encode quote");
         let response_bytes = protocol
-            .handle_message(&quote_bytes)
+            .try_handle_request(&quote_bytes)
             .await
-            .expect("handle quote");
+            .expect("handle quote")
+            .expect("expected response");
         let response = ChunkMessage::decode(&response_bytes).expect("decode");
 
         match response.body {
@@ -964,9 +918,10 @@ mod tests {
         };
         let quote_bytes2 = quote_msg2.encode().expect("encode quote2");
         let response_bytes2 = protocol
-            .handle_message(&quote_bytes2)
+            .try_handle_request(&quote_bytes2)
             .await
-            .expect("handle quote2");
+            .expect("handle quote2")
+            .expect("expected response");
         let response2 = ChunkMessage::decode(&response_bytes2).expect("decode2");
 
         match response2.body {

--- a/tests/e2e/data_types/chunk.rs
+++ b/tests/e2e/data_types/chunk.rs
@@ -490,7 +490,10 @@ mod tests {
         let message_bytes = message.encode()?;
 
         // Send PUT request to protocol handler
-        let response_bytes = protocol.handle_message(&message_bytes).await?;
+        let response_bytes = protocol
+            .try_handle_request(&message_bytes)
+            .await?
+            .ok_or_else(|| color_eyre::eyre::eyre!("expected response"))?;
         let response = ChunkMessage::decode(&response_bytes)?;
 
         // Verify the response indicates payment is required or an error occurred
@@ -528,7 +531,10 @@ mod tests {
         };
         let get_message_bytes = get_message.encode()?;
 
-        let get_response_bytes = protocol.handle_message(&get_message_bytes).await?;
+        let get_response_bytes = protocol
+            .try_handle_request(&get_message_bytes)
+            .await?
+            .ok_or_else(|| color_eyre::eyre::eyre!("expected response"))?;
         let get_response = ChunkMessage::decode(&get_response_bytes)?;
 
         match get_response.body {

--- a/tests/e2e/security_attacks.rs
+++ b/tests/e2e/security_attacks.rs
@@ -61,9 +61,10 @@ async fn send_put_to_node(
         .encode()
         .map_err(|e| format!("Encode failed: {e}"))?;
     let response_bytes = protocol
-        .handle_message(&message_bytes)
+        .try_handle_request(&message_bytes)
         .await
-        .map_err(|e| format!("Handle failed: {e}"))?;
+        .map_err(|e| format!("Handle failed: {e}"))?
+        .ok_or("expected response")?;
     ChunkMessage::decode(&response_bytes).map_err(|e| format!("Decode failed: {e}"))
 }
 

--- a/tests/e2e/testnet.rs
+++ b/tests/e2e/testnet.rs
@@ -487,14 +487,16 @@ impl TestNode {
 
         // Handle the protocol message
         let timeout = Duration::from_secs(DEFAULT_CHUNK_OPERATION_TIMEOUT_SECS);
-        let response_bytes = tokio::time::timeout(timeout, protocol.handle_message(&message_bytes))
-            .await
-            .map_err(|_| {
-                TestnetError::Storage(format!(
-                    "Timeout storing chunk after {DEFAULT_CHUNK_OPERATION_TIMEOUT_SECS}s"
-                ))
-            })?
-            .map_err(|e| TestnetError::Storage(format!("Protocol error: {e}")))?;
+        let response_bytes =
+            tokio::time::timeout(timeout, protocol.try_handle_request(&message_bytes))
+                .await
+                .map_err(|_| {
+                    TestnetError::Storage(format!(
+                        "Timeout storing chunk after {DEFAULT_CHUNK_OPERATION_TIMEOUT_SECS}s"
+                    ))
+                })?
+                .map_err(|e| TestnetError::Storage(format!("Protocol error: {e}")))?
+                .ok_or_else(|| TestnetError::Storage("expected response".to_string()))?;
 
         // Parse response
         let response = ChunkMessage::decode(&response_bytes)
@@ -553,14 +555,16 @@ impl TestNode {
 
         // Handle the protocol message
         let timeout = Duration::from_secs(DEFAULT_CHUNK_OPERATION_TIMEOUT_SECS);
-        let response_bytes = tokio::time::timeout(timeout, protocol.handle_message(&message_bytes))
-            .await
-            .map_err(|_| {
-                TestnetError::Retrieval(format!(
-                    "Timeout retrieving chunk after {DEFAULT_CHUNK_OPERATION_TIMEOUT_SECS}s"
-                ))
-            })?
-            .map_err(|e| TestnetError::Retrieval(format!("Protocol error: {e}")))?;
+        let response_bytes =
+            tokio::time::timeout(timeout, protocol.try_handle_request(&message_bytes))
+                .await
+                .map_err(|_| {
+                    TestnetError::Retrieval(format!(
+                        "Timeout retrieving chunk after {DEFAULT_CHUNK_OPERATION_TIMEOUT_SECS}s"
+                    ))
+                })?
+                .map_err(|e| TestnetError::Retrieval(format!("Protocol error: {e}")))?
+                .ok_or_else(|| TestnetError::Retrieval("expected response".to_string()))?;
 
         // Parse response
         let response = ChunkMessage::decode(&response_bytes)
@@ -1159,8 +1163,8 @@ impl TestNetwork {
                             let protocol = Arc::clone(&protocol_clone);
                             let p2p = Arc::clone(&p2p_clone);
                             tokio::spawn(async move {
-                                match protocol.handle_message(&data).await {
-                                    Ok(response) => {
+                                match protocol.try_handle_request(&data).await {
+                                    Ok(Some(response)) => {
                                         if let Err(e) = p2p
                                             .send_message(
                                                 &source,
@@ -1174,6 +1178,9 @@ impl TestNetwork {
                                                 "Node {node_index} failed to send chunk response to {source}: {e}"
                                             );
                                         }
+                                    }
+                                    Ok(None) => {
+                                        // Response message — no reply needed
                                     }
                                     Err(e) => {
                                         warn!(

--- a/tests/e2e/testnet.rs
+++ b/tests/e2e/testnet.rs
@@ -496,7 +496,12 @@ impl TestNode {
                     ))
                 })?
                 .map_err(|e| TestnetError::Storage(format!("Protocol error: {e}")))?
-                .ok_or_else(|| TestnetError::Storage("expected response".to_string()))?;
+                .ok_or_else(|| {
+                    TestnetError::Storage(format!(
+                        "Protocol returned no response for PUT request (request_id={request_id}, node_index={})",
+                        self.index
+                    ))
+                })?;
 
         // Parse response
         let response = ChunkMessage::decode(&response_bytes)
@@ -564,7 +569,11 @@ impl TestNode {
                     ))
                 })?
                 .map_err(|e| TestnetError::Retrieval(format!("Protocol error: {e}")))?
-                .ok_or_else(|| TestnetError::Retrieval("expected response".to_string()))?;
+                .ok_or_else(|| {
+                    TestnetError::Retrieval(format!(
+                        "Protocol returned no response for GET request (request_id={request_id}, address={address:?})"
+                    ))
+                })?;
 
         // Parse response
         let response = ChunkMessage::decode(&response_bytes)


### PR DESCRIPTION
## Summary

- Removes the deprecated `handle_message` method from `AntProtocol`, which always returned response bytes even for response messages, risking infinite ping-pong loops
- Migrates all 22 call sites (unit tests, e2e tests, message handler loop) to `try_handle_request`, which returns `Option<Bytes>` (`None` for response messages)
- Updates `test_handle_unexpected_response_message` to assert `None` instead of an error response

## Test plan

- [x] All 272 unit tests pass (`cargo test`)
- [x] All 14 handler-specific tests pass (`cargo test --lib storage::handler`)
- [x] `cargo fmt` clean
- [x] No new clippy warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)