### PR TITLE
feat: replace ant-evm and libp2p with evmlib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,7 +863,7 @@ dependencies = [
  "reqwest",
  "rmp-serde",
  "saorsa-core",
- "saorsa-pqc 0.5.0",
+ "saorsa-pqc 0.5.1",
  "self-replace",
  "self_encryption",
  "semver 1.0.27",
@@ -2284,8 +2284,9 @@ dependencies = [
 
 [[package]]
 name = "evmlib"
-version = "0.4.9"
-source = "git+https://github.com/WithAutonomi/evmlib.git?branch=main#353ef597bcc7f3afa57025b620d54edd59e6c09c"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d608fcd0976beee509fef7fa391735571cb2fffd715ddca174322180300b6615"
 dependencies = [
  "alloy",
  "ant-merkle",
@@ -2921,7 +2922,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2939,7 +2940,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3234,9 +3235,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "797146bb2677299a1eb6b7b50a890f4c361b29ef967addf5b2fa45dae1bb6d7d"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4063,7 +4064,7 @@ dependencies = [
  "quinn-udp 0.5.14",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4101,7 +4102,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4114,7 +4115,7 @@ checksum = "76150b617afc75e6e21ac5f39bc196e80b65415ae48d62dbef8e2519d040ce42"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -4687,7 +4688,7 @@ dependencies = [
  "parking_lot",
  "postcard",
  "rand 0.8.5",
- "saorsa-pqc 0.5.0",
+ "saorsa-pqc 0.5.1",
  "saorsa-transport",
  "serde",
  "serde_json",
@@ -4745,9 +4746,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-pqc"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "846eb36cf54149d079fd824aa0aaeaa708dd612ef54eaaf65583c82f90b19f95"
+checksum = "a2ed2e429e5673763625ca5285bcbf15270fa16918cb5e63fc95ababacbb1a4c"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -4755,8 +4756,6 @@ dependencies = [
  "blake3",
  "bytes",
  "chacha20poly1305",
- "curve25519-dalek",
- "ed25519-dalek",
  "fips203",
  "fips204",
  "fips205",
@@ -4782,7 +4781,6 @@ dependencies = [
  "tokio",
  "tracing",
  "wide",
- "x25519-dalek",
  "zeroize",
 ]
 
@@ -6056,9 +6054,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "7dc0882f7b5bb01ae8c5215a1230832694481c1a4be062fd410e12ea3da5b631"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6069,9 +6067,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.65"
+version = "0.4.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+checksum = "19280959e2844181895ef62f065c63e0ca07ece4771b53d89bfdb967d97cbf05"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6079,9 +6077,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "75973d3066e01d035dbedaad2864c398df42f8dd7b1ea057c35b8407c015b537"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6089,9 +6087,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "91af5e4be765819e0bcfee7322c14374dc821e35e72fa663a830bbc7dc199eac"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6102,9 +6100,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "c9bf0406a78f02f336bf1e451799cca198e8acde4ffa278f0fb20487b150a633"
 dependencies = [
  "unicode-ident",
 ]
@@ -6159,9 +6157,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.92"
+version = "0.3.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+checksum = "749466a37ee189057f54748b200186b59a03417a117267baf3fd89cecc9fb837"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6218,7 +6216,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6233,7 +6231,7 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-core",
+ "windows-core 0.58.0",
  "windows-targets 0.52.6",
 ]
 
@@ -6243,11 +6241,24 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -6262,10 +6273,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-interface"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6288,13 +6321,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2285,6 +2285,7 @@ dependencies = [
 [[package]]
 name = "evmlib"
 version = "0.4.9"
+source = "git+https://github.com/WithAutonomi/evmlib.git?branch=feat/merge-ant-evm#976696e2f0f858ed9bd804f573f0799a170ffa3b"
 dependencies = [
  "alloy",
  "ant-merkle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,7 +760,7 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -826,29 +826,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ant-evm"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a83cf15203b24ca3fd13f9d481a3d15ca1c384032095f20d5069d8f9bc16afb"
-dependencies = [
- "ant-merkle",
- "custom_debug",
- "evmlib",
- "hex",
- "libp2p",
- "rand 0.8.5",
- "ring",
- "rmp-serde",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror 1.0.69",
- "tiny-keccak",
- "tracing",
- "xor_name",
-]
-
-[[package]]
 name = "ant-merkle"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,7 +840,6 @@ version = "0.7.0"
 dependencies = [
  "aes-gcm-siv",
  "alloy",
- "ant-evm",
  "blake3",
  "bytes",
  "chrono",
@@ -877,9 +853,7 @@ dependencies = [
  "heed",
  "hex",
  "hkdf",
- "libp2p",
  "lru",
- "multihash",
  "objc2",
  "objc2-foundation",
  "parking_lot",
@@ -1200,19 +1174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "asynchronous-codec"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
-dependencies = [
- "bytes",
- "futures-sink",
- "futures-util",
- "memchr",
- "pin-project-lite",
-]
-
-[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,26 +1243,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "base-x"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
-
-[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base256emoji"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e9430d9a245a77c92176e649af6e275f20839a48389859d1661e9a128d077c"
-dependencies = [
- "const-str",
- "match-lookup",
-]
 
 [[package]]
 name = "base64"
@@ -1463,15 +1408,6 @@ checksum = "503a0bcf59056a66c55d8eefd05e9c0f00f9c9cdddbb6bd499623ce49100da43"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
-]
-
-[[package]]
-name = "bs58"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
-dependencies = [
- "tinyvec",
 ]
 
 [[package]]
@@ -1740,12 +1676,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const-str"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
-
-[[package]]
 name = "const_format"
 version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,15 +1741,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -1978,59 +1899,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "custom_debug"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da7d1ad9567b3e11e877f1d7a0fa0360f04162f94965fc4448fbed41a65298e"
-dependencies = [
- "custom_debug_derive",
-]
-
-[[package]]
-name = "custom_debug_derive"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a707ceda8652f6c7624f2be725652e9524c815bf3b9d55a0b2320be2303f9c11"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "synstructure",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -2049,22 +1924,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
@@ -2088,26 +1952,6 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
-
-[[package]]
-name = "data-encoding-macro"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8142a83c17aa9461d637e649271eae18bf2edd00e91f2e105df36c3c16355bdb"
-dependencies = [
- "data-encoding",
- "data-encoding-macro-internal",
-]
-
-[[package]]
-name = "data-encoding-macro-internal"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
-dependencies = [
- "data-encoding",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "deflate64"
@@ -2297,12 +2141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dtoa"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2447,18 +2285,20 @@ dependencies = [
 [[package]]
 name = "evmlib"
 version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0830ac5a8d0e13e2275782c6375464ea49f255c0b59ccba4ca11f8fb7d67cea5"
 dependencies = [
  "alloy",
+ "ant-merkle",
  "exponential-backoff",
  "hex",
  "rand 0.8.5",
+ "rmp-serde",
  "serde",
  "serde_with",
  "thiserror 1.0.69",
+ "tiny-keccak",
  "tokio",
  "tracing",
+ "xor_name",
 ]
 
 [[package]]
@@ -2664,16 +2504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-bounded"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f328e7fb845fc832912fb6a34f40cf6d1888c92f974d1893a54e97b5ff542e"
-dependencies = [
- "futures-timer",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2728,12 +2558,6 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -2883,15 +2707,6 @@ dependencies = [
  "foldhash 0.2.0",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -3496,181 +3311,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libp2p"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce71348bf5838e46449ae240631117b487073d5f347c06d434caddcb91dceb5a"
-dependencies = [
- "bytes",
- "either",
- "futures",
- "futures-timer",
- "getrandom 0.2.17",
- "libp2p-allow-block-list",
- "libp2p-connection-limits",
- "libp2p-core",
- "libp2p-identify",
- "libp2p-identity",
- "libp2p-kad",
- "libp2p-metrics",
- "libp2p-swarm",
- "multiaddr",
- "pin-project",
- "rw-stream-sink",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "libp2p-allow-block-list"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16ccf824ee859ca83df301e1c0205270206223fd4b1f2e512a693e1912a8f4a"
-dependencies = [
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
-]
-
-[[package]]
-name = "libp2p-connection-limits"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18b8b607cf3bfa2f8c57db9c7d8569a315d5cc0a282e6bfd5ebfc0a9840b2a0"
-dependencies = [
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.43.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249128cd37a2199aff30a7675dffa51caf073b51aa612d2f544b19932b9aebca"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "libp2p-identity",
- "multiaddr",
- "multihash",
- "multistream-select",
- "parking_lot",
- "pin-project",
- "quick-protobuf",
- "rand 0.8.5",
- "rw-stream-sink",
- "thiserror 2.0.18",
- "tracing",
- "unsigned-varint 0.8.0",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-identify"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab792a8b68fdef443a62155b01970c81c3aadab5e659621b063ef252a8e65e8"
-dependencies = [
- "asynchronous-codec",
- "either",
- "futures",
- "futures-bounded",
- "futures-timer",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
- "quick-protobuf",
- "quick-protobuf-codec",
- "smallvec",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-identity"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c7892c221730ba55f7196e98b0b8ba5e04b4155651736036628e9f73ed6fc3"
-dependencies = [
- "bs58",
- "ed25519-dalek",
- "hkdf",
- "multihash",
- "quick-protobuf",
- "rand 0.8.5",
- "sha2",
- "thiserror 2.0.18",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "libp2p-kad"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d3fd632a5872ec804d37e7413ceea20588f69d027a0fa3c46f82574f4dee60"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "either",
- "fnv",
- "futures",
- "futures-bounded",
- "futures-timer",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
- "quick-protobuf",
- "quick-protobuf-codec",
- "rand 0.8.5",
- "sha2",
- "smallvec",
- "thiserror 2.0.18",
- "tracing",
- "uint 0.10.0",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-metrics"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805a555148522cb3414493a5153451910cb1a146c53ffbf4385708349baf62b7"
-dependencies = [
- "futures",
- "libp2p-core",
- "libp2p-identify",
- "libp2p-identity",
- "libp2p-kad",
- "libp2p-swarm",
- "pin-project",
- "prometheus-client",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-swarm"
-version = "0.47.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce88c6c4bf746c8482480345ea3edfd08301f49e026889d1cbccfa1808a9ed9e"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "hashlink",
- "libp2p-core",
- "libp2p-identity",
- "multistream-select",
- "rand 0.8.5",
- "smallvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3768,17 +3408,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "match-lookup"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3827,61 +3456,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "multiaddr"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
-dependencies = [
- "arrayref",
- "byteorder",
- "data-encoding",
- "libp2p-identity",
- "multibase",
- "multihash",
- "percent-encoding",
- "serde",
- "static_assertions",
- "unsigned-varint 0.8.0",
- "url",
-]
-
-[[package]]
-name = "multibase"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8694bb4835f452b0e3bb06dbebb1d6fc5385b6ca1caf2e55fd165c042390ec77"
-dependencies = [
- "base-x",
- "base256emoji",
- "data-encoding",
- "data-encoding-macro",
-]
-
-[[package]]
-name = "multihash"
-version = "0.19.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
-dependencies = [
- "core2",
- "unsigned-varint 0.8.0",
-]
-
-[[package]]
-name = "multistream-select"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
-dependencies = [
- "bytes",
- "futures",
- "log",
- "pin-project",
- "smallvec",
- "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -4407,7 +3981,7 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "uint 0.9.5",
+ "uint",
 ]
 
 [[package]]
@@ -4451,29 +4025,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus-client"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
-dependencies = [
- "dtoa",
- "itoa",
- "parking_lot",
- "prometheus-client-derive-encode",
-]
-
-[[package]]
-name = "prometheus-client-derive-encode"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proptest"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4497,28 +4048,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-protobuf"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "quick-protobuf-codec"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "quick-protobuf",
- "thiserror 1.0.69",
- "unsigned-varint 0.8.0",
-]
 
 [[package]]
 name = "quinn"
@@ -5116,17 +4645,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rw-stream-sink"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
-dependencies = [
- "futures",
- "pin-project",
- "static_assertions",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5581,7 +5099,7 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6383,18 +5901,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uint"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
-
-[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6439,18 +5945,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "unsigned-varint"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
-
-[[package]]
-name = "unsigned-varint"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2285,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "evmlib"
 version = "0.4.9"
-source = "git+https://github.com/WithAutonomi/evmlib.git?branch=feat/merge-ant-evm#976696e2f0f858ed9bd804f573f0799a170ffa3b"
+source = "git+https://github.com/WithAutonomi/evmlib.git?branch=main#353ef597bcc7f3afa57025b620d54edd59e6c09c"
 dependencies = [
  "alloy",
  "ant-merkle",
@@ -2921,7 +2921,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2939,7 +2939,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4063,7 +4063,7 @@ dependencies = [
  "quinn-udp 0.5.14",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4101,7 +4101,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4114,7 +4114,7 @@ checksum = "76150b617afc75e6e21ac5f39bc196e80b65415ae48d62dbef8e2519d040ce42"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -6218,7 +6218,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6233,7 +6233,7 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-core 0.58.0",
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 
@@ -6243,24 +6243,11 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -6275,32 +6262,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "windows-interface"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6323,31 +6288,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result 0.2.0",
+ "windows-result",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ saorsa-core = "0.20.0"
 saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment
-evmlib = { path = "/Users/anselme/Documents/maidsafe/saorsa/evmlib" }
+# TODO: update to crates.io version once evmlib with merged ant-evm types is released
+evmlib = { git = "https://github.com/WithAutonomi/evmlib.git", branch = "feat/merge-ant-evm" }
 xor_name = "5"
 
 # Caching - LRU cache for verified XorNames

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,7 @@ saorsa-core = "0.20.0"
 saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment
-# TODO: update to crates.io version once released
-evmlib = { git = "https://github.com/WithAutonomi/evmlib.git", branch = "main" }
+evmlib = "0.5.0"
 xor_name = "5"
 
 # Caching - LRU cache for verified XorNames

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,8 @@ saorsa-core = "0.20.0"
 saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment
-ant-evm = "0.1.19"
-evmlib = "0.4.9"
+evmlib = { path = "/Users/anselme/Documents/maidsafe/saorsa/evmlib" }
 xor_name = "5"
-libp2p = "0.56"  # For PeerId in payment proofs
-multihash = "0.19"  # For identity multihash in PeerId construction
 
 # Caching - LRU cache for verified XorNames
 lru = "0.16.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ saorsa-core = "0.20.0"
 saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment
-# TODO: update to crates.io version once evmlib with merged ant-evm types is released
-evmlib = { git = "https://github.com/WithAutonomi/evmlib.git", branch = "feat/merge-ant-evm" }
+# TODO: update to crates.io version once released
+evmlib = { git = "https://github.com/WithAutonomi/evmlib.git", branch = "main" }
 xor_name = "5"
 
 # Caching - LRU cache for verified XorNames

--- a/src/bin/ant-devnet/main.rs
+++ b/src/bin/ant-devnet/main.rs
@@ -56,9 +56,13 @@ async fn main() -> color_eyre::Result<()> {
     // Start Anvil and deploy contracts if EVM is enabled
     let evm_info = if cli.enable_evm {
         info!("Starting local Anvil blockchain for EVM payment enforcement...");
-        let testnet = evmlib::testnet::Testnet::new().await;
+        let testnet = evmlib::testnet::Testnet::new()
+            .await
+            .map_err(|e| color_eyre::eyre::eyre!("Failed to start Anvil testnet: {e}"))?;
         let network = testnet.to_network();
-        let wallet_key = testnet.default_wallet_private_key();
+        let wallet_key = testnet
+            .default_wallet_private_key()
+            .map_err(|e| color_eyre::eyre::eyre!("Failed to get wallet key: {e}"))?;
 
         let (rpc_url, token_addr, payments_addr, merkle_addr) = match &network {
             evmlib::Network::Custom(custom) => (

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -45,37 +45,23 @@ pub use data_types::{
 
 // Re-export hex_node_id_to_encoded_peer_id for payment operations
 use crate::error::{Error, Result};
-use ant_evm::EncodedPeerId;
-
-/// Identity multihash code (stores raw bytes without hashing).
-const MULTIHASH_IDENTITY_CODE: u64 = 0x00;
+use evmlib::EncodedPeerId;
 
 /// Convert a hex-encoded 32-byte node ID to an [`EncodedPeerId`].
 ///
 /// Peer IDs are 64-character hex strings representing 32 raw bytes.
-/// libp2p `PeerId` expects a multihash-encoded identity. This function bridges the two
-/// formats by wrapping the raw bytes in an identity multihash (code 0x00) and then
-/// converting to `EncodedPeerId` via `From<PeerId>`.
+/// This function decodes the hex string and wraps the raw bytes directly
+/// into an `EncodedPeerId`.
 ///
 /// # Errors
 ///
-/// Returns an error if the hex string is invalid or the peer ID cannot be constructed.
+/// Returns an error if the hex string is invalid or not exactly 32 bytes.
 pub fn hex_node_id_to_encoded_peer_id(hex_id: &str) -> Result<EncodedPeerId> {
     let raw_bytes = hex::decode(hex_id)
         .map_err(|e| Error::Payment(format!("Invalid hex peer ID '{hex_id}': {e}")))?;
-
-    let multihash =
-        multihash::Multihash::<64>::wrap(MULTIHASH_IDENTITY_CODE, &raw_bytes).map_err(|e| {
-            Error::Payment(format!(
-                "Failed to create multihash for peer '{hex_id}': {e}"
-            ))
-        })?;
-
-    let peer_id = libp2p::PeerId::from_multihash(multihash).map_err(|_| {
-        Error::Payment(format!(
-            "Failed to create PeerId from multihash for peer '{hex_id}'"
-        ))
+    let bytes: [u8; 32] = raw_bytes.try_into().map_err(|v: Vec<u8>| {
+        let len = v.len();
+        Error::Payment(format!("Peer ID must be 32 bytes, got {len}"))
     })?;
-
-    Ok(EncodedPeerId::from(peer_id))
+    Ok(EncodedPeerId::new(bytes))
 }

--- a/src/devnet.rs
+++ b/src/devnet.rs
@@ -10,8 +10,8 @@ use crate::payment::{
     QuotingMetricsTracker,
 };
 use crate::storage::{AntProtocol, LmdbStorage, LmdbStorageConfig};
-use ant_evm::RewardsAddress;
 use evmlib::Network as EvmNetwork;
+use evmlib::RewardsAddress;
 use rand::Rng;
 use saorsa_core::identity::NodeIdentity;
 use saorsa_core::{

--- a/src/payment/metrics.rs
+++ b/src/payment/metrics.rs
@@ -5,7 +5,7 @@
 //! - Storage capacity and usage
 //! - Network liveness information
 
-use ant_evm::QuotingMetrics;
+use evmlib::quoting_metrics::QuotingMetrics;
 use parking_lot::RwLock;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};

--- a/src/payment/pricing.rs
+++ b/src/payment/pricing.rs
@@ -20,7 +20,8 @@
 //! charge the same regardless of remaining capacity. The logarithmic curve ensures
 //! the network self-balances as nodes fill up.
 
-use ant_evm::{Amount, QuotingMetrics};
+use evmlib::common::Amount;
+use evmlib::quoting_metrics::QuotingMetrics;
 
 /// Minimum price floor (matches contract's `minPrice = 3`).
 const MIN_PRICE: u64 = 3;

--- a/src/payment/proof.rs
+++ b/src/payment/proof.rs
@@ -4,9 +4,9 @@
 //! on-chain transaction hashes returned by the wallet after payment.
 
 use crate::ant_protocol::{PROOF_TAG_MERKLE, PROOF_TAG_SINGLE_NODE};
-use ant_evm::merkle_payments::MerklePaymentProof;
-use ant_evm::ProofOfPayment;
 use evmlib::common::TxHash;
+use evmlib::merkle_payments::MerklePaymentProof;
+use evmlib::ProofOfPayment;
 use serde::{Deserialize, Serialize};
 
 /// A payment proof that includes both the quote-based proof and on-chain tx hashes.
@@ -116,15 +116,14 @@ pub fn deserialize_merkle_proof(bytes: &[u8]) -> std::result::Result<MerklePayme
 mod tests {
     use super::*;
     use alloy::primitives::FixedBytes;
-    use ant_evm::merkle_payments::{
+    use evmlib::merkle_payments::{
         MerklePaymentCandidateNode, MerklePaymentCandidatePool, MerklePaymentProof, MerkleTree,
         CANDIDATES_PER_POOL,
     };
-    use ant_evm::RewardsAddress;
-    use ant_evm::{EncodedPeerId, PaymentQuote};
     use evmlib::quoting_metrics::QuotingMetrics;
-    use libp2p::identity::Keypair;
-    use libp2p::PeerId;
+    use evmlib::EncodedPeerId;
+    use evmlib::PaymentQuote;
+    use evmlib::RewardsAddress;
     use saorsa_core::MlDsa65;
     use saorsa_pqc::pqc::types::MlDsaSecretKey;
     use saorsa_pqc::pqc::MlDsaOperations;
@@ -153,10 +152,9 @@ mod tests {
     }
 
     fn make_proof_of_payment() -> ProofOfPayment {
-        let keypair = Keypair::generate_ed25519();
-        let peer_id = PeerId::from_public_key(&keypair.public());
+        let random_peer = EncodedPeerId::new(rand::random());
         ProofOfPayment {
-            peer_quotes: vec![(EncodedPeerId::from(peer_id), make_test_quote())],
+            peer_quotes: vec![(random_peer, make_test_quote())],
         }
     }
 

--- a/src/payment/quote.rs
+++ b/src/payment/quote.rs
@@ -9,8 +9,10 @@
 
 use crate::error::{Error, Result};
 use crate::payment::metrics::QuotingMetricsTracker;
-use ant_evm::merkle_payments::MerklePaymentCandidateNode;
-use ant_evm::{PaymentQuote, QuotingMetrics, RewardsAddress};
+use evmlib::merkle_payments::MerklePaymentCandidateNode;
+use evmlib::quoting_metrics::QuotingMetrics;
+use evmlib::PaymentQuote;
+use evmlib::RewardsAddress;
 use saorsa_core::MlDsa65;
 use saorsa_pqc::pqc::types::{MlDsaPublicKey, MlDsaSecretKey, MlDsaSignature};
 use saorsa_pqc::pqc::MlDsaOperations;
@@ -612,7 +614,7 @@ mod tests {
         let quote = PaymentQuote {
             content: xor_name::XorName([0u8; 32]),
             timestamp: SystemTime::now(),
-            quoting_metrics: ant_evm::QuotingMetrics {
+            quoting_metrics: QuotingMetrics {
                 data_size: 0,
                 data_type: 0,
                 close_records_stored: 0,
@@ -761,7 +763,7 @@ mod tests {
             .duration_since(std::time::UNIX_EPOCH)
             .expect("system time")
             .as_secs();
-        let metrics = ant_evm::QuotingMetrics {
+        let metrics = QuotingMetrics {
             data_size: 4096,
             data_type: 0,
             close_records_stored: 10,

--- a/src/payment/single_node.rs
+++ b/src/payment/single_node.rs
@@ -12,10 +12,13 @@
 
 use crate::ant_protocol::CLOSE_GROUP_SIZE;
 use crate::error::{Error, Result};
-use ant_evm::{Amount, PaymentQuote, QuoteHash, QuotingMetrics, RewardsAddress};
+use evmlib::common::{Amount, QuoteHash};
 use evmlib::contract::payment_vault;
+use evmlib::quoting_metrics::QuotingMetrics;
 use evmlib::wallet::Wallet;
 use evmlib::Network as EvmNetwork;
+use evmlib::PaymentQuote;
+use evmlib::RewardsAddress;
 use tracing::info;
 
 /// Create zero-valued `QuotingMetrics` for payment verification.
@@ -330,9 +333,13 @@ mod tests {
     async fn test_standard_five_quote_payment() {
         // Use autonomi's setup pattern with increased timeout for CI
         let (node, rpc_url) = start_node_with_timeout();
-        let network_token = deploy_network_token_contract(&rpc_url, &node).await;
+        let network_token = deploy_network_token_contract(&rpc_url, &node)
+            .await
+            .expect("deploy network token");
         let mut payment_vault =
-            deploy_data_payments_contract(&rpc_url, &node, *network_token.contract.address()).await;
+            deploy_data_payments_contract(&rpc_url, &node, *network_token.contract.address())
+                .await
+                .expect("deploy data payments");
 
         let transaction_config = TransactionConfig::default();
 
@@ -397,9 +404,13 @@ mod tests {
     #[allow(clippy::expect_used)]
     async fn test_single_node_payment_strategy() {
         let (node, rpc_url) = start_node_with_timeout();
-        let network_token = deploy_network_token_contract(&rpc_url, &node).await;
+        let network_token = deploy_network_token_contract(&rpc_url, &node)
+            .await
+            .expect("deploy network token");
         let mut payment_vault =
-            deploy_data_payments_contract(&rpc_url, &node, *network_token.contract.address()).await;
+            deploy_data_payments_contract(&rpc_url, &node, *network_token.contract.address())
+                .await
+                .expect("deploy data payments");
 
         let transaction_config = TransactionConfig::default();
 
@@ -608,11 +619,15 @@ mod tests {
     #[serial]
     async fn test_single_node_with_real_prices() -> Result<()> {
         // Setup testnet
-        let testnet = Testnet::new().await;
+        let testnet = Testnet::new()
+            .await
+            .map_err(|e| Error::Payment(format!("Failed to start testnet: {e}")))?;
         let network = testnet.to_network();
-        let wallet =
-            Wallet::new_from_private_key(network.clone(), &testnet.default_wallet_private_key())
-                .map_err(|e| Error::Payment(format!("Failed to create wallet: {e}")))?;
+        let wallet_key = testnet
+            .default_wallet_private_key()
+            .map_err(|e| Error::Payment(format!("Failed to get wallet key: {e}")))?;
+        let wallet = Wallet::new_from_private_key(network.clone(), &wallet_key)
+            .map_err(|e| Error::Payment(format!("Failed to create wallet: {e}")))?;
 
         println!("✓ Started Anvil testnet");
 

--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -10,11 +10,12 @@ use crate::payment::proof::{
     deserialize_merkle_proof, deserialize_proof, detect_proof_type, ProofType,
 };
 use crate::payment::quote::{verify_quote_content, verify_quote_signature};
-use ant_evm::merkle_payments::OnChainPaymentInfo;
-use ant_evm::{ProofOfPayment, RewardsAddress};
 use evmlib::contract::merkle_payment_vault;
 use evmlib::merkle_batch_payment::PoolHash;
+use evmlib::merkle_payments::OnChainPaymentInfo;
 use evmlib::Network as EvmNetwork;
+use evmlib::ProofOfPayment;
+use evmlib::RewardsAddress;
 use lru::LruCache;
 use parking_lot::Mutex;
 use saorsa_core::identity::node_identity::peer_id_from_public_key_bytes;
@@ -253,9 +254,9 @@ impl PaymentVerifier {
                     Ok(PaymentStatus::PaymentVerified)
                 } else {
                     // No payment provided in production mode
+                    let xorname_hex = hex::encode(xorname);
                     Err(Error::Payment(format!(
-                        "Payment required for new data {}",
-                        hex::encode(xorname)
+                        "Payment required for new data {xorname_hex}"
                     )))
                 }
             }
@@ -365,10 +366,8 @@ impl PaymentVerifier {
             .verify_payment(payment_verifications)
             .await
             .map_err(|e| {
-                Error::Payment(format!(
-                    "EVM verification error for {}: {e}",
-                    hex::encode(xorname)
-                ))
+                let xorname_hex = hex::encode(xorname);
+                Error::Payment(format!("EVM verification error for {xorname_hex}: {e}"))
             })?;
 
         let paid_results: Vec<_> = results
@@ -377,27 +376,27 @@ impl PaymentVerifier {
             .collect();
 
         if paid_results.is_empty() {
+            let xorname_hex = hex::encode(xorname);
             return Err(Error::Payment(format!(
-                "Payment verification failed on-chain for {} (no paid quotes found)",
-                hex::encode(xorname)
+                "Payment verification failed on-chain for {xorname_hex} (no paid quotes found)"
             )));
         }
 
         for result in &paid_results {
             if !result.isValid {
+                let xorname_hex = hex::encode(xorname);
                 return Err(Error::Payment(format!(
-                    "Payment verification failed on-chain for {} (paid quote is invalid)",
-                    hex::encode(xorname)
+                    "Payment verification failed on-chain for {xorname_hex} (paid quote is invalid)"
                 )));
             }
         }
 
         if tracing::enabled!(tracing::Level::INFO) {
             let valid_count = paid_results.len();
+            let total_results = results.len();
+            let xorname_hex = hex::encode(xorname);
             info!(
-                "EVM payment verified for {} ({valid_count} paid and valid, {} total results)",
-                hex::encode(xorname),
-                results.len()
+                "EVM payment verified for {xorname_hex} ({valid_count} paid and valid, {total_results} total results)"
             );
         }
         Ok(())
@@ -416,7 +415,7 @@ impl PaymentVerifier {
             )));
         }
 
-        let mut seen: Vec<&ant_evm::EncodedPeerId> = Vec::with_capacity(quote_count);
+        let mut seen: Vec<&evmlib::EncodedPeerId> = Vec::with_capacity(quote_count);
         for (encoded_peer_id, _) in &payment.peer_quotes {
             if seen.contains(&encoded_peer_id) {
                 return Err(Error::Payment(format!(
@@ -433,10 +432,10 @@ impl PaymentVerifier {
     fn validate_quote_content(payment: &ProofOfPayment, xorname: &XorName) -> Result<()> {
         for (encoded_peer_id, quote) in &payment.peer_quotes {
             if !verify_quote_content(quote, xorname) {
+                let expected_hex = hex::encode(xorname);
+                let actual_hex = hex::encode(quote.content.0);
                 return Err(Error::Payment(format!(
-                    "Quote content address mismatch for peer {encoded_peer_id:?}: expected {}, got {}",
-                    hex::encode(xorname),
-                    hex::encode(quote.content.0)
+                    "Quote content address mismatch for peer {encoded_peer_id:?}: expected {expected_hex}, got {actual_hex}"
                 )));
             }
         }
@@ -482,25 +481,12 @@ impl PaymentVerifier {
             let expected_peer_id = peer_id_from_public_key_bytes(&quote.pub_key)
                 .map_err(|e| Error::Payment(format!("Invalid ML-DSA public key in quote: {e}")))?;
 
-            let libp2p_peer_id = encoded_peer_id
-                .to_peer_id()
-                .map_err(|e| Error::Payment(format!("Invalid encoded peer ID: {e}")))?;
-            let peer_id_bytes = libp2p_peer_id.to_bytes();
-            let raw_peer_bytes = if peer_id_bytes.len() > 2 {
-                &peer_id_bytes[2..]
-            } else {
-                return Err(Error::Payment(format!(
-                    "Invalid encoded peer ID: too short ({} bytes)",
-                    peer_id_bytes.len()
-                )));
-            };
-
-            if expected_peer_id.as_bytes() != raw_peer_bytes {
+            if expected_peer_id.as_bytes() != encoded_peer_id.as_bytes() {
+                let expected_hex = expected_peer_id.to_hex();
+                let actual_hex = hex::encode(encoded_peer_id.as_bytes());
                 return Err(Error::Payment(format!(
                     "Quote pub_key does not belong to claimed peer {encoded_peer_id:?}: \
-                     BLAKE3(pub_key) = {}, peer_id = {}",
-                    expected_peer_id.to_hex(),
-                    hex::encode(raw_peer_bytes)
+                     BLAKE3(pub_key) = {expected_hex}, peer_id = {actual_hex}"
                 )));
             }
         }
@@ -527,10 +513,10 @@ impl PaymentVerifier {
 
         // Verify the address in the proof matches the xorname being stored
         if merkle_proof.address.0 != *xorname {
+            let proof_hex = hex::encode(merkle_proof.address.0);
+            let store_hex = hex::encode(xorname);
             return Err(Error::Payment(format!(
-                "Merkle proof address mismatch: proof is for {}, but storing {}",
-                hex::encode(merkle_proof.address.0),
-                hex::encode(xorname)
+                "Merkle proof address mismatch: proof is for {proof_hex}, but storing {store_hex}"
             )));
         }
 
@@ -551,9 +537,9 @@ impl PaymentVerifier {
                 merkle_payment_vault::get_merkle_payment_info(&self.config.evm.network, pool_hash)
                     .await
                     .map_err(|e| {
+                        let pool_hex = hex::encode(pool_hash);
                         Error::Payment(format!(
-                            "Failed to query merkle payment info for pool {}: {e}",
-                            hex::encode(pool_hash)
+                            "Failed to query merkle payment info for pool {pool_hex}: {e}"
                         ))
                     })?;
 
@@ -615,7 +601,7 @@ impl PaymentVerifier {
 
         // Verify the cryptographic merkle proofs (address belongs to tree,
         // midpoint belongs to tree, roots match, timestamps valid).
-        ant_evm::merkle_payments::verify_merkle_proof(
+        evmlib::merkle_payments::verify_merkle_proof(
             &merkle_proof.address,
             &merkle_proof.data_proof,
             &merkle_proof.winner_pool.midpoint_proof,
@@ -624,18 +610,18 @@ impl PaymentVerifier {
             payment_info.merkle_payment_timestamp,
         )
         .map_err(|e| {
+            let xorname_hex = hex::encode(xorname);
             Error::Payment(format!(
-                "Merkle proof verification failed for {}: {e}",
-                hex::encode(xorname)
+                "Merkle proof verification failed for {xorname_hex}: {e}"
             ))
         })?;
 
         // Verify paid node count matches depth
-        if payment_info.paid_node_addresses.len() != payment_info.depth as usize {
+        let expected_depth = payment_info.depth as usize;
+        let actual_paid = payment_info.paid_node_addresses.len();
+        if actual_paid != expected_depth {
             return Err(Error::Payment(format!(
-                "Wrong number of paid nodes: expected {}, got {}",
-                payment_info.depth,
-                payment_info.paid_node_addresses.len()
+                "Wrong number of paid nodes: expected {expected_depth}, got {actual_paid}"
             )));
         }
 
@@ -951,7 +937,7 @@ mod tests {
         use crate::payment::proof::PaymentProof;
         use crate::payment::quote::{QuoteGenerator, XorName};
         use alloy::primitives::FixedBytes;
-        use ant_evm::{EncodedPeerId, RewardsAddress};
+        use evmlib::{EncodedPeerId, RewardsAddress};
         use saorsa_core::MlDsa65;
         use saorsa_pqc::pqc::types::MlDsaSecretKey;
         use saorsa_pqc::pqc::MlDsaOperations;
@@ -977,9 +963,7 @@ mod tests {
             let content: XorName = [i; 32];
             let quote = generator.create_quote(content, 4096, 0).expect("quote");
 
-            let keypair = libp2p::identity::Keypair::generate_ed25519();
-            let peer_id = libp2p::PeerId::from_public_key(&keypair.public());
-            peer_quotes.push((EncodedPeerId::from(peer_id), quote));
+            peer_quotes.push((EncodedPeerId::new(rand::random()), quote));
         }
 
         let proof = PaymentProof {
@@ -1008,9 +992,8 @@ mod tests {
     #[tokio::test]
     async fn test_content_address_mismatch_rejected() {
         use crate::payment::proof::{serialize_single_node_proof, PaymentProof};
-        use ant_evm::{EncodedPeerId, PaymentQuote, QuotingMetrics, RewardsAddress};
-        use libp2p::identity::Keypair;
-        use libp2p::PeerId;
+        use evmlib::quoting_metrics::QuotingMetrics;
+        use evmlib::{EncodedPeerId, PaymentQuote, RewardsAddress};
         use std::time::SystemTime;
 
         let verifier = create_test_verifier();
@@ -1042,9 +1025,7 @@ mod tests {
         // Build CLOSE_GROUP_SIZE quotes with distinct peer IDs
         let mut peer_quotes = Vec::new();
         for _ in 0..CLOSE_GROUP_SIZE {
-            let keypair = Keypair::generate_ed25519();
-            let peer_id = PeerId::from_public_key(&keypair.public());
-            peer_quotes.push((EncodedPeerId::from(peer_id), quote.clone()));
+            peer_quotes.push((EncodedPeerId::new(rand::random()), quote.clone()));
         }
 
         let proof = PaymentProof {
@@ -1071,8 +1052,9 @@ mod tests {
         xorname: [u8; 32],
         timestamp: SystemTime,
         rewards_address: RewardsAddress,
-    ) -> ant_evm::PaymentQuote {
-        use ant_evm::{PaymentQuote, QuotingMetrics};
+    ) -> evmlib::PaymentQuote {
+        use evmlib::quoting_metrics::QuotingMetrics;
+        use evmlib::PaymentQuote;
 
         PaymentQuote {
             content: xor_name::XorName(xorname),
@@ -1095,9 +1077,7 @@ mod tests {
     }
 
     /// Helper: wrap quotes into a tagged serialized `PaymentProof`.
-    fn serialize_proof(
-        peer_quotes: Vec<(ant_evm::EncodedPeerId, ant_evm::PaymentQuote)>,
-    ) -> Vec<u8> {
+    fn serialize_proof(peer_quotes: Vec<(evmlib::EncodedPeerId, evmlib::PaymentQuote)>) -> Vec<u8> {
         use crate::payment::proof::{serialize_single_node_proof, PaymentProof};
 
         let proof = PaymentProof {
@@ -1109,7 +1089,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_expired_quote_rejected() {
-        use ant_evm::{EncodedPeerId, RewardsAddress};
+        use evmlib::{EncodedPeerId, RewardsAddress};
         use std::time::Duration;
 
         let verifier = create_test_verifier();
@@ -1122,9 +1102,7 @@ mod tests {
 
         let mut peer_quotes = Vec::new();
         for _ in 0..CLOSE_GROUP_SIZE {
-            let keypair = libp2p::identity::Keypair::generate_ed25519();
-            let peer_id = libp2p::PeerId::from_public_key(&keypair.public());
-            peer_quotes.push((EncodedPeerId::from(peer_id), quote.clone()));
+            peer_quotes.push((EncodedPeerId::new(rand::random()), quote.clone()));
         }
 
         let proof_bytes = serialize_proof(peer_quotes);
@@ -1140,7 +1118,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_future_timestamp_rejected() {
-        use ant_evm::{EncodedPeerId, RewardsAddress};
+        use evmlib::{EncodedPeerId, RewardsAddress};
         use std::time::Duration;
 
         let verifier = create_test_verifier();
@@ -1153,9 +1131,7 @@ mod tests {
 
         let mut peer_quotes = Vec::new();
         for _ in 0..CLOSE_GROUP_SIZE {
-            let keypair = libp2p::identity::Keypair::generate_ed25519();
-            let peer_id = libp2p::PeerId::from_public_key(&keypair.public());
-            peer_quotes.push((EncodedPeerId::from(peer_id), quote.clone()));
+            peer_quotes.push((EncodedPeerId::new(rand::random()), quote.clone()));
         }
 
         let proof_bytes = serialize_proof(peer_quotes);
@@ -1171,7 +1147,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_quote_within_clock_skew_tolerance_accepted() {
-        use ant_evm::{EncodedPeerId, RewardsAddress};
+        use evmlib::{EncodedPeerId, RewardsAddress};
         use std::time::Duration;
 
         let verifier = create_test_verifier();
@@ -1184,9 +1160,7 @@ mod tests {
 
         let mut peer_quotes = Vec::new();
         for _ in 0..CLOSE_GROUP_SIZE {
-            let keypair = libp2p::identity::Keypair::generate_ed25519();
-            let peer_id = libp2p::PeerId::from_public_key(&keypair.public());
-            peer_quotes.push((EncodedPeerId::from(peer_id), quote.clone()));
+            peer_quotes.push((EncodedPeerId::new(rand::random()), quote.clone()));
         }
 
         let proof_bytes = serialize_proof(peer_quotes);
@@ -1202,7 +1176,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_quote_just_beyond_clock_skew_tolerance_rejected() {
-        use ant_evm::{EncodedPeerId, RewardsAddress};
+        use evmlib::{EncodedPeerId, RewardsAddress};
         use std::time::Duration;
 
         let verifier = create_test_verifier();
@@ -1215,9 +1189,7 @@ mod tests {
 
         let mut peer_quotes = Vec::new();
         for _ in 0..CLOSE_GROUP_SIZE {
-            let keypair = libp2p::identity::Keypair::generate_ed25519();
-            let peer_id = libp2p::PeerId::from_public_key(&keypair.public());
-            peer_quotes.push((EncodedPeerId::from(peer_id), quote.clone()));
+            peer_quotes.push((EncodedPeerId::new(rand::random()), quote.clone()));
         }
 
         let proof_bytes = serialize_proof(peer_quotes);
@@ -1236,7 +1208,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_quote_23h_old_still_accepted() {
-        use ant_evm::{EncodedPeerId, RewardsAddress};
+        use evmlib::{EncodedPeerId, RewardsAddress};
         use std::time::Duration;
 
         let verifier = create_test_verifier();
@@ -1249,9 +1221,7 @@ mod tests {
 
         let mut peer_quotes = Vec::new();
         for _ in 0..CLOSE_GROUP_SIZE {
-            let keypair = libp2p::identity::Keypair::generate_ed25519();
-            let peer_id = libp2p::PeerId::from_public_key(&keypair.public());
-            peer_quotes.push((EncodedPeerId::from(peer_id), quote.clone()));
+            peer_quotes.push((EncodedPeerId::new(rand::random()), quote.clone()));
         }
 
         let proof_bytes = serialize_proof(peer_quotes);
@@ -1266,23 +1236,14 @@ mod tests {
     }
 
     /// Helper: build an `EncodedPeerId` that matches the BLAKE3 hash of an ML-DSA public key.
-    fn encoded_peer_id_for_pub_key(pub_key: &[u8]) -> ant_evm::EncodedPeerId {
+    fn encoded_peer_id_for_pub_key(pub_key: &[u8]) -> evmlib::EncodedPeerId {
         let ant_peer_id = peer_id_from_public_key_bytes(pub_key).expect("valid ML-DSA pub key");
-        // Wrap raw 32-byte peer ID in identity multihash format: [0x00, length, ...bytes]
-        let raw = ant_peer_id.as_bytes();
-        let mut multihash_bytes = Vec::with_capacity(2 + raw.len());
-        multihash_bytes.push(0x00); // identity multihash code
-                                    // PeerId is always 32 bytes, safely fits in u8
-        multihash_bytes.push(u8::try_from(raw.len()).unwrap_or(32));
-        multihash_bytes.extend_from_slice(raw);
-        let libp2p_peer_id =
-            libp2p::PeerId::from_bytes(&multihash_bytes).expect("valid multihash peer ID");
-        ant_evm::EncodedPeerId::from(libp2p_peer_id)
+        evmlib::EncodedPeerId::new(*ant_peer_id.as_bytes())
     }
 
     #[tokio::test]
     async fn test_local_not_in_paid_set_rejected() {
-        use ant_evm::RewardsAddress;
+        use evmlib::RewardsAddress;
         use saorsa_core::MlDsa65;
         use saorsa_pqc::pqc::MlDsaOperations;
 
@@ -1328,7 +1289,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_wrong_peer_binding_rejected() {
-        use ant_evm::{EncodedPeerId, RewardsAddress};
+        use evmlib::{EncodedPeerId, RewardsAddress};
         use saorsa_core::MlDsa65;
         use saorsa_pqc::pqc::MlDsaOperations;
 
@@ -1349,9 +1310,7 @@ mod tests {
         // Use random ed25519 peer IDs — they won't match BLAKE3(pub_key)
         let mut peer_quotes = Vec::new();
         for _ in 0..CLOSE_GROUP_SIZE {
-            let keypair = libp2p::identity::Keypair::generate_ed25519();
-            let peer_id = libp2p::PeerId::from_public_key(&keypair.public());
-            peer_quotes.push((EncodedPeerId::from(peer_id), quote.clone()));
+            peer_quotes.push((EncodedPeerId::new(rand::random()), quote.clone()));
         }
 
         let proof_bytes = serialize_proof(peer_quotes);
@@ -1400,7 +1359,7 @@ mod tests {
     #[tokio::test]
     async fn test_single_node_tagged_proof_deserialization() {
         use crate::payment::proof::serialize_single_node_proof;
-        use ant_evm::{EncodedPeerId, RewardsAddress};
+        use evmlib::{EncodedPeerId, RewardsAddress};
 
         let verifier = create_test_verifier();
         let xorname = [0xA2u8; 32];
@@ -1410,9 +1369,7 @@ mod tests {
         let quote = make_fake_quote(xorname, SystemTime::now(), rewards_addr);
         let mut peer_quotes = Vec::new();
         for _ in 0..CLOSE_GROUP_SIZE {
-            let keypair = libp2p::identity::Keypair::generate_ed25519();
-            let peer_id = libp2p::PeerId::from_public_key(&keypair.public());
-            peer_quotes.push((EncodedPeerId::from(peer_id), quote.clone()));
+            peer_quotes.push((EncodedPeerId::new(rand::random()), quote.clone()));
         }
 
         let proof = crate::payment::proof::PaymentProof {
@@ -1453,7 +1410,7 @@ mod tests {
         let verifier = create_test_verifier();
 
         let pool_hash: PoolHash = [0xBBu8; 32];
-        let payment_info = ant_evm::merkle_payments::OnChainPaymentInfo {
+        let payment_info = evmlib::merkle_payments::OnChainPaymentInfo {
             depth: 4,
             merkle_payment_timestamp: 1_700_000_000,
             paid_node_addresses: vec![],
@@ -1498,9 +1455,9 @@ mod tests {
     /// Helper: build 16 validly-signed ML-DSA-65 candidate nodes.
     fn make_candidate_nodes(
         timestamp: u64,
-    ) -> [ant_evm::merkle_payments::MerklePaymentCandidateNode;
-           ant_evm::merkle_payments::CANDIDATES_PER_POOL] {
-        use ant_evm::merkle_payments::{MerklePaymentCandidateNode, CANDIDATES_PER_POOL};
+    ) -> [evmlib::merkle_payments::MerklePaymentCandidateNode;
+           evmlib::merkle_payments::CANDIDATES_PER_POOL] {
+        use evmlib::merkle_payments::{MerklePaymentCandidateNode, CANDIDATES_PER_POOL};
         use saorsa_core::MlDsa65;
         use saorsa_pqc::pqc::types::MlDsaSecretKey;
         use saorsa_pqc::pqc::MlDsaOperations;
@@ -1508,7 +1465,7 @@ mod tests {
         std::array::from_fn::<_, CANDIDATES_PER_POOL, _>(|i| {
             let ml_dsa = MlDsa65::new();
             let (pub_key, secret_key) = ml_dsa.generate_keypair().expect("keygen");
-            let metrics = ant_evm::QuotingMetrics {
+            let metrics = evmlib::quoting_metrics::QuotingMetrics {
                 data_size: 1024,
                 data_type: 0,
                 close_records_stored: i * 10,
@@ -1539,14 +1496,12 @@ mod tests {
     /// Helper: build a valid `MerklePaymentProof` with real ML-DSA-65
     /// signatures. Returns the raw proof, pool hash, xorname, and timestamp.
     fn make_valid_merkle_proof() -> (
-        ant_evm::merkle_payments::MerklePaymentProof,
+        evmlib::merkle_payments::MerklePaymentProof,
         evmlib::merkle_batch_payment::PoolHash,
         [u8; 32],
         u64,
     ) {
-        use ant_evm::merkle_payments::{
-            MerklePaymentCandidatePool, MerklePaymentProof, MerkleTree,
-        };
+        use evmlib::merkle_payments::{MerklePaymentCandidatePool, MerklePaymentProof, MerkleTree};
 
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -1701,7 +1656,7 @@ mod tests {
                     hash[j] = *b;
                 }
             }
-            let info = ant_evm::merkle_payments::OnChainPaymentInfo {
+            let info = evmlib::merkle_payments::OnChainPaymentInfo {
                 depth: 4,
                 merkle_payment_timestamp: 1_700_000_000,
                 paid_node_addresses: vec![],
@@ -1716,7 +1671,7 @@ mod tests {
 
         // Insert one more — should evict the oldest
         let overflow_hash: PoolHash = [0xFFu8; 32];
-        let info = ant_evm::merkle_payments::OnChainPaymentInfo {
+        let info = evmlib::merkle_payments::OnChainPaymentInfo {
             depth: 8,
             merkle_payment_timestamp: 1_800_000_000,
             paid_node_addresses: vec![],
@@ -1750,7 +1705,7 @@ mod tests {
             let v = verifier.clone();
             handles.push(std::thread::spawn(move || {
                 let hash: PoolHash = [i; 32];
-                let info = ant_evm::merkle_payments::OnChainPaymentInfo {
+                let info = evmlib::merkle_payments::OnChainPaymentInfo {
                     depth: i,
                     merkle_payment_timestamp: u64::from(i) * 1000,
                     paid_node_addresses: vec![],
@@ -1792,7 +1747,7 @@ mod tests {
 
         // Pre-populate pool cache so we skip the on-chain query
         {
-            let info = ant_evm::merkle_payments::OnChainPaymentInfo {
+            let info = evmlib::merkle_payments::OnChainPaymentInfo {
                 depth: 4,
                 merkle_payment_timestamp: timestamp,
                 paid_node_addresses: vec![],
@@ -1825,7 +1780,7 @@ mod tests {
         // Pre-populate pool cache with a DIFFERENT timestamp than the candidates
         {
             let mismatched_ts = timestamp + 9999;
-            let info = ant_evm::merkle_payments::OnChainPaymentInfo {
+            let info = evmlib::merkle_payments::OnChainPaymentInfo {
                 depth: 4,
                 merkle_payment_timestamp: mismatched_ts,
                 paid_node_addresses: vec![],
@@ -1855,7 +1810,7 @@ mod tests {
         // so verify_merkle_proof passes the depth check, then the paid node
         // index out-of-bounds check fires.
         {
-            let info = ant_evm::merkle_payments::OnChainPaymentInfo {
+            let info = evmlib::merkle_payments::OnChainPaymentInfo {
                 depth: 2,
                 merkle_payment_timestamp: ts,
                 paid_node_addresses: vec![
@@ -1889,7 +1844,7 @@ mod tests {
         // Tree has depth 2, so provide 2 paid node entries.
         // Both use valid indices but the second has a wrong reward address.
         {
-            let info = ant_evm::merkle_payments::OnChainPaymentInfo {
+            let info = evmlib::merkle_payments::OnChainPaymentInfo {
                 depth: 2,
                 merkle_payment_timestamp: ts,
                 paid_node_addresses: vec![
@@ -1920,7 +1875,7 @@ mod tests {
         // Pre-populate pool cache with depth=3 but only 1 paid node address
         // (depth must equal paid_node_addresses.len())
         {
-            let info = ant_evm::merkle_payments::OnChainPaymentInfo {
+            let info = evmlib::merkle_payments::OnChainPaymentInfo {
                 depth: 3,
                 merkle_payment_timestamp: ts,
                 paid_node_addresses: vec![(RewardsAddress::new([0u8; 20]), 0)],

--- a/src/payment/wallet.rs
+++ b/src/payment/wallet.rs
@@ -5,8 +5,8 @@
 
 use crate::config::EvmNetworkConfig;
 use crate::error::{Error, Result};
-use ant_evm::RewardsAddress;
 use evmlib::Network as EvmNetwork;
+use evmlib::RewardsAddress;
 
 /// EVM wallet configuration for a node.
 #[derive(Debug, Clone)]

--- a/src/storage/handler.rs
+++ b/src/storage/handler.rs
@@ -390,7 +390,7 @@ mod tests {
     use crate::payment::metrics::QuotingMetricsTracker;
     use crate::payment::{EvmVerifierConfig, PaymentVerifierConfig};
     use crate::storage::LmdbStorageConfig;
-    use ant_evm::RewardsAddress;
+    use evmlib::RewardsAddress;
     use saorsa_core::identity::NodeIdentity;
     use saorsa_core::MlDsa65;
     use saorsa_pqc::pqc::types::MlDsaSecretKey;
@@ -782,7 +782,7 @@ mod tests {
     #[tokio::test]
     async fn test_merkle_candidate_quote_request() {
         use crate::payment::quote::verify_merkle_candidate_signature;
-        use ant_evm::merkle_payments::MerklePaymentCandidateNode;
+        use evmlib::merkle_payments::MerklePaymentCandidateNode;
 
         // create_test_protocol already wires ML-DSA-65 signing
         let (protocol, _temp) = create_test_protocol().await;

--- a/tests/e2e/anvil.rs
+++ b/tests/e2e/anvil.rs
@@ -57,7 +57,9 @@ impl TestAnvil {
     pub async fn new() -> Result<Self> {
         info!("Starting Anvil EVM testnet");
 
-        let testnet = Testnet::new().await;
+        let testnet = Testnet::new()
+            .await
+            .map_err(|e| AnvilError::Startup(format!("Failed to start Anvil testnet: {e}")))?;
 
         info!("Anvil testnet started");
 
@@ -79,9 +81,14 @@ impl TestAnvil {
     }
 
     /// Get the default wallet private key (pre-funded Anvil account).
-    #[must_use]
-    pub fn default_wallet_key(&self) -> String {
-        self.testnet.default_wallet_private_key()
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the wallet key cannot be retrieved.
+    pub fn default_wallet_key(&self) -> Result<String> {
+        self.testnet
+            .default_wallet_private_key()
+            .map_err(|e| AnvilError::Startup(format!("Failed to get wallet key: {e}")))
     }
 
     /// Create a wallet funded with test tokens.
@@ -93,7 +100,10 @@ impl TestAnvil {
     /// Returns an error if wallet creation fails.
     pub fn create_funded_wallet(&self) -> Result<Wallet> {
         let network = self.testnet.to_network();
-        let private_key = self.testnet.default_wallet_private_key();
+        let private_key = self
+            .testnet
+            .default_wallet_private_key()
+            .map_err(|e| AnvilError::Startup(format!("Failed to get wallet key: {e}")))?;
 
         let wallet = Wallet::new_from_private_key(network, &private_key)
             .map_err(|e| AnvilError::Startup(format!("Failed to create funded wallet: {e}")))?;
@@ -188,7 +198,7 @@ mod tests {
     async fn test_anvil_creation() {
         let anvil = TestAnvil::new().await.unwrap();
         let _network = anvil.to_network();
-        assert!(!anvil.default_wallet_key().is_empty());
+        assert!(!anvil.default_wallet_key().unwrap().is_empty());
     }
 
     #[test]

--- a/tests/e2e/data_types/chunk.rs
+++ b/tests/e2e/data_types/chunk.rs
@@ -63,13 +63,13 @@ mod tests {
     use std::sync::Arc;
 
     use crate::{TestHarness, TestNetwork};
-    use ant_evm::RewardsAddress;
     use ant_node::payment::{
         EvmVerifierConfig, PaymentVerifier, PaymentVerifierConfig, QuoteGenerator,
         QuotingMetricsTracker,
     };
     use ant_node::storage::{AntProtocol, LmdbStorage, LmdbStorageConfig};
     use evmlib::testnet::Testnet;
+    use evmlib::RewardsAddress;
     use rand::seq::SliceRandom;
     use serial_test::serial;
 
@@ -421,7 +421,9 @@ mod tests {
     async fn create_evm_enabled_protocol(
         test_name: &str,
     ) -> color_eyre::Result<(AntProtocol, std::path::PathBuf, Testnet)> {
-        let testnet = Testnet::new().await;
+        let testnet = Testnet::new()
+            .await
+            .map_err(|e| color_eyre::eyre::eyre!("Failed to start testnet: {e}"))?;
         let network = testnet.to_network();
 
         let temp_dir = std::env::temp_dir().join(format!("{test_name}_{}", rand::random::<u64>()));
@@ -476,7 +478,7 @@ mod tests {
         let address = ChunkTestFixture::compute_address(data);
 
         // Create empty payment proof
-        let empty_payment = rmp_serde::to_vec(&ant_evm::ProofOfPayment {
+        let empty_payment = rmp_serde::to_vec(&evmlib::ProofOfPayment {
             peer_quotes: vec![],
         })?;
 

--- a/tests/e2e/integration_tests.rs
+++ b/tests/e2e/integration_tests.rs
@@ -120,7 +120,7 @@ async fn test_network_with_evm() {
     let anvil = harness.anvil().expect("Anvil should be present");
     // Verify the Anvil testnet is usable by checking we can get a network config
     let _network = anvil.to_network();
-    assert!(!anvil.default_wallet_key().is_empty());
+    assert!(!anvil.default_wallet_key().expect("wallet key").is_empty());
 
     harness.teardown().await.expect("Failed to teardown");
 }

--- a/tests/e2e/merkle_payment.rs
+++ b/tests/e2e/merkle_payment.rs
@@ -14,11 +14,6 @@
 
 use super::harness::TestHarness;
 use super::testnet::TestNetworkConfig;
-use ant_evm::merkle_payments::{
-    MerklePaymentCandidateNode, MerklePaymentCandidatePool, MerklePaymentProof, MerkleTree,
-    CANDIDATES_PER_POOL,
-};
-use ant_evm::RewardsAddress;
 use ant_node::ant_protocol::{
     ChunkMessage, ChunkMessageBody, ChunkPutRequest, ChunkPutResponse, ProtocolError,
     PROOF_TAG_MERKLE,
@@ -27,8 +22,13 @@ use ant_node::compute_address;
 use ant_node::payment::{
     serialize_merkle_proof, MAX_PAYMENT_PROOF_SIZE_BYTES, MIN_PAYMENT_PROOF_SIZE_BYTES,
 };
+use evmlib::merkle_payments::{
+    MerklePaymentCandidateNode, MerklePaymentCandidatePool, MerklePaymentProof, MerkleTree,
+    CANDIDATES_PER_POOL,
+};
 use evmlib::quoting_metrics::QuotingMetrics;
 use evmlib::testnet::Testnet;
+use evmlib::RewardsAddress;
 use rand::Rng;
 use saorsa_core::MlDsa65;
 use saorsa_pqc::pqc::types::MlDsaSecretKey;
@@ -87,7 +87,7 @@ async fn send_put_to_node(
 
 /// Create a lightweight test harness with payment enforcement and Anvil wiring.
 async fn setup_enforcement_env() -> Result<(TestHarness, Testnet), Box<dyn std::error::Error>> {
-    let testnet = Testnet::new().await;
+    let testnet = Testnet::new().await?;
     let network = testnet.to_network();
     let config = TestNetworkConfig::minimal()
         .with_payment_enforcement()

--- a/tests/e2e/payment_flow.rs
+++ b/tests/e2e/payment_flow.rs
@@ -48,7 +48,7 @@ impl PaymentTestEnv {
     /// Create a funded wallet from the Anvil testnet.
     fn create_funded_wallet(&self) -> Result<Wallet, Box<dyn std::error::Error>> {
         let network = self.testnet.to_network();
-        let private_key = self.testnet.default_wallet_private_key();
+        let private_key = self.testnet.default_wallet_private_key()?;
 
         let wallet = Wallet::new_from_private_key(network, &private_key)?;
         info!("Created funded wallet: {}", wallet.address());
@@ -74,7 +74,7 @@ async fn init_testnet_and_evm() -> Result<PaymentTestEnv, Box<dyn std::error::Er
     info!("Initializing payment test environment");
 
     // Start Anvil EVM testnet FIRST so we can wire it to nodes
-    let testnet = Testnet::new().await;
+    let testnet = Testnet::new().await?;
     let network = testnet.to_network();
     info!("Anvil testnet started");
 

--- a/tests/e2e/security_attacks.rs
+++ b/tests/e2e/security_attacks.rs
@@ -10,13 +10,13 @@
 
 use super::harness::TestHarness;
 use super::testnet::TestNetworkConfig;
-use ant_evm::ProofOfPayment;
 use ant_node::ant_protocol::{
     ChunkMessage, ChunkMessageBody, ChunkPutRequest, ChunkPutResponse, ProtocolError,
 };
 use ant_node::compute_address;
 use ant_node::payment::PaymentProof;
 use evmlib::testnet::Testnet;
+use evmlib::ProofOfPayment;
 use rand::Rng;
 use serial_test::serial;
 use std::time::Duration;
@@ -71,7 +71,7 @@ async fn send_put_to_node(
 /// Create a lightweight test harness with payment enforcement and Anvil wiring.
 /// Returns (harness, testnet) -- keep testnet alive to avoid Anvil teardown.
 async fn setup_enforcement_env() -> Result<(TestHarness, Testnet), Box<dyn std::error::Error>> {
-    let testnet = Testnet::new().await;
+    let testnet = Testnet::new().await?;
     let network = testnet.to_network();
     let config = TestNetworkConfig::minimal()
         .with_payment_enforcement()

--- a/tests/e2e/testnet.rs
+++ b/tests/e2e/testnet.rs
@@ -13,7 +13,6 @@
 //! - Payment verification (when enabled)
 //! - LMDB storage persistence
 
-use ant_evm::RewardsAddress;
 use ant_node::ant_protocol::{
     ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkMessageBody, ChunkPutRequest,
     ChunkPutResponse, CHUNK_PROTOCOL_ID,
@@ -26,6 +25,7 @@ use ant_node::payment::{
 use ant_node::storage::{AntProtocol, LmdbStorage, LmdbStorageConfig};
 use bytes::Bytes;
 use evmlib::Network as EvmNetwork;
+use evmlib::RewardsAddress;
 use futures::future::join_all;
 use rand::Rng;
 use saorsa_core::identity::PeerId;


### PR DESCRIPTION
## Summary

- Remove `ant-evm`, `libp2p`, and `multihash` dependencies entirely
- All payment types now come from evmlib (which absorbed the needed ant-evm types)
- `EncodedPeerId` is now `[u8; 32]` (native saorsa PeerId, no libp2p multihash encoding)
- `hex_node_id_to_encoded_peer_id()` simplified to direct hex decode
- `validate_peer_bindings()` compares raw 32-byte PeerIds directly
- ~530 transitive dependencies removed from lock file

## Context

Depends on WithAutonomi/evmlib#3 — evmlib must absorb the ant-evm types first.

The saorsa network uses native 32-byte PeerIds (BLAKE3 hash of ML-DSA-65 public keys), not libp2p PeerIds. The old code wrapped these in a libp2p identity-multihash (34 bytes), passed through `libp2p::PeerId`, then unwrapped by stripping the 2-byte header. This PR removes that overhead entirely.

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt + clippy` clean (strict deny on unwrap/expect/panic)
- [x] `cargo test --lib` — 300 tests pass
- [ ] E2E tests with local devnet