### PR TITLE
feat: avoid clustered restarts during upgrades

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,9 +390,9 @@ jobs:
 
   release:
     name: Create GitHub Release
-    needs: [validate, sign]
+    needs: [validate, sign, publish-crate]
+    if: ${{ always() && !cancelled() && needs.validate.result == 'success' && needs.sign.result == 'success' && (needs.publish-crate.result == 'success' || needs.publish-crate.result == 'skipped') && github.event.inputs.dry_run != 'true' }}
     runs-on: ubuntu-latest
-    if: github.event.inputs.dry_run != 'true'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -371,7 +371,7 @@ jobs:
     name: Publish to crates.io
     needs: [validate, test]
     runs-on: ubuntu-latest
-    if: github.event.inputs.dry_run != 'true'
+    if: github.event.inputs.dry_run != 'true' && needs.validate.outputs.is_prerelease != 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -390,7 +390,7 @@ jobs:
 
   release:
     name: Create GitHub Release
-    needs: [validate, sign, publish-crate]
+    needs: [validate, sign]
     runs-on: ubuntu-latest
     if: github.event.inputs.dry_run != 'true'
     steps:

--- a/src/config.rs
+++ b/src/config.rs
@@ -369,7 +369,7 @@ const fn default_check_interval() -> u64 {
 }
 
 const fn default_staged_rollout_hours() -> u64 {
-    1 // 1 hour window for staged rollout (testing)
+    24 // 24 hour window for staged rollout
 }
 
 // ============================================================================

--- a/src/node.rs
+++ b/src/node.rs
@@ -602,16 +602,41 @@ impl RunningNode {
                                     jittered_duration
                                 },
                                 |remaining| {
-                                    let wake_time = chrono::Utc::now()
-                                        + chrono::Duration::from_std(remaining).unwrap_or_else(|e| {
-                                            warn!("chrono::Duration::from_std failed for rollout delay ({e}), defaulting to 1 minute");
-                                            chrono::Duration::minutes(1)
-                                        });
-                                    info!("Will apply upgrade at {}", wake_time.to_rfc3339());
-                                    remaining
+                                    // If the rollout delay has fully elapsed but the upgrade was
+                                    // not successfully applied, avoid a tight loop by backing off
+                                    // at least one check interval before retrying.
+                                    if remaining.is_zero() {
+                                        let backoff = jittered_interval(monitor.check_interval());
+                                        let next_check = chrono::Utc::now()
+                                            + chrono::Duration::from_std(backoff).unwrap_or_else(|e| {
+                                                warn!("chrono::Duration::from_std failed for backoff ({e}), defaulting to 1 hour");
+                                                chrono::Duration::hours(1)
+                                            });
+                                        info!(
+                                            "Upgrade rollout delay elapsed but previous apply did not succeed; \
+                                             backing off, next check scheduled for {}",
+                                            next_check.to_rfc3339()
+                                        );
+                                        backoff
+                                    } else {
+                                        let wake_time = chrono::Utc::now()
+                                            + chrono::Duration::from_std(remaining).unwrap_or_else(|e| {
+                                                warn!("chrono::Duration::from_std failed for rollout delay ({e}), defaulting to 1 minute");
+                                                chrono::Duration::minutes(1)
+                                            });
+                                        info!("Will apply upgrade at {}", wake_time.to_rfc3339());
+                                        remaining
+                                    }
                                 },
                             );
-                            tokio::time::sleep(sleep_duration).await;
+                            // Use select! so shutdown can interrupt long sleeps
+                            // (e.g. during a full rollout window delay).
+                            tokio::select! {
+                                () = shutdown.cancelled() => {
+                                    break;
+                                }
+                                () = tokio::time::sleep(sleep_duration) => {}
+                            }
                         }
                     }
                 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -585,16 +585,33 @@ impl RunningNode {
                                     warn!("Error during upgrade process: {}", e);
                                 }
                             }
