### PR TITLE
fix: prevent replication neighbor sync from blocking shutdown under active traffic

### DIFF
--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -255,8 +255,16 @@ impl ReplicationEngine {
     /// released (e.g. before reopening the same LMDB environment).
     pub async fn shutdown(&mut self) {
         self.shutdown.cancel();
-        for handle in self.task_handles.drain(..) {
-            let _ = handle.await;
+        for (i, mut handle) in self.task_handles.drain(..).enumerate() {
+            match tokio::time::timeout(std::time::Duration::from_secs(10), &mut handle).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) if e.is_cancelled() => {}
+                Ok(Err(e)) => warn!("Replication task {i} panicked during shutdown: {e}"),
+                Err(_) => {
+                    warn!("Replication task {i} did not stop within 10s, aborting");
+                    handle.abort();
+                }
+            }
         }
     }
 
@@ -435,18 +443,23 @@ impl ReplicationEngine {
                         debug!("Neighbor sync triggered by topology change");
                     }
                 }
-                run_neighbor_sync_round(
-                    &p2p,
-                    &storage,
-                    &paid_list,
-                    &queues,
-                    &config,
-                    &sync_state,
-                    &sync_history,
-                    &is_bootstrapping,
-                    &bootstrap_state,
-                )
-                .await;
+                // Wrap the sync round in a select so shutdown cancels
+                // in-progress network operations rather than waiting for
+                // the full round to complete.
+                tokio::select! {
+                    () = shutdown.cancelled() => break,
+                    _ = run_neighbor_sync_round(
+                        &p2p,
+                        &storage,
+                        &paid_list,
+                        &queues,
+                        &config,
+                        &sync_state,
+                        &sync_history,
+                        &is_bootstrapping,
+                        &bootstrap_state,
+                    ) => {}
+                }
             }
             debug!("Neighbor sync loop shut down");
         });


### PR DESCRIPTION
## Summary

- The replication engine's neighbor sync loop ran `run_neighbor_sync_round()` outside its `tokio::select!` block, preventing shutdown cancellation from being noticed during long sync rounds
- Wrap the sync round in `tokio::select!` with `shutdown.cancelled()` so in-progress operations are cancelled immediately
- Add 10-second timeout to replication engine task joins in `shutdown()` as defense in depth

## Context

Discovered during auto-upgrade testing on a 100-node testnet with active client uploads. The companion fix in saorsa-core (saorsa-labs/saorsa-core#fix/dht-shutdown-hang-under-traffic) resolved the DHT shutdown hang for 98% of nodes. The remaining 2% were stuck at `engine.shutdown().await` in the replication engine, where the neighbor sync task was mid-round when shutdown fired.

## Test plan

- [x] Both fixes together tested on 151-node testnet (27 AWS + 14 Vultr + 15 DO standard + 16 DO NAT + 7 bootstrap) with 3 clients uploading 10MB files continuously
- [x] **151/151 services restarted cleanly, 0 hangs, 0 upload failures** throughout the 2-hour rollout window
- [x] `cargo check` clean

**Depends on:** saorsa-labs/saorsa-core PR for the DHT shutdown fix (same root cause pattern, different code layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)