### PR TITLE
Release v0.10.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,9 +122,9 @@ jobs:
             echo "profile_dir=debug" >> $GITHUB_OUTPUT
             echo "Building DEBUG (RC pre-release: logging enabled)"
           else
-            echo "build_flags=--release --no-default-features" >> $GITHUB_OUTPUT
+            echo "build_flags=--release --no-default-features --features logging" >> $GITHUB_OUTPUT
             echo "profile_dir=release" >> $GITHUB_OUTPUT
-            echo "Building RELEASE (logging stripped)"
+            echo "Building RELEASE (logging enabled, other defaults stripped)"
           fi
 
       - name: Install Rust toolchain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,7 +4674,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#78d2f4093263c141a0f88d8896324b287f36e685"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#3095981601fdd9f24ed503c38b1e87f5d4e27900"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4787,7 +4787,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#d99e5ab11d95fefaf04b7e3f8024f67859925608"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#9009e64afed6693c7dd4951257fe4d02af6e26de"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4755,7 +4755,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#abe2babb43f8d0cf709f675ebc2577c5c0ec89a8"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#05d47b868842a93eac54f55146975d585e815049"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0-rc.6"
+version = "0.10.0-rc.7"
 dependencies = [
  "aes-gcm-siv",
  "alloy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4761,7 +4761,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#4a776272121c0c21aa2a740263afbfaa949c7fdf"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#eb859475f3947e47f7defdc87fea2e6aa83989a8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4874,7 +4874,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/jacderida/saorsa-transport.git?branch=round4-combined#9a8ffa256ce0f07b4d5b22d97b0010ac1be8ad1d"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#4587a333e697d432163a8a4aa09a79abd738594c"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1190,6 +1190,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "attohttpc"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
+dependencies = [
+ "base64",
+ "http",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "auto_impl"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,13 +1532,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -2632,6 +2655,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -2667,6 +2691,25 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.13.1",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -2879,6 +2922,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -3065,6 +3109,26 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "igd-next"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac9a3c8278f43b4cd8463380f4a25653ac843e5b177e1d3eaf849cc9ba10d4d"
+dependencies = [
+ "attohttpc",
+ "bytes",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rand 0.10.0",
+ "tokio",
+ "url",
+ "xmltree",
 ]
 
 [[package]]
@@ -4172,6 +4236,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4209,6 +4284,12 @@ dependencies = [
  "getrandom 0.3.4",
  "serde",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_xorshift"
@@ -4674,7 +4755,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#14131e307ebe0c870f0b4a1dca992fae434551e0"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#abe2babb43f8d0cf709f675ebc2577c5c0ec89a8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4787,7 +4868,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#e861d3a5cb607a3e0162687ac5a7a23f0596e696"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#3d73241042e212af9e929dd3721df65c9d3a05b9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4801,6 +4882,7 @@ dependencies = [
  "dirs 5.0.1",
  "futures-util",
  "hex",
+ "igd-next",
  "indexmap 2.13.1",
  "keyring",
  "libc",
@@ -6794,6 +6876,21 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xmltree"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
+dependencies = [
+ "xml-rs",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2941,15 +2941,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3373,9 +3372,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libm"
@@ -3957,9 +3956,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -4622,9 +4621,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4761,7 +4760,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#eb859475f3947e47f7defdc87fea2e6aa83989a8"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#8acdf5baece7f5410ecaae5a1ec3a6c84cdcf31f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4874,7 +4873,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#4587a333e697d432163a8a4aa09a79abd738594c"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#f2b30ad1fa6f90a0a2d51d8b271893e01ec6aec7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4755,7 +4755,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#106303ebf8be77d7cf6ef15913a7717d029b5ee9"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#34258e70dfabe785c8aff9631243f4521e095915"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4868,7 +4868,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#c86a37fba6bffb0b45266ba8270e5202098252ed"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#52ef49364ea71520787fb9edb2a2df476bc3c281"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4755,7 +4755,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#d77cb3fc7c5d6436746bc7c23133a8f65bf334db"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#106303ebf8be77d7cf6ef15913a7717d029b5ee9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4868,7 +4868,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#28264672995950e5094f6d1f5cfea588c018c2b7"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#c86a37fba6bffb0b45266ba8270e5202098252ed"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0-rc.14"
+version = "0.10.0-rc.15"
 dependencies = [
  "aes-gcm-siv",
  "alloy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0-rc.19"
+version = "0.10.0"
 dependencies = [
  "aes-gcm-siv",
  "alloy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0-rc.16"
+version = "0.10.0-rc.17"
 dependencies = [
  "aes-gcm-siv",
  "alloy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,7 +4674,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#0a6b17820706f3f57213a0f4f5a0747840af81f3"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#0d01b71a21dff4a92656a971f5e7dbf2c968227d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4787,7 +4787,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#e29f32464c308b1d61a8481b16f7970f4a583688"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#da74da9c8a80788b6639ce092abadbe7cc3e6b18"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
  "saorsa-pqc 0.5.1",
  "self-replace",
  "self_encryption",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "serial_test",
@@ -1480,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2325,9 +2325,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
 
 [[package]]
 name = "fastrlp"
@@ -4508,7 +4508,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.27",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -4674,8 +4674,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad51589091bdbfbf8c42b5db37428a1cad0febd0af616ef3fe3a0f38dc921b24"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#dcfc79ec66e33704cc88937d7555ba93a9762be1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4788,8 +4787,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e33412e61b0cb630410981a629f967a858b1663be8f71b75eadb66c9588ef26"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#24bec697562a972bfac01a2b730a3694e5fc5fd7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5000,9 +4998,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "semver-parser"
@@ -6139,7 +6137,7 @@ dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
  "indexmap 2.13.1",
- "semver 1.0.27",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -6735,7 +6733,7 @@ dependencies = [
  "id-arena",
  "indexmap 2.13.1",
  "log",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0-rc.7"
+version = "0.10.0-rc.8"
 dependencies = [
  "aes-gcm-siv",
  "alloy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2348,9 +2348,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fastrlp"
@@ -2777,9 +2777,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heed"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a56c94661ddfb51aa9cdfbf102cfcc340aa69267f95ebccc4af08d7c530d393"
+checksum = "ad82d6598ccf1dac15c8b758a1bd282b755b6776be600429176757190a1b0202"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -3403,9 +3403,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lmdb-master-sys"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864808e0b19fb6dd3b70ba94ee671b82fce17554cf80aeb0a155c65bb08027df"
+checksum = "aaeb9bd22e73bd1babffff614994b341e9b2008de7bb73bf1f7e9154f1978f8b"
 dependencies = [
  "cc",
  "doxygen-rs",
@@ -4755,7 +4755,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#81a29f7e55f5d36a85d9303125a3784fbcd4eac9"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#d77cb3fc7c5d6436746bc7c23133a8f65bf334db"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4868,7 +4868,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#496721bee0e5b535d5aec07513ec3ced29d20644"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#28264672995950e5094f6d1f5cfea588c018c2b7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0-rc.2"
+version = "0.10.0-rc.3"
 dependencies = [
  "aes-gcm-siv",
  "alloy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,7 +4674,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#3cb58bf3cc387182be9dc7096bb9057efd49e4b2"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#78d2f4093263c141a0f88d8896324b287f36e685"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4787,7 +4787,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#f65af2e5a04ed8cc6476baab80c665f7dae33b53"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#d99e5ab11d95fefaf04b7e3f8024f67859925608"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,13 +428,13 @@ dependencies = [
  "derive_more",
  "foldhash 0.2.0",
  "hashbrown 0.16.1",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "k256",
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rapidhash",
  "ruint",
  "rustc-hash",
@@ -650,7 +650,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -1492,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2705,7 +2705,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2754,6 +2754,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heapless"
@@ -3125,7 +3131,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand 0.10.0",
+ "rand 0.10.1",
  "tokio",
  "url",
  "xmltree",
@@ -3170,12 +3176,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -3300,9 +3306,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3379,14 +3385,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -4057,7 +4063,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.10+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -4101,7 +4107,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -4146,7 +4152,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4226,9 +4232,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4237,9 +4243,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
@@ -4354,9 +4360,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -4542,7 +4548,7 @@ dependencies = [
  "primitive-types",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rlp",
  "ruint-macro",
  "serde_core",
@@ -4700,9 +4706,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4755,6 +4761,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#4a776272121c0c21aa2a740263afbfaa949c7fdf"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4882,7 +4889,7 @@ dependencies = [
  "futures-util",
  "hex",
  "igd-next",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "keyring",
  "libc",
  "lru-slab",
@@ -5163,7 +5170,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -5190,7 +5197,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -5662,9 +5669,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -5771,7 +5778,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -5781,11 +5788,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.10+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.1",
@@ -6134,9 +6141,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6147,9 +6154,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6157,9 +6164,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6167,9 +6174,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6180,9 +6187,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -6204,7 +6211,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -6217,7 +6224,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "semver 1.0.28",
 ]
 
@@ -6237,9 +6244,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6762,7 +6769,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -6793,7 +6800,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -6812,7 +6819,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "semver 1.0.28",
  "serde",
@@ -7058,7 +7065,7 @@ dependencies = [
  "flate2",
  "getrandom 0.3.4",
  "hmac",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "lzma-rs",
  "memchr",
  "pbkdf2",
@@ -7116,11 +7123,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "saorsa-transport"
-version = "0.31.0"
-
-[[patch.unused]]
-name = "saorsa-transport"
-version = "0.31.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4755,7 +4755,6 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#e92150dae8b464f99a46bcaf18bb71828b01400e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4868,7 +4867,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#6e85dd904d33071c82c8629b504ceeffd5af8655"
+source = "git+https://github.com/jacderida/saorsa-transport.git?branch=round4-combined#9a8ffa256ce0f07b4d5b22d97b0010ac1be8ad1d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7117,3 +7116,11 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "saorsa-transport"
+version = "0.31.0"
+
+[[patch.unused]]
+name = "saorsa-transport"
+version = "0.31.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0-rc.13"
+version = "0.10.0-rc.14"
 dependencies = [
  "aes-gcm-siv",
  "alloy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0-rc.12"
+version = "0.10.0-rc.13"
 dependencies = [
  "aes-gcm-siv",
  "alloy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,7 +4674,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#3095981601fdd9f24ed503c38b1e87f5d4e27900"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#4d183078d2eea53b5018f4cfe5914281cb7f4279"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4787,7 +4787,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#9009e64afed6693c7dd4951257fe4d02af6e26de"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#e861d3a5cb607a3e0162687ac5a7a23f0596e696"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0-rc.15"
+version = "0.10.0-rc.16"
 dependencies = [
  "aes-gcm-siv",
  "alloy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,7 +4674,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#4d183078d2eea53b5018f4cfe5914281cb7f4279"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#bf7b4a7746ff6a39a7b49be647bcd4522b8b8801"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2941,9 +2941,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.8"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
@@ -4759,8 +4759,8 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#7d739775b8d1c6164f8407acf63d7ed6d75dd02a"
+version = "0.23.0"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?tag=v0.23.0#caa559518ff3eea8c49b4cbd54ef3e65445f92ce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4872,8 +4872,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#7986b01604b745fc9e7c3714d46486485d0771cf"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250826f52ac60992947359218d83c21f658aa85407e3980a5dbb258eff4c0cc3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5668,9 +5669,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0-rc.11"
+version = "0.10.0-rc.12"
 dependencies = [
  "aes-gcm-siv",
  "alloy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0-rc.17"
+version = "0.10.0-rc.18"
 dependencies = [
  "aes-gcm-siv",
  "alloy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0-rc.4"
+version = "0.10.0-rc.5"
 dependencies = [
  "aes-gcm-siv",
  "alloy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0-rc.18"
+version = "0.10.0-rc.19"
 dependencies = [
  "aes-gcm-siv",
  "alloy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e9e31d834fe25fe991b8884e4b9f0e59db4a97d86e05d1464d6899c013cd62"
+checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -434,7 +434,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rapidhash",
  "ruint",
  "rustc-hash",
@@ -1315,9 +1315,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -1539,7 +1539,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2655,7 +2655,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -3434,9 +3434,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -4106,7 +4106,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -4151,7 +4151,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.3",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4231,9 +4231,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4248,7 +4248,7 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4292,9 +4292,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -4316,9 +4316,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -4547,7 +4547,7 @@ dependencies = [
  "primitive-types",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rlp",
  "ruint-macro",
  "serde_core",
@@ -4705,9 +4705,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4760,7 +4760,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#8acdf5baece7f5410ecaae5a1ec3a6c84cdcf31f"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#7d739775b8d1c6164f8407acf63d7ed6d75dd02a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4873,7 +4873,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#f2b30ad1fa6f90a0a2d51d8b271893e01ec6aec7"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#7986b01604b745fc9e7c3714d46486485d0771cf"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0-rc.10"
+version = "0.10.0-rc.11"
 dependencies = [
  "aes-gcm-siv",
  "alloy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,7 +4674,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#bf7b4a7746ff6a39a7b49be647bcd4522b8b8801"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#14131e307ebe0c870f0b4a1dca992fae434551e0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0-rc.1"
+version = "0.10.0-rc.2"
 dependencies = [
  "aes-gcm-siv",
  "alloy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0-rc.8"
+version = "0.10.0-rc.9"
 dependencies = [
  "aes-gcm-siv",
  "alloy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0-rc.5"
+version = "0.10.0-rc.6"
 dependencies = [
  "aes-gcm-siv",
  "alloy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0-rc.3"
+version = "0.10.0-rc.4"
 dependencies = [
  "aes-gcm-siv",
  "alloy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,7 +4674,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#dcfc79ec66e33704cc88937d7555ba93a9762be1"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#0a6b17820706f3f57213a0f4f5a0747840af81f3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4787,7 +4787,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#24bec697562a972bfac01a2b730a3694e5fc5fd7"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#e29f32464c308b1d61a8481b16f7970f4a583688"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4755,7 +4755,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#34258e70dfabe785c8aff9631243f4521e095915"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#e92150dae8b464f99a46bcaf18bb71828b01400e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4868,7 +4868,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#52ef49364ea71520787fb9edb2a2df476bc3c281"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#6e85dd904d33071c82c8629b504ceeffd5af8655"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,7 +4674,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#0d01b71a21dff4a92656a971f5e7dbf2c968227d"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#3cb58bf3cc387182be9dc7096bb9057efd49e4b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4787,7 +4787,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#da74da9c8a80788b6639ce092abadbe7cc3e6b18"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#f65af2e5a04ed8cc6476baab80c665f7dae33b53"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4760,7 +4760,8 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.23.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?tag=v0.23.0#caa559518ff3eea8c49b4cbd54ef3e65445f92ce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eefc3539465111e2769b9b8334ddd4d7071e12c183de4a9fee7d9bfbdb3da23"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0-rc.9"
+version = "0.10.0-rc.10"
 dependencies = [
  "aes-gcm-siv",
  "alloy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4755,7 +4755,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#05d47b868842a93eac54f55146975d585e815049"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.1#81a29f7e55f5d36a85d9303125a3784fbcd4eac9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4868,7 +4868,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#3d73241042e212af9e929dd3721df65c9d3a05b9"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#496721bee0e5b535d5aec07513ec3ced29d20644"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.10.0-rc.2"
+version = "0.10.0-rc.3"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.10.0-rc.14"
+version = "0.10.0-rc.15"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.10.0-rc.12"
+version = "0.10.0-rc.13"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.10.0-rc.13"
+version = "0.10.0-rc.14"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.10.0-rc.19"
+version = "0.10.0"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.10.0-rc.7"
+version = "0.10.0-rc.8"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/bin/ant-devnet/main.rs"
 
 [dependencies]
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
-saorsa-core = "0.22.0"
+saorsa-core = { git = "https://github.com/saorsa-labs/saorsa-core.git", branch = "rc-2026.4.1" }
 saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.10.0-rc.16"
+version = "0.10.0-rc.17"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.10.0-rc.6"
+version = "0.10.0-rc.7"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.10.0-rc.4"
+version = "0.10.0-rc.5"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.10.0-rc.1"
+version = "0.10.0-rc.2"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.10.0-rc.5"
+version = "0.10.0-rc.6"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.10.0-rc.3"
+version = "0.10.0-rc.4"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.10.0-rc.11"
+version = "0.10.0-rc.12"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.10.0-rc.8"
+version = "0.10.0-rc.9"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/bin/ant-devnet/main.rs"
 
 [dependencies]
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
-saorsa-core = { git = "https://github.com/saorsa-labs/saorsa-core.git", tag = "v0.23.0" }
+saorsa-core = "0.23.0"
 saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.10.0-rc.18"
+version = "0.10.0-rc.19"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.10.0-rc.15"
+version = "0.10.0-rc.16"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.10.0-rc.9"
+version = "0.10.0-rc.10"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.10.0-rc.17"
+version = "0.10.0-rc.18"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.10.0-rc.10"
+version = "0.10.0-rc.11"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/bin/ant-devnet/main.rs"
 
 [dependencies]
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
-saorsa-core = { git = "https://github.com/saorsa-labs/saorsa-core.git", branch = "rc-2026.4.1" }
+saorsa-core = { git = "https://github.com/saorsa-labs/saorsa-core.git", tag = "v0.23.0" }
 saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment

--- a/src/bin/ant-devnet/cli.rs
+++ b/src/bin/ant-devnet/cli.rs
@@ -44,7 +44,16 @@ pub struct Cli {
     #[arg(long)]
     pub manifest: Option<PathBuf>,
 
+    /// Enable logging output.
+    /// When omitted, the tracing subscriber is not installed and no log
+    /// records are emitted, even if the binary was built with the
+    /// `logging` feature. `--log-level` is ignored unless this flag is set.
+    #[cfg(feature = "logging")]
+    #[arg(long, env = "ANT_ENABLE_LOGGING")]
+    pub enable_logging: bool,
+
     /// Log level for devnet process.
+    #[cfg(feature = "logging")]
     #[arg(long, default_value = "info")]
     pub log_level: String,
 

--- a/src/bin/ant-devnet/main.rs
+++ b/src/bin/ant-devnet/main.rs
@@ -15,7 +15,7 @@ async fn main() -> color_eyre::Result<()> {
     let cli = Cli::parse();
 
     #[cfg(feature = "logging")]
-    {
+    if cli.enable_logging {
         use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
         let filter =

--- a/src/bin/ant-node/cli.rs
+++ b/src/bin/ant-node/cli.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 #[derive(Parser, Debug)]
 #[command(name = "ant-node")]
 #[command(author, version, about, long_about = None)]
+#[allow(clippy::struct_excessive_bools)] // unrelated CLI toggles, not a state machine
 pub struct Cli {
     /// Root directory for node data.
     #[arg(long, env = "ANT_ROOT_DIR")]
@@ -60,6 +61,15 @@ pub struct Cli {
     /// Metrics port for Prometheus scraping (0 to disable).
     #[arg(long, default_value = "9100", env = "ANT_METRICS_PORT")]
     pub metrics_port: u16,
+
+    /// Enable logging output.
+    /// When omitted, the tracing subscriber is not installed and no log
+    /// records are emitted, even if the binary was built with the
+    /// `logging` feature. The remaining `--log-*` options are ignored
+    /// unless this flag is set.
+    #[cfg(feature = "logging")]
+    #[arg(long, env = "ANT_ENABLE_LOGGING")]
+    pub enable_logging: bool,
 
     /// Log level.
     #[cfg(feature = "logging")]

--- a/src/bin/ant-node/main.rs
+++ b/src/bin/ant-node/main.rs
@@ -9,18 +9,26 @@ use ant_node::config::BootstrapSource;
 use ant_node::NodeBuilder;
 use clap::Parser;
 use cli::Cli;
+#[cfg(feature = "logging")]
+use cli::CliLogFormat;
+#[cfg(feature = "logging")]
+use tracing_subscriber::prelude::*;
+#[cfg(feature = "logging")]
+use tracing_subscriber::{fmt, EnvFilter, Layer};
 
-/// Initialize the tracing subscriber when the `logging` feature is active.
+/// Initialize the tracing subscriber when the `logging` feature is active
+/// **and** the user passed `--enable-logging`.
 ///
-/// Returns a guard that must be held for the lifetime of the process to ensure
-/// buffered logs are flushed on shutdown.
+/// Returns `Ok(None)` when logging was not requested. Otherwise returns a
+/// guard (possibly `None` for stdout sinks) that must be held for the
+/// lifetime of the process to ensure buffered logs are flushed on shutdown.
 #[cfg(feature = "logging")]
 fn init_logging(
     cli: &Cli,
 ) -> color_eyre::Result<Option<tracing_appender::non_blocking::WorkerGuard>> {
-    use cli::CliLogFormat;
-    use tracing_subscriber::prelude::*;
-    use tracing_subscriber::{fmt, EnvFilter, Layer};
+    if !cli.enable_logging {
+        return Ok(None);
+    }
 
     let log_format = cli.log_format;
     let log_dir = cli.log_dir.clone();

--- a/src/payment/pricing.rs
+++ b/src/payment/pricing.rs
@@ -1,48 +1,60 @@
-//! Simple quadratic pricing algorithm for ant-node.
+//! Quadratic pricing with a baseline floor for ant-node (Phase 1 recalibration).
 //!
-//! Uses the formula `(close_records_stored / 6000)^2` to calculate storage price.
-//! Integer division means nodes with fewer than 6000 records get a ratio of 0,
-//! but a minimum floor of 1 prevents free storage.
+//! Formula: `price_per_chunk_ANT(n) = BASELINE + K × (n / D)²`
+//!
+//! This recalibration introduces a non-zero `BASELINE` so that empty nodes
+//! charge a meaningful spam-barrier price, and re-anchors `K` so per-GB USD
+//! pricing matches real-world targets at the current ~$0.10/ANT token price.
+//! The legacy formula produced ~$25/GB at the lower stable boundary and ~$0/GB
+//! when nodes were empty — both unreasonable.
+//!
+//! ## Parameters
+//!
+//! | Constant  | Value         | Role                                            |
+//! |-----------|---------------|-------------------------------------------------|
+//! | BASELINE  | 0.00390625 ANT| Price at empty (bootstrap-phase spam barrier)   |
+//! | K         | 0.03515625 ANT| Quadratic coefficient                           |
+//! | D         | 6000          | Lower stable boundary (records stored)          |
 //!
 //! ## Design Rationale
 //!
-//! The quadratic curve creates natural load balancing:
-//! - **Lightly loaded nodes** (< 6000 records) charge the minimum floor price
-//! - **Moderately loaded nodes** charge proportionally more as records grow
-//! - **Heavily loaded nodes** charge quadratically more, pushing clients elsewhere
+//! - **Empty / lightly loaded nodes** charge the `BASELINE` floor, preventing
+//!   free storage and acting as a bootstrap-phase spam barrier.
+//! - **Moderately loaded nodes** add a small quadratic contribution on top.
+//! - **Heavily loaded nodes** charge quadratically more, pushing clients
+//!   toward less-loaded nodes elsewhere in the network.
 
 use evmlib::common::Amount;
 
-/// Divisor for the pricing formula.
-const PRICING_DIVISOR: u64 = 6000;
+/// Lower stable boundary of the quadratic curve, in records stored.
+const PRICING_DIVISOR: u128 = 6000;
 
 /// `PRICING_DIVISOR²`, precomputed to avoid repeated multiplication.
-const DIVISOR_SQUARED: u64 = PRICING_DIVISOR * PRICING_DIVISOR;
+const DIVISOR_SQUARED: u128 = PRICING_DIVISOR * PRICING_DIVISOR;
 
-/// 1 token = 10^18 wei.
-const WEI_PER_TOKEN: u128 = 1_000_000_000_000_000_000;
+/// Baseline price at empty / bootstrap-phase spam barrier.
+///
+/// `0.00390625 ANT × 10¹⁸ wei/ANT = 3_906_250_000_000_000 wei`.
+const PRICE_BASELINE_WEI: u128 = 3_906_250_000_000_000;
 
-/// Minimum price in wei (1 wei) to prevent free storage.
-const MIN_PRICE_WEI: u128 = 1;
+/// Quadratic coefficient `K`.
+///
+/// `0.03515625 ANT × 10¹⁸ wei/ANT = 35_156_250_000_000_000 wei`.
+const PRICE_COEFFICIENT_WEI: u128 = 35_156_250_000_000_000;
 
 /// Calculate storage price in wei from the number of close records stored.
 ///
-/// Formula: `price_wei = n² × 10¹⁸ / 6000²`
+/// Formula: `price_wei = BASELINE + n² × K / D²`
 ///
-/// This is equivalent to `(n / 6000)²` in tokens, converted to wei, but
-/// preserves sub-token precision by scaling before dividing. U256 arithmetic
-/// prevents overflow for large record counts.
+/// where `BASELINE = 0.00390625 ANT`, `K = 0.03515625 ANT`, and `D = 6000`.
+/// U256 arithmetic prevents overflow for large record counts.
 #[must_use]
 pub fn calculate_price(close_records_stored: usize) -> Amount {
     let n = Amount::from(close_records_stored);
     let n_squared = n.saturating_mul(n);
-    let price_wei =
-        n_squared.saturating_mul(Amount::from(WEI_PER_TOKEN)) / Amount::from(DIVISOR_SQUARED);
-    if price_wei.is_zero() {
-        Amount::from(MIN_PRICE_WEI)
-    } else {
-        price_wei
-    }
+    let quadratic_wei = n_squared.saturating_mul(Amount::from(PRICE_COEFFICIENT_WEI))
+        / Amount::from(DIVISOR_SQUARED);
+    Amount::from(PRICE_BASELINE_WEI).saturating_add(quadratic_wei)
 }
 
 #[cfg(test)]
@@ -50,53 +62,67 @@ pub fn calculate_price(close_records_stored: usize) -> Amount {
 mod tests {
     use super::*;
 
-    const WEI: u128 = WEI_PER_TOKEN;
+    /// 1 token = 10¹⁸ wei (used for test sanity-checks).
+    const WEI_PER_TOKEN: u128 = 1_000_000_000_000_000_000;
 
-    /// Helper: expected price for n records = n² * 10^18 / 6000²
+    /// Helper: expected price matching the formula `BASELINE + n² × K / D²`.
     fn expected_price(n: u64) -> Amount {
-        let n = Amount::from(n);
-        n * n * Amount::from(WEI) / Amount::from(DIVISOR_SQUARED)
+        let n_amt = Amount::from(n);
+        let quad =
+            n_amt * n_amt * Amount::from(PRICE_COEFFICIENT_WEI) / Amount::from(DIVISOR_SQUARED);
+        Amount::from(PRICE_BASELINE_WEI) + quad
     }
 
     #[test]
-    fn test_zero_records_gets_min_price() {
+    fn test_zero_records_gets_baseline() {
+        // At n = 0 the quadratic term vanishes, leaving the baseline floor.
         let price = calculate_price(0);
-        assert_eq!(price, Amount::from(MIN_PRICE_WEI));
+        assert_eq!(price, Amount::from(PRICE_BASELINE_WEI));
     }
 
     #[test]
-    fn test_one_record_nonzero() {
-        // 1² * 1e18 / 36e6 = 1e18 / 36e6 ≈ 27_777_777_777
+    fn test_baseline_is_nonzero_spam_barrier() {
+        // The baseline ensures even empty nodes charge a meaningful price,
+        // making the legacy MIN_PRICE_WEI = 1 sentinel redundant.
+        assert!(calculate_price(0) > Amount::ZERO);
+        assert!(calculate_price(1) > calculate_price(0));
+    }
+
+    #[test]
+    fn test_one_record_above_baseline() {
         let price = calculate_price(1);
         assert_eq!(price, expected_price(1));
-        assert!(price > Amount::ZERO);
+        assert!(price > Amount::from(PRICE_BASELINE_WEI));
     }
 
     #[test]
-    fn test_at_divisor_gets_one_token() {
-        // 6000² * 1e18 / 6000² = 1e18
+    fn test_at_divisor_is_baseline_plus_k() {
+        // At n = D the quadratic contribution equals K × 1² = K.
+        // price = BASELINE + K = 0.00390625 + 0.03515625 = 0.0390625 ANT
         let price = calculate_price(6000);
-        assert_eq!(price, Amount::from(WEI));
+        let expected = Amount::from(PRICE_BASELINE_WEI + PRICE_COEFFICIENT_WEI);
+        assert_eq!(price, expected);
     }
 
     #[test]
-    fn test_double_divisor_gets_four_tokens() {
-        // 12000² * 1e18 / 6000² = 4e18
+    fn test_double_divisor_is_baseline_plus_four_k() {
+        // At n = 2D the quadratic contribution is 4K.
         let price = calculate_price(12000);
-        assert_eq!(price, Amount::from(4 * WEI));
+        let expected = Amount::from(PRICE_BASELINE_WEI + 4 * PRICE_COEFFICIENT_WEI);
+        assert_eq!(price, expected);
     }
 
     #[test]
-    fn test_triple_divisor_gets_nine_tokens() {
-        // 18000² * 1e18 / 6000² = 9e18
+    fn test_triple_divisor_is_baseline_plus_nine_k() {
+        // At n = 3D the quadratic contribution is 9K.
         let price = calculate_price(18000);
-        assert_eq!(price, Amount::from(9 * WEI));
+        let expected = Amount::from(PRICE_BASELINE_WEI + 9 * PRICE_COEFFICIENT_WEI);
+        assert_eq!(price, expected);
     }
 
     #[test]
     fn test_smooth_pricing_no_staircase() {
-        // With the old integer-division approach, 6000 and 11999 gave the same price.
-        // Now 11999 should give a higher price than 6000.
+        // 11999 should give a strictly higher price than 6000 (no integer-division plateau).
         let price_6k = calculate_price(6000);
         let price_11k = calculate_price(11999);
         assert!(
@@ -141,19 +167,23 @@ mod tests {
     }
 
     #[test]
-    fn test_quadratic_growth() {
-        // price at 4x records should be 16x price at 1x
-        let price_1x = calculate_price(6000);
-        let price_4x = calculate_price(24000);
-        assert_eq!(price_1x, Amount::from(WEI));
-        assert_eq!(price_4x, Amount::from(16 * WEI));
+    fn test_quadratic_growth_excluding_baseline() {
+        // Subtracting the baseline, quadratic contribution should scale with n².
+        // At 2× records the quadratic portion is 4×; at 4× records it is 16×.
+        let base = Amount::from(PRICE_BASELINE_WEI);
+        let quad_6k = calculate_price(6000) - base;
+        let quad_12k = calculate_price(12000) - base;
+        let quad_24k = calculate_price(24000) - base;
+        assert_eq!(quad_12k, quad_6k * Amount::from(4u64));
+        assert_eq!(quad_24k, quad_6k * Amount::from(16u64));
     }
 
     #[test]
-    fn test_small_record_counts_are_cheap() {
-        // 100 records: 100² * 1e18 / 36e6 ≈ 277_777_777_777_777 wei ≈ 0.000278 tokens
+    fn test_small_record_counts_near_baseline() {
+        // At small n, price is dominated by the baseline — quadratic term is tiny.
         let price = calculate_price(100);
         assert_eq!(price, expected_price(100));
-        assert!(price < Amount::from(WEI)); // well below 1 token
+        assert!(price < Amount::from(WEI_PER_TOKEN)); // well below 1 ANT
+        assert!(price > Amount::from(PRICE_BASELINE_WEI)); // strictly above baseline
     }
 }

--- a/src/replication/config.rs
+++ b/src/replication/config.rs
@@ -70,6 +70,15 @@ pub const SELF_LOOKUP_INTERVAL_MIN: Duration = Duration::from_secs(SELF_LOOKUP_I
 /// Periodic self-lookup cadence range (max).
 pub const SELF_LOOKUP_INTERVAL_MAX: Duration = Duration::from_secs(SELF_LOOKUP_INTERVAL_MAX_SECS);
 
+/// Maximum number of concurrent outbound replication sends.
+///
+/// Caps how many fresh-replication chunk transfers can be in-flight at once
+/// across the entire replication engine. Prevents bandwidth saturation on
+/// home broadband connections when multiple chunks arrive simultaneously.
+/// Each send transfers up to 4 MB (MAX_CHUNK_SIZE), so a limit of 3 means
+/// at most ~12 MB queued for the upload link at any instant.
+pub const MAX_CONCURRENT_REPLICATION_SENDS: usize = 3;
+
 /// Concurrent fetches cap, derived from hardware thread count.
 ///
 /// Uses `std::thread::available_parallelism()` so the node scales to the

--- a/src/replication/config.rs
+++ b/src/replication/config.rs
@@ -75,7 +75,7 @@ pub const SELF_LOOKUP_INTERVAL_MAX: Duration = Duration::from_secs(SELF_LOOKUP_I
 /// Caps how many fresh-replication chunk transfers can be in-flight at once
 /// across the entire replication engine. Prevents bandwidth saturation on
 /// home broadband connections when multiple chunks arrive simultaneously.
-/// Each send transfers up to 4 MB (MAX_CHUNK_SIZE), so a limit of 3 means
+/// Each send transfers up to 4 MB (`MAX_CHUNK_SIZE`), so a limit of 3 means
 /// at most ~12 MB queued for the upload link at any instant.
 pub const MAX_CONCURRENT_REPLICATION_SENDS: usize = 3;
 

--- a/src/replication/fresh.rs
+++ b/src/replication/fresh.rs
@@ -99,6 +99,10 @@ pub async fn replicate_fresh(
             // Acquire a permit before sending — this caps the number of
             // concurrent outbound replication transfers across the engine.
             let _permit = sem.acquire().await;
+            debug!(
+                "Replication send permit acquired for peer {peer_id} ({} available)",
+                sem.available_permits()
+            );
             if let Err(e) = p2p
                 .send_message(&peer_id, REPLICATION_PROTOCOL_ID, data, &[])
                 .await

--- a/src/replication/fresh.rs
+++ b/src/replication/fresh.rs
@@ -11,6 +11,7 @@ use crate::logging::{debug, warn};
 use rand::Rng;
 use saorsa_core::identity::PeerId;
 use saorsa_core::P2PNode;
+use tokio::sync::Semaphore;
 
 use crate::ant_protocol::XorName;
 use crate::replication::config::{ReplicationConfig, REPLICATION_PROTOCOL_ID};
@@ -38,6 +39,10 @@ pub struct FreshWriteEvent {
 /// Sends fresh offers to close group members and `PaidNotify` to
 /// `PaidCloseGroup`. Both are fire-and-forget (no ack tracking or retry per
 /// Section 6.1, rule 8).
+///
+/// The `send_semaphore` limits how many outbound chunk transfers can be
+/// in-flight concurrently across the entire replication engine, preventing
+/// bandwidth saturation on home broadband connections.
 pub async fn replicate_fresh(
     key: &XorName,
     data: &[u8],
@@ -45,6 +50,7 @@ pub async fn replicate_fresh(
     p2p_node: &Arc<P2PNode>,
     paid_list: &Arc<PaidList>,
     config: &ReplicationConfig,
+    send_semaphore: &Arc<Semaphore>,
 ) {
     let self_id = *p2p_node.peer_id();
 
@@ -88,7 +94,11 @@ pub async fn replicate_fresh(
         let p2p = Arc::clone(p2p_node);
         let data = encoded.clone();
         let peer_id = *peer;
+        let sem = Arc::clone(send_semaphore);
         tokio::spawn(async move {
+            // Acquire a permit before sending — this caps the number of
+            // concurrent outbound replication transfers across the engine.
+            let _permit = sem.acquire().await;
             if let Err(e) = p2p
                 .send_message(&peer_id, REPLICATION_PROTOCOL_ID, data, &[])
                 .await
@@ -99,6 +109,8 @@ pub async fn replicate_fresh(
     }
 
     // Rule 7-8: Send PaidNotify to every member of PaidCloseGroup(K).
+    // PaidNotify messages are small metadata (no chunk data), so they don't
+    // need semaphore gating.
     send_paid_notify(key, proof_of_payment, p2p_node, config).await;
 
     debug!(

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -38,7 +38,7 @@ use crate::logging::{debug, error, info, warn};
 use futures::stream::FuturesUnordered;
 use futures::{Future, StreamExt};
 use rand::Rng;
-use tokio::sync::{mpsc, Notify, RwLock};
+use tokio::sync::{mpsc, Notify, RwLock, Semaphore};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -46,7 +46,9 @@ use crate::ant_protocol::XorName;
 use crate::error::{Error, Result};
 use crate::payment::PaymentVerifier;
 use crate::replication::audit::AuditTickResult;
-use crate::replication::config::{max_parallel_fetch, ReplicationConfig, REPLICATION_PROTOCOL_ID};
+use crate::replication::config::{
+    max_parallel_fetch, ReplicationConfig, MAX_CONCURRENT_REPLICATION_SENDS, REPLICATION_PROTOCOL_ID,
+};
 use crate::replication::paid_list::PaidList;
 use crate::replication::protocol::{
     FreshReplicationResponse, NeighborSyncResponse, ReplicationMessage, ReplicationMessageBody,
@@ -122,6 +124,9 @@ pub struct ReplicationEngine {
     sync_trigger: Arc<Notify>,
     /// Notified when `is_bootstrapping` transitions from `true` to `false`.
     bootstrap_complete_notify: Arc<Notify>,
+    /// Limits concurrent outbound replication sends to prevent bandwidth
+    /// saturation on home broadband connections.
+    send_semaphore: Arc<Semaphore>,
     /// Receiver for fresh-write events from the chunk PUT handler.
     ///
     /// When present, `start()` spawns a drainer task that calls
@@ -173,6 +178,7 @@ impl ReplicationEngine {
             is_bootstrapping: Arc::new(RwLock::new(true)),
             sync_trigger: Arc::new(Notify::new()),
             bootstrap_complete_notify: Arc::new(Notify::new()),
+            send_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_REPLICATION_SENDS)),
             fresh_write_rx: Some(fresh_write_rx),
             shutdown,
             task_handles: Vec::new(),
@@ -272,6 +278,7 @@ impl ReplicationEngine {
             &self.p2p_node,
             &self.paid_list,
             &self.config,
+            &self.send_semaphore,
         )
         .await;
     }
@@ -289,6 +296,7 @@ impl ReplicationEngine {
         let p2p = Arc::clone(&self.p2p_node);
         let paid_list = Arc::clone(&self.paid_list);
         let config = Arc::clone(&self.config);
+        let send_semaphore = Arc::clone(&self.send_semaphore);
         let shutdown = self.shutdown.clone();
 
         let handle = tokio::spawn(async move {
@@ -304,6 +312,7 @@ impl ReplicationEngine {
                             &p2p,
                             &paid_list,
                             &config,
+                            &send_semaphore,
                         )
                         .await;
                     }

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -255,8 +255,16 @@ impl ReplicationEngine {
     /// released (e.g. before reopening the same LMDB environment).
     pub async fn shutdown(&mut self) {
         self.shutdown.cancel();
-        for handle in self.task_handles.drain(..) {
-            let _ = handle.await;
+        for (i, mut handle) in self.task_handles.drain(..).enumerate() {
+            match tokio::time::timeout(std::time::Duration::from_secs(10), &mut handle).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) if e.is_cancelled() => {}
+                Ok(Err(e)) => warn!("Replication task {i} panicked during shutdown: {e}"),
+                Err(_) => {
+                    warn!("Replication task {i} did not stop within 10s, aborting");
+                    handle.abort();
+                }
+            }
         }
     }
 
@@ -435,18 +443,23 @@ impl ReplicationEngine {
                         debug!("Neighbor sync triggered by topology change");
                     }
                 }
-                run_neighbor_sync_round(
-                    &p2p,
-                    &storage,
-                    &paid_list,
-                    &queues,
-                    &config,
-                    &sync_state,
-                    &sync_history,
-                    &is_bootstrapping,
-                    &bootstrap_state,
-                )
-                .await;
+                // Wrap the sync round in a select so shutdown cancels
+                // in-progress network operations rather than waiting for
+                // the full round to complete.
+                tokio::select! {
+                    () = shutdown.cancelled() => break,
+                    _ = run_neighbor_sync_round(
+                        &p2p,
+                        &storage,
+                        &paid_list,
+                        &queues,
+                        &config,
+                        &sync_state,
+                        &sync_history,
+                        &is_bootstrapping,
+                        &bootstrap_state,
+                    ) => {}
+                }
             }
             debug!("Neighbor sync loop shut down");
         });

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -47,7 +47,8 @@ use crate::error::{Error, Result};
 use crate::payment::PaymentVerifier;
 use crate::replication::audit::AuditTickResult;
 use crate::replication::config::{
-    max_parallel_fetch, ReplicationConfig, MAX_CONCURRENT_REPLICATION_SENDS, REPLICATION_PROTOCOL_ID,
+    max_parallel_fetch, ReplicationConfig, MAX_CONCURRENT_REPLICATION_SENDS,
+    REPLICATION_PROTOCOL_ID,
 };
 use crate::replication::paid_list::PaidList;
 use crate::replication::protocol::{
@@ -448,7 +449,7 @@ impl ReplicationEngine {
                 // the full round to complete.
                 tokio::select! {
                     () = shutdown.cancelled() => break,
-                    _ = run_neighbor_sync_round(
+                    () = run_neighbor_sync_round(
                         &p2p,
                         &storage,
                         &paid_list,


### PR DESCRIPTION
## Summary
- Update saorsa-core to v0.23.0
- Enable `logging` feature flag in release builds
- Pricing baseline recalibration with floor
- Fix replication shutdown hang under active traffic
- Cap concurrent outbound replication sends
- Require `--enable-logging` flag for tracing subscriber
- Bump version to 0.10.0

## Test plan
- [ ] Verify release workflow builds with `--features logging`
- [ ] Smoke test a testnet with the built binaries
- [ ] Confirm auto-upgrade works from latest RC

🤖 Generated with [Claude Code](https://claude.com/claude-code)