### PR TITLE
fix(tests): disable IPv6 in e2e testnet to fix Windows/macOS CI

### DIFF
--- a/tests/e2e/live_testnet.rs
+++ b/tests/e2e/live_testnet.rs
@@ -38,6 +38,7 @@ async fn create_testnet_client() -> P2PNode {
     println!("Connecting to testnet via: {bootstrap_addrs:?}");
 
     let mut config = CoreNodeConfig::builder()
+        .ipv6(false)
         .local(true)
         .build()
         .expect("Failed to create config");

--- a/tests/e2e/testnet.rs
+++ b/tests/e2e/testnet.rs
@@ -1145,8 +1145,14 @@ impl TestNetwork {
 
         // Build configuration for saorsa-core P2PNode (saorsa-core is an external crate).
         // .local(true) auto-enables allow_loopback for test nodes on 127.0.0.1.
+        // .ipv6(false) keeps the bind on 127.0.0.1 only; Windows GitHub
+        // Actions runners (and some macOS runners) can't bind a dual-stack
+        // v6 socket and the whole testnet startup fails with
+        // "Failed to create dual-stack network nodes: Failed to create transport".
+        // Loopback-only tests don't need v6.
         let mut core_config = CoreNodeConfig::builder()
             .port(node.port)
+            .ipv6(false)
             .local(true)
             .connection_timeout(Duration::from_secs(TEST_CORE_CONNECTION_TIMEOUT_SECS))
             .max_message_size(MAX_REPLICATION_MESSAGE_SIZE.max(MAX_WIRE_MESSAGE_SIZE))


### PR DESCRIPTION
## Summary

The e2e test harness creates loopback-only nodes on 127.0.0.1 but left `ipv6` at its default (`true`), which makes saorsa-core try to bind a dual-stack v6 socket on top. Windows GitHub Actions runners — and some macOS runners — can't do that. Result: every recent CI run hits

```
Failed to create node 0: Transport error: Setup failed:
Failed to create dual-stack network nodes: Failed to create transport
```

and the testnet startup fans out into the next 70+ tests reporting the same error.

## What landed

Pin `.ipv6(false)` in `CoreNodeConfig::builder()` for `testnet.rs`. Loopback-only tests don't need v6 — the bind addr is already `Ipv4Addr::LOCALHOST`. Matching change is already present in ant-client's `tests/support/mod.rs:246`.

## Visible failures this fixes

From the merged v0.11.0 release CI:

- `replication::test_verification_with_paid_list_check`
- `security_attacks::test_attack_proof_too_large`
- All Merkle E2E (macos-latest) tests in ant-client repo

## Test plan

- [x] `cargo check --tests --features test-utils`: clean
- [x] `cargo clippy --tests --features test-utils -- -D warnings`: clean
- [x] `cargo fmt --all -- --check`: clean
- [ ] CI on Windows + macOS (via this PR)
