### PR TITLE
feat!: require --enable-logging flag to install tracing subscriber

### DIFF
--- a/src/bin/ant-devnet/cli.rs
+++ b/src/bin/ant-devnet/cli.rs
@@ -44,7 +44,16 @@ pub struct Cli {
     #[arg(long)]
     pub manifest: Option<PathBuf>,
 
+    /// Enable logging output.
+    /// When omitted, the tracing subscriber is not installed and no log
+    /// records are emitted, even if the binary was built with the
+    /// `logging` feature. `--log-level` is ignored unless this flag is set.
+    #[cfg(feature = "logging")]
+    #[arg(long, env = "ANT_ENABLE_LOGGING")]
+    pub enable_logging: bool,
+
     /// Log level for devnet process.
+    #[cfg(feature = "logging")]
     #[arg(long, default_value = "info")]
     pub log_level: String,
 

--- a/src/bin/ant-devnet/main.rs
+++ b/src/bin/ant-devnet/main.rs
@@ -15,7 +15,7 @@ async fn main() -> color_eyre::Result<()> {
     let cli = Cli::parse();
 
     #[cfg(feature = "logging")]
-    {
+    if cli.enable_logging {
         use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
         let filter =

--- a/src/bin/ant-node/cli.rs
+++ b/src/bin/ant-node/cli.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 #[derive(Parser, Debug)]
 #[command(name = "ant-node")]
 #[command(author, version, about, long_about = None)]
+#[allow(clippy::struct_excessive_bools)] // unrelated CLI toggles, not a state machine
 pub struct Cli {
     /// Root directory for node data.
     #[arg(long, env = "ANT_ROOT_DIR")]
@@ -60,6 +61,15 @@ pub struct Cli {
     /// Metrics port for Prometheus scraping (0 to disable).
     #[arg(long, default_value = "9100", env = "ANT_METRICS_PORT")]
     pub metrics_port: u16,
+
+    /// Enable logging output.
+    /// When omitted, the tracing subscriber is not installed and no log
+    /// records are emitted, even if the binary was built with the
+    /// `logging` feature. The remaining `--log-*` options are ignored
+    /// unless this flag is set.
+    #[cfg(feature = "logging")]
+    #[arg(long, env = "ANT_ENABLE_LOGGING")]
+    pub enable_logging: bool,
 
     /// Log level.
     #[cfg(feature = "logging")]

--- a/src/bin/ant-node/main.rs
+++ b/src/bin/ant-node/main.rs
@@ -9,18 +9,26 @@ use ant_node::config::BootstrapSource;
 use ant_node::NodeBuilder;
 use clap::Parser;
 use cli::Cli;
+#[cfg(feature = "logging")]
+use cli::CliLogFormat;
+#[cfg(feature = "logging")]
+use tracing_subscriber::prelude::*;
+#[cfg(feature = "logging")]
+use tracing_subscriber::{fmt, EnvFilter, Layer};
 
-/// Initialize the tracing subscriber when the `logging` feature is active.
+/// Initialize the tracing subscriber when the `logging` feature is active
+/// **and** the user passed `--enable-logging`.
 ///
-/// Returns a guard that must be held for the lifetime of the process to ensure
-/// buffered logs are flushed on shutdown.
+/// Returns `Ok(None)` when logging was not requested. Otherwise returns a
+/// guard (possibly `None` for stdout sinks) that must be held for the
+/// lifetime of the process to ensure buffered logs are flushed on shutdown.
 #[cfg(feature = "logging")]
 fn init_logging(
     cli: &Cli,
 ) -> color_eyre::Result<Option<tracing_appender::non_blocking::WorkerGuard>> {
-    use cli::CliLogFormat;
-    use tracing_subscriber::prelude::*;
-    use tracing_subscriber::{fmt, EnvFilter, Layer};
+    if !cli.enable_logging {
+        return Ok(None);
+    }
 
     let log_format = cli.log_format;
     let log_dir = cli.log_dir.clone();


### PR DESCRIPTION
## Summary

- Adds an explicit `--enable-logging` flag (env: `ANT_ENABLE_LOGGING`) to both `ant-node` and `ant-devnet`. Without it, the tracing subscriber is never installed and no log records are emitted, even when the binary is built with the `logging` feature.
- The remaining `--log-level` / `--log-format` / `--log-dir` / `--log-max-files` options are ignored unless `--enable-logging` is set.
- Hoists the `tracing_subscriber` `use` statements in `ant-node/main.rs` to file scope per the project's "imports at module level only" rule.

## Why

Previously, default builds (which include the `logging` feature) auto-installed a stdout subscriber, so any invocation of `ant-node` printed logs whether the operator wanted them or not. Logging output should be opt-in at runtime, not just at build time.

## BREAKING CHANGE

Default builds no longer log to stdout automatically. Operators that relied on implicit logging must now pass `--enable-logging` (or set `ANT_ENABLE_LOGGING=1`).

## Test plan

- [x] `cargo build --bin ant-node --bin ant-devnet` (default features)
- [x] `cargo build --bin ant-node --bin ant-devnet --no-default-features`
- [x] `cargo clippy --bins --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Smoke test: `./ant-node --rewards-address 0x0…` produces 0 lines of output
- [x] Smoke test: `./ant-node --enable-logging --rewards-address 0x0…` produces normal tracing output
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)