### PR TITLE
chore: update saorsa-core to 0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4672,9 +4672,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c045892301eb0f4fe3961760cbeb3592cf3d8b936a70b1a11d3f7043cdb82f"
+checksum = "19de0950a0c9c9a3f97681c539e513c52c909866caddef5d825fe2dcbd1b0173"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/bin/ant-devnet/main.rs"
 
 [dependencies]
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
-saorsa-core = "0.20.0"
+saorsa-core = "0.21.0"
 saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment


### PR DESCRIPTION
## Summary
- Update `saorsa-core` dependency from 0.20.0 to 0.21.0
- No code changes required — compiles cleanly with the new version

## Test plan
- [x] `cargo build --release` succeeds locally
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)