### PR TITLE
chore: bump evmlib from 0.7 to 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2285,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "evmlib"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af67fe5494790b75d91fed4c5dd3215098e5adf071f73f40a238d199116c75ac"
+checksum = "1338c23c9ce1b4e54ff5cc65e53ce859095f121bfc742e474e1e1f2e03748000"
 dependencies = [
  "alloy",
  "ant-merkle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ saorsa-core = "0.21.0"
 saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment
-evmlib = "0.7"
+evmlib = "0.8"
 xor_name = "5"
 
 # Caching - LRU cache for verified XorNames


### PR DESCRIPTION
## Summary
- Bump `evmlib` dependency from 0.7 to 0.8

## Test plan
- [ ] CI passes with the new evmlib version
- [ ] Payment verification tests remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)