### PR TITLE
fix: cap concurrent outbound replication sends

### DIFF
--- a/src/replication/config.rs
+++ b/src/replication/config.rs
@@ -70,6 +70,15 @@ pub const SELF_LOOKUP_INTERVAL_MIN: Duration = Duration::from_secs(SELF_LOOKUP_I
 /// Periodic self-lookup cadence range (max).
 pub const SELF_LOOKUP_INTERVAL_MAX: Duration = Duration::from_secs(SELF_LOOKUP_INTERVAL_MAX_SECS);
 
+/// Maximum number of concurrent outbound replication sends.
+///
+/// Caps how many fresh-replication chunk transfers can be in-flight at once
+/// across the entire replication engine. Prevents bandwidth saturation on
+/// home broadband connections when multiple chunks arrive simultaneously.
+/// Each send transfers up to 4 MB (MAX_CHUNK_SIZE), so a limit of 3 means
+/// at most ~12 MB queued for the upload link at any instant.
+pub const MAX_CONCURRENT_REPLICATION_SENDS: usize = 3;
+
 /// Concurrent fetches cap, derived from hardware thread count.
 ///
 /// Uses `std::thread::available_parallelism()` so the node scales to the

--- a/src/replication/fresh.rs
+++ b/src/replication/fresh.rs
@@ -99,6 +99,10 @@ pub async fn replicate_fresh(
             // Acquire a permit before sending — this caps the number of
             // concurrent outbound replication transfers across the engine.
             let _permit = sem.acquire().await;
+            debug!(
+                "Replication send permit acquired for peer {peer_id} ({} available)",
+                sem.available_permits()
+            );
             if let Err(e) = p2p
                 .send_message(&peer_id, REPLICATION_PROTOCOL_ID, data, &[])
                 .await

--- a/src/replication/fresh.rs
+++ b/src/replication/fresh.rs
@@ -11,6 +11,7 @@ use crate::logging::{debug, warn};
 use rand::Rng;
 use saorsa_core::identity::PeerId;
 use saorsa_core::P2PNode;
+use tokio::sync::Semaphore;
 
 use crate::ant_protocol::XorName;
 use crate::replication::config::{ReplicationConfig, REPLICATION_PROTOCOL_ID};
@@ -38,6 +39,10 @@ pub struct FreshWriteEvent {
 /// Sends fresh offers to close group members and `PaidNotify` to
 /// `PaidCloseGroup`. Both are fire-and-forget (no ack tracking or retry per
 /// Section 6.1, rule 8).
+///
+/// The `send_semaphore` limits how many outbound chunk transfers can be
+/// in-flight concurrently across the entire replication engine, preventing
+/// bandwidth saturation on home broadband connections.
 pub async fn replicate_fresh(
     key: &XorName,
     data: &[u8],
@@ -45,6 +50,7 @@ pub async fn replicate_fresh(
     p2p_node: &Arc<P2PNode>,
     paid_list: &Arc<PaidList>,
     config: &ReplicationConfig,
+    send_semaphore: &Arc<Semaphore>,
 ) {
     let self_id = *p2p_node.peer_id();
 
@@ -88,7 +94,11 @@ pub async fn replicate_fresh(
         let p2p = Arc::clone(p2p_node);
         let data = encoded.clone();
         let peer_id = *peer;
+        let sem = Arc::clone(send_semaphore);
         tokio::spawn(async move {
+            // Acquire a permit before sending — this caps the number of
+            // concurrent outbound replication transfers across the engine.
+            let _permit = sem.acquire().await;
             if let Err(e) = p2p
                 .send_message(&peer_id, REPLICATION_PROTOCOL_ID, data, &[])
                 .await
@@ -99,6 +109,8 @@ pub async fn replicate_fresh(
     }
 
     // Rule 7-8: Send PaidNotify to every member of PaidCloseGroup(K).
+    // PaidNotify messages are small metadata (no chunk data), so they don't
+    // need semaphore gating.
     send_paid_notify(key, proof_of_payment, p2p_node, config).await;
 
     debug!(

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -38,7 +38,7 @@ use crate::logging::{debug, error, info, warn};
 use futures::stream::FuturesUnordered;
 use futures::{Future, StreamExt};
 use rand::Rng;
-use tokio::sync::{mpsc, Notify, RwLock};
+use tokio::sync::{mpsc, Notify, RwLock, Semaphore};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -46,7 +46,9 @@ use crate::ant_protocol::XorName;
 use crate::error::{Error, Result};
 use crate::payment::PaymentVerifier;
 use crate::replication::audit::AuditTickResult;
-use crate::replication::config::{max_parallel_fetch, ReplicationConfig, REPLICATION_PROTOCOL_ID};
+use crate::replication::config::{
+    max_parallel_fetch, ReplicationConfig, MAX_CONCURRENT_REPLICATION_SENDS, REPLICATION_PROTOCOL_ID,
+};
 use crate::replication::paid_list::PaidList;
 use crate::replication::protocol::{
     FreshReplicationResponse, NeighborSyncResponse, ReplicationMessage, ReplicationMessageBody,
@@ -122,6 +124,9 @@ pub struct ReplicationEngine {
     sync_trigger: Arc<Notify>,
     /// Notified when `is_bootstrapping` transitions from `true` to `false`.
     bootstrap_complete_notify: Arc<Notify>,
+    /// Limits concurrent outbound replication sends to prevent bandwidth
+    /// saturation on home broadband connections.
+    send_semaphore: Arc<Semaphore>,
     /// Receiver for fresh-write events from the chunk PUT handler.
     ///
     /// When present, `start()` spawns a drainer task that calls
@@ -173,6 +178,7 @@ impl ReplicationEngine {
             is_bootstrapping: Arc::new(RwLock::new(true)),
             sync_trigger: Arc::new(Notify::new()),
             bootstrap_complete_notify: Arc::new(Notify::new()),
+            send_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_REPLICATION_SENDS)),
             fresh_write_rx: Some(fresh_write_rx),
             shutdown,
             task_handles: Vec::new(),
@@ -272,6 +278,7 @@ impl ReplicationEngine {
             &self.p2p_node,
             &self.paid_list,
             &self.config,
+            &self.send_semaphore,
         )
         .await;
     }
@@ -289,6 +296,7 @@ impl ReplicationEngine {
         let p2p = Arc::clone(&self.p2p_node);
         let paid_list = Arc::clone(&self.paid_list);
         let config = Arc::clone(&self.config);
+        let send_semaphore = Arc::clone(&self.send_semaphore);
         let shutdown = self.shutdown.clone();
 
         let handle = tokio::spawn(async move {
@@ -304,6 +312,7 @@ impl ReplicationEngine {
                             &p2p,
                             &paid_list,
                             &config,
+                            &send_semaphore,
                         )
                         .await;
                     }


### PR DESCRIPTION
## Summary

- Add a shared semaphore (`MAX_CONCURRENT_REPLICATION_SENDS = 3`) that limits how many fresh-replication chunk transfers can be in-flight simultaneously
- Prevents bandwidth saturation on home broadband connections when multiple chunks arrive for replication at once

## Problem

When a node stores a chunk, it immediately spawns 7 concurrent `tokio::spawn` tasks to replicate the 4MB chunk to its close group peers — with no concurrency limit. For a 50MB upload (13 chunks), a node could have up to 91 concurrent 4MB sends in-flight simultaneously. On a typical home broadband connection (10-20 Mbps upload), this saturates the link for seconds, causing latency for all household traffic.

## Changes

- Add `MAX_CONCURRENT_REPLICATION_SENDS = 3` constant in `replication/config.rs`
- Add `send_semaphore: Arc<Semaphore>` to `ReplicationEngine`, initialized with the constant
- Pass the semaphore through to `replicate_fresh()`, which acquires a permit before each outbound send
- `PaidNotify` messages (small metadata, no chunk data) are exempt from the semaphore
- Add a `debug!` log for permit acquisition to aid observability
- All 7 close-group replicas are still made — sends queue through the semaphore instead of firing simultaneously. Zero data loss risk.

## Test plan

- [x] Deployed on 67-node testnet (`ant-repl-fix2`) across 4 cloud providers with 20% NAT
- [x] Verified replication still completes: chunks found on 10+ nodes (exceeding close group size of 7)
- [x] Verified peak per-node bandwidth reduced from 14.8 MB/s to ~8.7 MB/s (worst case)
- [x] Verified uploads complete successfully (~2-3 min per 50MB file)
- [x] Verified zero node restarts (no crash loops)
- [x] Binary verified via `strings` grep for probe string "Replication send permit acquired"

🤖 Generated with [Claude Code](https://claude.com/claude-code)