### PR TITLE
fix(payment): dedupe merkle candidate PeerIds + clearer sparse-network error

### DIFF
--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -771,10 +771,49 @@ impl PaymentVerifier {
     /// Wrapped by [`verify_merkle_candidate_closeness`] with a pass-cache and
     /// single-flight guard so a batch of chunks and a storm of forged PUTs
     /// don't multiply the lookup cost.
+    /// Derive each candidate's `PeerId` from its `pub_key` and reject the
+    /// pool if any `PeerId` appears more than once.
+    ///
+    /// This is a pure-validation pre-check, runnable without a `P2PNode`:
+    /// catches the case where one real peer's `pub_key` is repeated to
+    /// inflate the closeness match count, without paying for a Kademlia
+    /// lookup. An honest pool has [`evmlib::merkle_payments::CANDIDATES_PER_POOL`]
+    /// distinct candidate `pub_keys` by construction.
+    fn derive_distinct_candidate_peer_ids(
+        pool: &evmlib::merkle_payments::MerklePaymentCandidatePool,
+    ) -> Result<Vec<PeerId>> {
+        let mut candidate_peer_ids = Vec::with_capacity(pool.candidate_nodes.len());
+        let mut seen = std::collections::HashSet::with_capacity(pool.candidate_nodes.len());
+        for candidate in &pool.candidate_nodes {
+            let pid = peer_id_from_public_key_bytes(&candidate.pub_key).map_err(|e| {
+                Error::Payment(format!(
+                    "Invalid ML-DSA public key in merkle candidate: {e}"
+                ))
+            })?;
+            if !seen.insert(pid) {
+                return Err(Error::Payment(
+                    "Merkle candidate pool rejected: duplicate candidate PeerId. An \
+                     honest pool has 16 distinct candidate pub_keys; duplicates would \
+                     let a single real peer satisfy the closeness threshold by being \
+                     counted multiple times."
+                        .into(),
+                ));
+            }
+            candidate_peer_ids.push(pid);
+        }
+        Ok(candidate_peer_ids)
+    }
+
+    #[allow(clippy::too_many_lines)]
     async fn verify_merkle_candidate_closeness_inner(
         &self,
         pool: &evmlib::merkle_payments::MerklePaymentCandidatePool,
     ) -> Result<()> {
+        // Pre-check: catch malformed/hostile pools (duplicate candidate
+        // PeerIds) before paying for the Kademlia lookup. Runs in unit
+        // tests without a P2PNode too.
+        let candidate_peer_ids = Self::derive_distinct_candidate_peer_ids(pool)?;
+
         // Release the RwLock guard before any await to avoid holding it
         // across an iterative Kademlia lookup.
         let attached = self.p2p_node.read().as_ref().map(Arc::clone);
@@ -811,20 +850,6 @@ impl PaymentVerifier {
         };
 
         let pool_address = pool.midpoint_proof.address();
-
-        // Derive each candidate's would-be PeerId from its pub_key. Fail
-        // closed on malformed keys — the candidate signature check ran
-        // upstream so a valid-looking pool ought to parse cleanly here.
-        let mut candidate_peer_ids = Vec::with_capacity(pool.candidate_nodes.len());
-        for candidate in &pool.candidate_nodes {
-            let pid = peer_id_from_public_key_bytes(&candidate.pub_key).map_err(|e| {
-                Error::Payment(format!(
-                    "Invalid ML-DSA public key in merkle candidate: {e}"
-                ))
-            })?;
-            candidate_peer_ids.push(pid);
-        }
-
         let lookup_count = pool.candidate_nodes.len();
         let network_lookup = p2p_node
             .dht_manager()
@@ -857,10 +882,32 @@ impl PaymentVerifier {
                 }
             };
 
-        // Set-membership check against the returned closest-peers list. The
-        // lookup may return fewer than `lookup_count` on a sparse network,
-        // which only tightens the bar — any candidate not in the returned
-        // list counts as unmatched.
+        // Sparse-network short-circuit: if the DHT itself returned fewer
+        // peers than the closeness threshold, the proof can never pass —
+        // not because the candidates are forged, but because we don't
+        // have an authoritative view to compare against. Surface this
+        // distinct cause so operators can tell "retry once the network
+        // settles" apart from "this peer sent a forged pool".
+        if network_peers.len() < Self::CANDIDATE_CLOSENESS_REQUIRED {
+            debug!(
+                "Merkle closeness deferred: network lookup returned {} peers \
+                 for pool midpoint {} (need at least {} to verify)",
+                network_peers.len(),
+                hex::encode(pool_address.0),
+                Self::CANDIDATE_CLOSENESS_REQUIRED,
+            );
+            return Err(Error::Payment(format!(
+                "Merkle candidate pool rejected: authoritative DHT lookup returned \
+                 only {} peers, less than the {} required to verify candidate \
+                 closeness. Retry once the routing table populates further.",
+                network_peers.len(),
+                Self::CANDIDATE_CLOSENESS_REQUIRED,
+            )));
+        }
+
+        // Set-membership check against the returned closest-peers list.
+        // Candidate `PeerId`s are deduplicated upstream, so each match
+        // corresponds to a distinct peer.
         let network_set: std::collections::HashSet<PeerId> =
             network_peers.iter().map(|n| n.peer_id).collect();
         let matched = candidate_peer_ids
@@ -1995,6 +2042,40 @@ mod tests {
         assert!(
             err.to_string().contains("forged pool"),
             "waiter must surface the leader's error message, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn closeness_rejects_pool_with_duplicate_candidate_pub_keys() {
+        // An attacker who submits 16 copies of the same real peer's pub_key
+        // would otherwise satisfy the 13/16 closeness threshold trivially:
+        // that one peer's membership in the DHT-returned set would count
+        // 16 times. The dedupe check in verify_merkle_candidate_closeness_inner
+        // must reject the pool BEFORE the network lookup runs (so this test
+        // works even with no P2PNode attached).
+        let verifier = create_test_verifier();
+        let pool_hash = [0xDDu8; 32];
+
+        // Build a normal pool, then overwrite every candidate's pub_key
+        // with a single shared key so all 16 derive to the same PeerId.
+        let mut candidates = make_candidate_nodes(1_700_000_000);
+        let shared_pub_key = candidates[0].pub_key.clone();
+        for c in &mut candidates {
+            c.pub_key = shared_pub_key.clone();
+        }
+        let pool = MerklePaymentCandidatePool {
+            midpoint_proof: fake_midpoint_proof(),
+            candidate_nodes: candidates,
+        };
+
+        let result = verifier
+            .verify_merkle_candidate_closeness(&pool, pool_hash)
+            .await;
+        let err = result.expect_err("duplicate candidate PeerIds must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("duplicate candidate PeerId"),
+            "rejection must be the duplicate-PeerId branch, got: {msg}"
         );
     }
 


### PR DESCRIPTION
## Summary

Two follow-ups to the pay-yourself closeness check (PR #77, in `v0.11.0-rc.1`) flagged by Greptile/Copilot but not blocking the RC. Both are in `src/payment/verifier.rs`.

## 1. Reject pools with duplicate candidate `PeerId`s

The closeness check counts how many candidate `PeerId`s appear in the DHT-returned closest-set, and requires `13/16` matches. Without dedup, an attacker can submit 16 copies of one real peer's pub_key — that one peer's membership in the network set counts 16 times and trivially satisfies the threshold.

An honest pool has `CANDIDATES_PER_POOL` distinct candidates by construction. Reject pools with duplicates outright:

```rust
fn derive_distinct_candidate_peer_ids(pool: &MerklePaymentCandidatePool) -> Result<Vec<PeerId>>
```

Factored as a small helper, called as a pre-check before any network work — so the cost is paid only on malformed/hostile pools.

## 2. Distinguish "sparse network" from "forged pool" in the rejection error

Previously, when `find_closest_nodes_network` returned `<13` peers for any reason (sparse routing table, partition, transient flake), the rejection error was the generic "candidate pub_keys do not match" — misleading, since the cause was the network state, not the pool. Added an explicit short-circuit branch with a "retry once the routing table populates further" message so operators can tell transient conditions apart from an actual attack signal.

## Test plan

- [x] New unit test `closeness_rejects_pool_with_duplicate_candidate_pub_keys` — replaces all 16 candidates' `pub_key` with a single shared key, asserts the rejection is the duplicate-PeerId branch.
- [x] Existing 43 verifier unit tests still pass (44 total now).
- [x] Existing 8 e2e merkle tests still pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `RUSTDOCFLAGS="--deny=warnings" cargo doc --no-deps` clean.

## Notes

Targeting `rc-2026.4.2` since #77 isn't in `main` yet (it landed in the RC branch). If you'd prefer the rebase to `main` instead let me know.

## CI note

CI is configured to only run on PRs targeting `main` (`.github/workflows/ci.yml`: `pull_request: branches: [main]`). This PR targets `rc-2026.4.2` because #77 only exists there. All checks were run locally:
- `cargo test --lib payment::verifier`: 44 passed (was 43, +1 new)
- `cargo test --features test-utils --test e2e merkle -- --test-threads=1`: 8 passed
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- `RUSTDOCFLAGS="--deny=warnings" cargo doc --no-deps`: clean

If you prefer CI to run, the PR can be retargeted at `main` once #77 lands there, or the workflow can be updated to also run on `rc-*` branches.