### PR TITLE
fix: make GitHub release depend on successful crate publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,7 +390,7 @@ jobs:
 
   release:
     name: Create GitHub Release
-    needs: [validate, sign]
+    needs: [validate, sign, publish-crate]
     runs-on: ubuntu-latest
     if: github.event.inputs.dry_run != 'true'
     steps:


### PR DESCRIPTION
## Summary

- Adds `publish-crate` to the `release` job's `needs` list so a GitHub release is only created if crate publishing succeeds

## Test plan

- [ ] Verify release workflow graph shows the correct dependency chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)