### PR TITLE
feat(devnet): add loopback_only flag for LAN testnet support

### DIFF
--- a/src/devnet.rs
+++ b/src/devnet.rs
@@ -179,7 +179,7 @@ pub struct DevnetConfig {
     /// mode so inter-node bootstrap (which still uses loopback addresses
     /// on the lab host) continues to work.
     ///
-    /// Passed through to [`saorsa_core::NodeConfigBuilder::local`].
+    /// Passed through to saorsa-core's `NodeConfigBuilder::local`.
     pub loopback_only: bool,
 }
 

--- a/src/devnet.rs
+++ b/src/devnet.rs
@@ -164,6 +164,23 @@ pub struct DevnetConfig {
     /// When `Some`, nodes will use this network (e.g. Anvil testnet) for
     /// on-chain verification. Defaults to Arbitrum One when `None`.
     pub evm_network: Option<EvmNetwork>,
+
+    /// Bind nodes to loopback addresses (`127.0.0.1`/`::1`) only.
+    ///
+    /// When `true` (the default), nodes listen on loopback only — the
+    /// historical single-host devnet behavior, suitable for development
+    /// and integration tests where every node and every client run on
+    /// the same machine.
+    ///
+    /// When `false`, nodes bind to all interfaces (`0.0.0.0`/`::`), which
+    /// is required for cross-host LAN devnets where client machines need
+    /// to reach the devnet's nodes via the lab server's LAN IP. The
+    /// transport-layer `allow_loopback` flag is enabled explicitly in this
+    /// mode so inter-node bootstrap (which still uses loopback addresses
+    /// on the lab host) continues to work.
+    ///
+    /// Passed through to [`saorsa_core::NodeConfigBuilder::local`].
+    pub loopback_only: bool,
 }
 
 impl Default for DevnetConfig {
@@ -185,6 +202,7 @@ impl Default for DevnetConfig {
             enable_node_logging: false,
             cleanup_data_dir: true,
             evm_network: None,
+            loopback_only: true,
         }
     }
 }
@@ -574,9 +592,17 @@ impl Devnet {
         debug!("Starting node {} on port {}", node.index, node.port);
         *node.state.write().await = NodeState::Starting;
 
-        let mut core_config = CoreNodeConfig::builder()
-            .port(node.port)
-            .local(true)
+        let builder = CoreNodeConfig::builder().port(node.port);
+        // Historical single-host devnet path uses local(true), which auto-enables
+        // allow_loopback for routing. LAN devnet path binds all interfaces and
+        // re-enables allow_loopback explicitly so inter-node bootstrap via
+        // loopback addresses continues to work.
+        let builder = if self.config.loopback_only {
+            builder.local(true)
+        } else {
+            builder.local(false).allow_loopback(true)
+        };
+        let mut core_config = builder
             .max_message_size(crate::ant_protocol::MAX_WIRE_MESSAGE_SIZE)
             .build()
             .map_err(|e| DevnetError::Core(format!("Failed to create core config: {e}")))?;


### PR DESCRIPTION
## Summary

Adds an opt-in `loopback_only: bool` field on `DevnetConfig` (default
`true`) so the devnet harness can bind nodes to all interfaces instead
of loopback-only. Default-true preserves bit-identical behavior for all
existing callers; `loopback_only: false` enables a cross-host LAN
devnet path.

This is purely a dev-orchestration change — `Devnet`/`DevnetConfig`
are dev-only and not on the production node runtime path.

## Why — LAN testnets for app testing

Every developer running an Autonomi-network app today needs to spin up
their own 25-node + Anvil stack locally to test against. That doesn't
scale across mixed-OS test fleets (Windows + macOS + Linux laptops on
one team). The motivating use case here is a "lab box" that hosts the
devnet once, with other devices on the same LAN acting as thin testers
that fetch the bootstrap manifest and run `ant file upload`/`download`.

A sibling tool (separate repo, `testnet-lan`) serves the rewritten
manifest over HTTP. It's not in this PR — that lives independently and
consumes whatever this exposes.

## Changes

`src/devnet.rs`:

- New `loopback_only: bool` field on `DevnetConfig`.
- `Default` impl sets `loopback_only: true`.
- `start_node` bifurcates the saorsa-core builder:
  - `loopback_only=true`: identical to today — `.local(true)` only.
  - `loopback_only=false`: `.local(false).allow_loopback(true)`. The
    explicit `allow_loopback` is required because saorsa-core's
    `local(false)` would otherwise default it to `false`, which would
    reject the loopback bootstrap addresses devnet nodes still use to
    dial each other on the same lab host.

29 insertions, 3 deletions. No changes to manifest types or other public
API.

## Backwards compatibility

| Caller | Result |
|---|---|
| `DevnetConfig::default()` | `loopback_only: true` — historical behavior |
| `DevnetConfig::minimal()` / `small()` | inherits `..Self::default()` — historical |
| Struct-update syntax (`DevnetConfig { evm_network: …, ..default() }`) | inherits — historical |
| Exhaustive struct literals | would need to add the field; standard pattern is `..Default::default()` so this is unlikely in practice |

## Compatibility with saorsa-labs/saorsa-core#105

This change is **complementary**, not in conflict, with
[saorsa-labs/saorsa-core#105](https://github.com/saorsa-labs/saorsa-core/pull/105)
(LAN-scoped DHT addresses). The two operate at different layers:

- **This PR**: decides which interfaces devnet nodes *bind* to.
- **saorsa-core#105**: decides which addresses get *shared* with which
  peers and tags them as `AddressType::Lan`.

When both land, the LAN testnet path improves: with `loopback_only=false`,
saorsa-transport's `listen_addrs()` reports LAN addresses, and
saorsa-core#105's `peer_can_receive_lan_addresses` heuristic correctly
hands LAN-tagged entries to clients on the same network. saorsa-core#105
alone wouldn't enable cross-host LAN devnets — without this PR, the
devnet has no LAN address to share. They depend on each other for
the full LAN-testnet story.

`maybe_swap_same_lan_ip_to_loopback` from #105 only triggers when a peer
announces our own LAN IP back at us (intra-host case), which doesn't
fire for clients on different hosts. No interaction issue.

## Test plan

- [x] `cargo build --lib` clean
- [x] `cargo test --lib`: 448/448 passing on the unchanged default path
- [x] `cargo fmt --all -- --check` clean
- [x] No new clippy warnings (one pre-existing `never_loop` lint at
      line ~770 fires on bare `main` too; not introduced here)
- [ ] Cross-host LAN smoke test against a second machine — pending the
      sibling testnet-lan tool reaching public review

🤖 Generated with [Claude Code](https://claude.com/claude-code)