### PR TITLE
feat!: drop bootstrap_cache wrapper and CLI surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,8 +890,7 @@ dependencies = [
 [[package]]
 name = "ant-protocol"
 version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe630f23f4adae05beba7e2c0861ab9c1a6d2cc88c98898e3742bed3a5a4ce35"
+source = "git+https://github.com/WithAutonomi/ant-protocol.git?branch=mick/remove-bootstrap-cache#70fe8a035899e784c9b3d4520b62dc9151a93f45"
 dependencies = [
  "blake3",
  "bytes",
@@ -4792,8 +4791,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed544b4fb88a5615649893ee2d1394e0f48633f63dc72700e51f6b133fdfc1c"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=mick/remove-bootstrap-cache#37d13d8b1f447f3dcb35995e9d7ccd68b6eb54f7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4907,8 +4905,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df373519d88540825f435bf3c5c6e300377871b28f16cdd461db3c3f4bb5323"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=mick/remove-bootstrap-cache#f3ad915d1395755675f41108b1391ea346267ef2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,10 @@ path = "src/bin/ant-devnet/main.rs"
 # Until then, the git pin tracks the matching saorsa-core lineage
 # (the rc-2026.4.2 branch) so Cargo can unify the wire types here
 # with ant-protocol's re-exports.
-ant-protocol = "2.0.1"
+ant-protocol = { git = "https://github.com/WithAutonomi/ant-protocol.git", branch = "mick/remove-bootstrap-cache" }
 
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
-saorsa-core = "0.24.0"
+saorsa-core = { git = "https://github.com/saorsa-labs/saorsa-core.git", branch = "mick/remove-bootstrap-cache" }
 saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment

--- a/src/bin/ant-node/cli.rs
+++ b/src/bin/ant-node/cli.rs
@@ -1,8 +1,8 @@
 //! Command-line interface definition.
 
 use ant_node::config::{
-    BootstrapCacheConfig, BootstrapPeersConfig, BootstrapSource, EvmNetworkConfig, NetworkMode,
-    NodeConfig, PaymentConfig, UpgradeChannel,
+    BootstrapPeersConfig, BootstrapSource, EvmNetworkConfig, NetworkMode, NodeConfig,
+    PaymentConfig, UpgradeChannel,
 };
 use clap::{Parser, ValueEnum};
 use std::net::SocketAddr;
@@ -133,18 +133,6 @@ pub struct Cli {
     /// that will restart the process automatically.
     #[arg(long)]
     pub stop_on_upgrade: bool,
-
-    /// Disable persistent bootstrap cache.
-    #[arg(long)]
-    pub disable_bootstrap_cache: bool,
-
-    /// Directory for bootstrap cache files.
-    #[arg(long, env = "ANT_BOOTSTRAP_CACHE_DIR")]
-    pub bootstrap_cache_dir: Option<PathBuf>,
-
-    /// Maximum peers to cache in the bootstrap cache.
-    #[arg(long, default_value = "10000", env = "ANT_BOOTSTRAP_CACHE_CAPACITY")]
-    pub bootstrap_cache_capacity: usize,
 }
 
 /// Upgrade channel CLI enum.
@@ -280,14 +268,6 @@ impl Cli {
             rewards_address: self.rewards_address,
             evm_network,
             metrics_port: self.metrics_port,
-        };
-
-        // Bootstrap cache config
-        config.bootstrap_cache = BootstrapCacheConfig {
-            enabled: !self.disable_bootstrap_cache,
-            cache_dir: self.bootstrap_cache_dir,
-            max_contacts: self.bootstrap_cache_capacity,
-            ..config.bootstrap_cache
         };
 
         // Determine bootstrap source and apply auto-discovery if needed.

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,10 +116,6 @@ pub struct NodeConfig {
     #[serde(default)]
     pub payment: PaymentConfig,
 
-    /// Bootstrap cache configuration for persistent peer storage.
-    #[serde(default)]
-    pub bootstrap_cache: BootstrapCacheConfig,
-
     /// Storage configuration for chunk persistence.
     #[serde(default)]
     pub storage: StorageConfig,
@@ -282,7 +278,6 @@ impl Default for NodeConfig {
             testnet: TestnetConfig::default(),
             upgrade: UpgradeConfig::default(),
             payment: PaymentConfig::default(),
-            bootstrap_cache: BootstrapCacheConfig::default(),
             storage: StorageConfig::default(),
             close_group_cache_dir: None,
             max_message_size: default_max_message_size(),
@@ -407,61 +402,6 @@ const fn default_staged_rollout_hours() -> u64 {
 
 // ============================================================================
 // Bootstrap Cache Configuration
-// ============================================================================
-
-/// Bootstrap cache configuration for persistent peer storage.
-///
-/// The bootstrap cache stores discovered peers across node restarts,
-/// ranking them by quality metrics (success rate, latency, recency).
-/// This reduces dependency on hardcoded bootstrap nodes and enables
-/// faster network reconnection after restarts.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BootstrapCacheConfig {
-    /// Enable persistent bootstrap cache.
-    /// Default: true
-    #[serde(default = "default_bootstrap_cache_enabled")]
-    pub enabled: bool,
-
-    /// Directory for cache files.
-    /// Default: `{root_dir}/bootstrap_cache/`
-    #[serde(default)]
-    pub cache_dir: Option<PathBuf>,
-
-    /// Maximum contacts to store in the cache.
-    /// Default: 10,000
-    #[serde(default = "default_bootstrap_max_contacts")]
-    pub max_contacts: usize,
-
-    /// Stale contact threshold in days.
-    /// Contacts older than this are removed during cleanup.
-    /// Default: 7 days
-    #[serde(default = "default_bootstrap_stale_days")]
-    pub stale_threshold_days: u64,
-}
-
-impl Default for BootstrapCacheConfig {
-    fn default() -> Self {
-        Self {
-            enabled: default_bootstrap_cache_enabled(),
-            cache_dir: None,
-            max_contacts: default_bootstrap_max_contacts(),
-            stale_threshold_days: default_bootstrap_stale_days(),
-        }
-    }
-}
-
-const fn default_bootstrap_cache_enabled() -> bool {
-    true
-}
-
-const fn default_bootstrap_max_contacts() -> usize {
-    10_000
-}
-
-const fn default_bootstrap_stale_days() -> u64 {
-    7
-}
-
 // ============================================================================
 // Storage Configuration
 // ============================================================================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub use client::{
     compute_address, hex_node_id_to_encoded_peer_id, peer_id_to_xor_name, xor_distance, DataChunk,
     XorName,
 };
-pub use config::{BootstrapCacheConfig, NodeConfig, StorageConfig};
+pub use config::{NodeConfig, StorageConfig};
 pub use devnet::{Devnet, DevnetConfig, DevnetEvmInfo, DevnetManifest};
 pub use error::{Error, Result};
 pub use event::{NodeEvent, NodeEventsChannel};

--- a/src/node.rs
+++ b/src/node.rs
@@ -20,7 +20,6 @@ use crate::upgrade::{
 use rand::Rng;
 use saorsa_core::identity::NodeIdentity;
 use saorsa_core::{
-    BootstrapConfig as CoreBootstrapConfig, BootstrapManager,
     IPDiversityConfig as CoreDiversityConfig, MultiAddr, NodeConfig as CoreNodeConfig, P2PEvent,
     P2PNode,
 };
@@ -108,14 +107,6 @@ impl NodeBuilder {
             Some(Self::build_upgrade_monitor(&self.config, node_id_seed))
         };
 
-        // Initialize bootstrap cache manager if enabled
-        let bootstrap_manager = if self.config.bootstrap_cache.enabled {
-            Self::build_bootstrap_manager(&self.config).await
-        } else {
-            info!("Bootstrap cache disabled");
-            None
-        };
-
         // Initialize ANT protocol handler for chunk storage and
         // wire the fresh-write channel so PUTs trigger replication.
         let (ant_protocol, fresh_write_rx) = if self.config.storage.enabled {
@@ -173,7 +164,6 @@ impl NodeBuilder {
             events_tx,
             events_rx: Some(events_rx),
             upgrade_monitor,
-            bootstrap_manager,
             ant_protocol,
             replication_engine,
             protocol_task: None,
@@ -410,41 +400,6 @@ impl NodeBuilder {
 
         Ok(protocol)
     }
-
-    /// Build the bootstrap cache manager from config.
-    async fn build_bootstrap_manager(config: &NodeConfig) -> Option<BootstrapManager> {
-        let cache_dir = config
-            .bootstrap_cache
-            .cache_dir
-            .clone()
-            .unwrap_or_else(|| config.root_dir.join("bootstrap_cache"));
-
-        // Create cache directory
-        if let Err(e) = std::fs::create_dir_all(&cache_dir) {
-            warn!("Failed to create bootstrap cache directory: {e}");
-            return None;
-        }
-
-        let bootstrap_config = CoreBootstrapConfig {
-            cache_dir,
-            max_peers: config.bootstrap_cache.max_contacts,
-            ..CoreBootstrapConfig::default()
-        };
-
-        match BootstrapManager::with_config(bootstrap_config).await {
-            Ok(manager) => {
-                info!(
-                    "Bootstrap cache initialized with {} max contacts",
-                    config.bootstrap_cache.max_contacts
-                );
-                Some(manager)
-            }
-            Err(e) => {
-                warn!("Failed to initialize bootstrap cache: {e}");
-                None
-            }
-        }
-    }
 }
 
 /// A running Ant node.
@@ -455,8 +410,6 @@ pub struct RunningNode {
     events_tx: NodeEventsSender,
     events_rx: Option<NodeEventsChannel>,
     upgrade_monitor: Option<UpgradeMonitor>,
-    /// Bootstrap cache manager for persistent peer storage.
-    bootstrap_manager: Option<BootstrapManager>,
     /// ANT protocol handler for chunk storage.
     ant_protocol: Option<Arc<AntProtocol>>,
     /// Replication engine (manages neighbor sync, verification, audits).
@@ -690,15 +643,6 @@ impl RunningNode {
 
         // Run the main event loop with signal handling
         self.run_event_loop().await?;
-
-        // Log bootstrap cache stats before shutdown
-        if let Some(ref manager) = self.bootstrap_manager {
-            let stats = manager.stats().await;
-            info!(
-                "Bootstrap cache shutdown: {} peers, avg quality {:.2}",
-                stats.total_peers, stats.average_quality
-            );
-        }
 
         // Shutdown replication engine before P2P so background tasks don't
         // use a dead P2P layer, and Arc<LmdbStorage> references are released.


### PR DESCRIPTION
## Summary
- Removes saorsa-node's own `BootstrapCacheConfig` from `src/config.rs` (different struct from saorsa-transport's, fields `enabled` / `cache_dir` / `max_contacts` / `stale_threshold_days`) and the `bootstrap_cache` field on `NodeConfig`.
- Drops the `pub use config::BootstrapCacheConfig` re-export from `lib.rs`.
- Removes `build_bootstrap_manager`, the `bootstrap_manager: Option<BootstrapManager>` field on `RunningNode`, and the shutdown-time stats log line from `node.rs`.
- Removes the **`--disable-bootstrap-cache`**, **`--bootstrap-cache-dir`**, and **`--bootstrap-cache-capacity`** CLI flags from the `ant-node` binary, plus the `ANT_BOOTSTRAP_CACHE_DIR` and `ANT_BOOTSTRAP_CACHE_CAPACITY` env-var fallbacks.
- Bumps `ant-protocol` and `saorsa-core` to track the corresponding branches.

## ⚠️ Operator-facing breakage
Anyone with these flags or env vars baked into systemd unit files / Docker entrypoints / deploy scripts must remove them **before** rolling out the new binary, or the process will fail at startup with clap's unknown-argument error.

## Depends on
- WithAutonomi/ant-protocol#1
- saorsa-labs/saorsa-core#107
(both transitively pin saorsa-labs/saorsa-transport#73)

## Backwards compatibility
- Wire-level: unchanged. Mixed networks of upgraded and non-upgraded nodes interoperate freely (PROTOCOL_VERSION = 1 untouched, on-wire `Capabilities` struct unchanged, DHT/chunk/payment unchanged).
- Old config files with `[bootstrap_cache]` sections still parse — `NodeConfig` does not set `#[serde(deny_unknown_fields)]`, so serde silently drops the unknown section.
- `config/production.toml` in this repo still has a stale `[bootstrap_cache]` example block; harmless but worth a follow-up cleanup.

## Test plan
- [ ] `cargo check --all-targets`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --lib` (448 of 449 passed; one pre-existing flaky `test_bootstrap_peers_discover_env_var` env-var-race fails on plain `main` too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)