-                            // Schedule next check with jitter to prevent fleet re-alignment
-                            let jittered_duration =
-                                jittered_interval(monitor.check_interval());
-                            let next_check = chrono::Utc::now()
-                                + chrono::Duration::from_std(jittered_duration).unwrap_or_else(|e| {
-                                    warn!("chrono::Duration::from_std failed for interval ({e}), defaulting to 1 hour");
-                                    chrono::Duration::hours(1)
-                                });
-                            info!("Next upgrade check scheduled for {}", next_check.to_rfc3339());
-                            tokio::time::sleep(jittered_duration).await;
+                            // If an upgrade is pending, sleep for exactly the remaining
+                            // rollout delay so the node restarts at its scheduled time
+                            // rather than waiting for the next check interval tick.
+                            let sleep_duration = monitor.time_until_upgrade().map_or_else(
+                                || {
+                                    // No pending upgrade - schedule next check with jitter
+                                    let jittered_duration =
+                                        jittered_interval(monitor.check_interval());
+                                    let next_check = chrono::Utc::now()
+                                        + chrono::Duration::from_std(jittered_duration).unwrap_or_else(|e| {
+                                            warn!("chrono::Duration::from_std failed for interval ({e}), defaulting to 1 hour");
+                                            chrono::Duration::hours(1)
+                                        });
+                                    info!("Next upgrade check scheduled for {}", next_check.to_rfc3339());
+                                    jittered_duration
+                                },
+                                |remaining| {
+                                    let wake_time = chrono::Utc::now()
+                                        + chrono::Duration::from_std(remaining).unwrap_or_else(|e| {
+                                            warn!("chrono::Duration::from_std failed for rollout delay ({e}), defaulting to 1 minute");
+                                            chrono::Duration::minutes(1)
+                                        });
+                                    info!("Will apply upgrade at {}", wake_time.to_rfc3339());
+                                    remaining
+                                },
+                            );
+                            tokio::time::sleep(sleep_duration).await;
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

- Increase the default staged rollout window from 1 hour to 24 hours, giving nodes more room to spread out their restarts
- When a pending upgrade is detected, sleep for exactly the remaining rollout delay instead of waiting for the next check interval tick — this eliminates restart clustering caused by quantization to the check interval
- Skip crates.io publish for pre-release versions (RC, alpha, beta) in the release workflow

## Test plan

- [x] Validated with 100-node testnet using 2-hour rollout window
- [x] Scheduled restart times are uniformly distributed across the rollout window
- [x] Actual restart times match scheduled times (no burst clustering)
- [x] All existing unit tests pass
- [x] Clippy and cargo fmt pass

## Test results

Auto-Upgrade Test Results: DEV-01

All 91 nodes (90 regular + 1 genesis) successfully upgraded from v0.7.0 to v0.7.10-rc.1.

| Check | Result |
|-------|--------|
| All nodes upgrade to v0.7.10-rc.1 | PASS (91/91) |
| Binary downloaded once per host | PASS (1 download per VM, rest cached) |
| Release info fetched once per host | PASS (2-3 fetches due to cache TTL over 2hr window, 34-53 cache hits each) |
| No upgrade errors | PASS (zero errors found) |
| Peer ID retention | PASS (identical before/after) |
| Port retention | N/A (nodes use random ports by design with 0.0.0.0:0) |
| Restart time distribution | PASS (spread across full 2-hour window, 2-11 per 10-min bucket, no clustering) |
| Graceful shutdown logged | PASS (91/91) |
| NRestarts = 1 | PASS (91/91) |
| No /proc/PID/exe (deleted) | PASS (91/91 - no stale binaries) |
| systemd stop/start cycle | PASS |

Key findings:

- Binary caching works - only 1 download per host, subsequent nodes detect the binary was already replaced
- Restart distribution is even - no clustered bursts, scheduled-to-actual accuracy within 5-11 seconds
- No stale binaries - the (deleted) issue from previous tests is fully resolved
- All process restarts verified via systemd NRestarts=1 and journalctl stop/start cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)