### PR TITLE
chore: pin saorsa-core and saorsa-transport to always-masque-relay branches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4558,9 +4558,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -4789,7 +4789,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=mick/always-masque-relay-rebased#7e2fb8433ba1a4328a90a7ba853ed1137a41aef0"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=mick/always-masque-relay-rebased#65583ed9cbdf79b185f315b13d8c1463ca60e309"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4789,7 +4789,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=mick/always-masque-relay-rebased#65583ed9cbdf79b185f315b13d8c1463ca60e309"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=mick/always-masque-relay-rebased#d37491fd2ead4b2e81f85a8d3c43e707bbafacc7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,13 +266,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8222b1d88f9a6d03be84b0f5e76bb60cd83991b43ad8ab6477f0e4a7809b98d"
+checksum = "407510740da514b694fecb44d8b3cebdc60d448f70cc5d24743e8ba273448a6e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "borsh",
+ "once_cell",
  "serde",
 ]
 
@@ -4733,9 +4734,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4788,7 +4789,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.22.0"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=mick/always-masque-relay-rebased#007e06c8759da23cfc5eeb942093a59578bb238e"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=mick/always-masque-relay-rebased#7e2fb8433ba1a4328a90a7ba853ed1137a41aef0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4901,8 +4902,8 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.32.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=mick/always-masque-relay-rebased#87f92d022d10d00d874fc69e3fb4b268e84719b0"
+version = "0.31.0"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=mick/always-masque-relay-rebased#ec163406f526f42667f12a1ed4f5b6ec0ed4e02e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5293,9 +5294,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -5830,7 +5831,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -5839,7 +5840,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -6000,9 +6001,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -6159,11 +6160,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -6172,7 +6173,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -6770,9 +6771,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -6785,6 +6786,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,6 +2292,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4775,9 +4787,8 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d459ba0e4f1a3ac918a1d6b17db392cccde2ee74569545d171d7644fc6463cc7"
+version = "0.22.0"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=mick/always-masque-relay-rebased#007e06c8759da23cfc5eeb942093a59578bb238e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4891,8 +4902,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "250826f52ac60992947359218d83c21f658aa85407e3980a5dbb258eff4c0cc3"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=mick/always-masque-relay-rebased#87f92d022d10d00d874fc69e3fb4b268e84719b0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4904,6 +4914,7 @@ dependencies = [
  "core-foundation 0.9.4",
  "dashmap",
  "dirs 5.0.1",
+ "enum_dispatch",
  "futures-util",
  "hex",
  "igd-next",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/bin/ant-devnet/main.rs"
 
 [dependencies]
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
-saorsa-core = "0.23.1"
+saorsa-core = { git = "https://github.com/saorsa-labs/saorsa-core.git", branch = "mick/always-masque-relay-rebased" }
 saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment


### PR DESCRIPTION
## Summary
- Switch `saorsa-core` (0.23.1 → git, branch `mick/always-masque-relay-rebased`) and `saorsa-transport` (registry → git, same branch) to consume the always-on MASQUE relay work ahead of a published release.
- Picks up `enum_dispatch` as a new transitive dependency via `saorsa-transport`.

## Test plan
- [ ] `cargo build --release`
- [ ] `cargo test`
- [ ] `cargo clippy --all-features -- -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used`

🤖 Generated with [Claude Code](https://claude.com/claude-code)