### PR TITLE
Pin Saorsa dependencies to stability-improvements branches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,7 +866,7 @@ dependencies = [
  "rand 0.8.6",
  "reqwest",
  "rmp-serde",
- "saorsa-core 0.24.2 (git+https://github.com/saorsa-labs/saorsa-core?branch=fix/stability-improvements)",
+ "saorsa-core",
  "saorsa-pqc 0.5.1",
  "self-replace",
  "self_encryption",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "ant-protocol"
 version = "2.0.3"
-source = "git+https://github.com/jacderida/ant-protocol.git?rev=4aac7d35b69a5d0906a6f2acd5d1d0beb52dcbb8#4aac7d35b69a5d0906a6f2acd5d1d0beb52dcbb8"
+source = "git+https://github.com/WithAutonomi/ant-protocol?branch=main#93e63b8a41a97c37c24d1164a3ee5525e002ddcd"
 dependencies = [
  "blake3",
  "bytes",
@@ -900,7 +900,7 @@ dependencies = [
  "hex",
  "postcard",
  "rmp-serde",
- "saorsa-core 0.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "saorsa-core",
  "saorsa-pqc 0.5.1",
  "serde",
  "tokio",
@@ -2444,9 +2444,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4849,38 +4849,6 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e194874b524ad2a50d0976eb4ebcb81aea326dfb475373de9a2942a90cb2cc"
-dependencies = [
- "anyhow",
- "async-trait",
- "blake3",
- "bytes",
- "dashmap",
- "dirs 6.0.0",
- "futures",
- "hex",
- "lru",
- "once_cell",
- "parking_lot",
- "postcard",
- "rand 0.8.6",
- "saorsa-pqc 0.5.1",
- "saorsa-transport 0.34.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
- "uuid",
- "wyz",
-]
-
-[[package]]
-name = "saorsa-core"
-version = "0.24.2"
 source = "git+https://github.com/saorsa-labs/saorsa-core?branch=fix/stability-improvements#5586795740eafd9818e827baa2eb2677ff3ba942"
 dependencies = [
  "anyhow",
@@ -4897,7 +4865,7 @@ dependencies = [
  "postcard",
  "rand 0.8.6",
  "saorsa-pqc 0.5.1",
- "saorsa-transport 0.34.1 (git+https://github.com/saorsa-labs/saorsa-transport?branch=fix/stability-improvements)",
+ "saorsa-transport",
  "serde",
  "serde_json",
  "tempfile",
@@ -4989,66 +4957,6 @@ dependencies = [
  "tokio",
  "tracing",
  "wide",
- "zeroize",
-]
-
-[[package]]
-name = "saorsa-transport"
-version = "0.34.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ebc09fb51e2c325e61ff09892f1256c60ef4f3beb881fd2980befe3e53e9bc"
-dependencies = [
- "anyhow",
- "async-trait",
- "aws-lc-rs",
- "blake3",
- "bytes",
- "chrono",
- "clap",
- "core-foundation 0.9.4",
- "dashmap",
- "dirs 5.0.1",
- "enum_dispatch",
- "futures-util",
- "hex",
- "igd-next",
- "indexmap 2.14.0",
- "keyring",
- "libc",
- "lru-slab",
- "nix",
- "once_cell",
- "parking_lot",
- "pin-project-lite",
- "quinn-udp 0.6.1",
- "rand 0.8.6",
- "rcgen",
- "regex",
- "reqwest",
- "rustc-hash",
- "rustls",
- "rustls-native-certs",
- "rustls-pemfile",
- "rustls-platform-verifier 0.6.2",
- "rustls-post-quantum",
- "saorsa-pqc 0.4.2",
- "serde",
- "serde_json",
- "serde_yaml",
- "slab",
- "socket2 0.5.10",
- "system-configuration",
- "thiserror 2.0.18",
- "time",
- "tinyvec",
- "tokio",
- "tokio-util",
- "tracing",
- "tracing-subscriber",
- "unicode-width",
- "uuid",
- "windows",
- "x25519-dalek",
  "zeroize",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,15 +266,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6ae911a2fc304a7cb80a79fb7bed6d1474aed4e7c203df1f8ff538f64fc78d"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "borsh",
  "once_cell",
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -865,7 +866,7 @@ dependencies = [
  "rand 0.8.6",
  "reqwest",
  "rmp-serde",
- "saorsa-core",
+ "saorsa-core 0.24.2 (git+https://github.com/saorsa-labs/saorsa-core?branch=fix/stability-improvements)",
  "saorsa-pqc 0.5.1",
  "self-replace",
  "self_encryption",
@@ -899,7 +900,7 @@ dependencies = [
  "hex",
  "postcard",
  "rmp-serde",
- "saorsa-core",
+ "saorsa-core 0.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "saorsa-pqc 0.5.1",
  "serde",
  "tokio",
@@ -1308,7 +1309,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -1316,6 +1317,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitcoin-io"
@@ -1444,6 +1454,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,9 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2425,13 +2444,12 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -2790,9 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapless"
@@ -3213,7 +3231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -3456,10 +3474,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
  "libc",
- "plain",
- "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -3878,7 +3893,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -4029,12 +4044,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4171,7 +4180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
- "bit-vec",
+ "bit-vec 0.8.0",
  "bitflags",
  "num-traits",
  "rand 0.9.4",
@@ -4404,9 +4413,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.7"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "pem",
  "ring",
@@ -4421,15 +4430,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -4866,7 +4866,38 @@ dependencies = [
  "postcard",
  "rand 0.8.6",
  "saorsa-pqc 0.5.1",
- "saorsa-transport",
+ "saorsa-transport 0.34.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "wyz",
+]
+
+[[package]]
+name = "saorsa-core"
+version = "0.24.2"
+source = "git+https://github.com/saorsa-labs/saorsa-core?branch=fix/stability-improvements#5586795740eafd9818e827baa2eb2677ff3ba942"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "blake3",
+ "bytes",
+ "dashmap",
+ "dirs 6.0.0",
+ "futures",
+ "hex",
+ "lru",
+ "once_cell",
+ "parking_lot",
+ "postcard",
+ "rand 0.8.6",
+ "saorsa-pqc 0.5.1",
+ "saorsa-transport 0.34.1 (git+https://github.com/saorsa-labs/saorsa-transport?branch=fix/stability-improvements)",
  "serde",
  "serde_json",
  "tempfile",
@@ -4966,6 +4997,65 @@ name = "saorsa-transport"
 version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31ebc09fb51e2c325e61ff09892f1256c60ef4f3beb881fd2980befe3e53e9bc"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "aws-lc-rs",
+ "blake3",
+ "bytes",
+ "chrono",
+ "clap",
+ "core-foundation 0.9.4",
+ "dashmap",
+ "dirs 5.0.1",
+ "enum_dispatch",
+ "futures-util",
+ "hex",
+ "igd-next",
+ "indexmap 2.14.0",
+ "keyring",
+ "libc",
+ "lru-slab",
+ "nix",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "quinn-udp 0.6.1",
+ "rand 0.8.6",
+ "rcgen",
+ "regex",
+ "reqwest",
+ "rustc-hash",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-platform-verifier 0.6.2",
+ "rustls-post-quantum",
+ "saorsa-pqc 0.4.2",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "slab",
+ "socket2 0.5.10",
+ "system-configuration",
+ "thiserror 2.0.18",
+ "time",
+ "tinyvec",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "unicode-width",
+ "uuid",
+ "windows",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "saorsa-transport"
+version = "0.34.1"
+source = "git+https://github.com/saorsa-labs/saorsa-transport?branch=fix/stability-improvements#55f423ca5e3312e31ba22475b68a76f4ffd50285"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5254,11 +5344,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5273,9 +5364,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5783,9 +5874,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -7045,10 +7136,11 @@ dependencies = [
 
 [[package]]
 name = "yasna"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 dependencies = [
+ "bit-vec 0.9.1",
  "time",
 ]
 
@@ -7097,9 +7189,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/bin/ant-devnet/main.rs"
 # Until then, the git pin tracks the matching saorsa-core lineage
 # (the rc-2026.4.2 branch) so Cargo can unify the wire types here
 # with ant-protocol's re-exports.
-ant-protocol = { git = "https://github.com/WithAutonomi/ant-protocol", branch = "fix/stability-improvements" }
+ant-protocol = { git = "https://github.com/WithAutonomi/ant-protocol", branch = "main" }
 
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
 saorsa-core = { git = "https://github.com/saorsa-labs/saorsa-core", branch = "fix/stability-improvements" }
@@ -171,23 +171,14 @@ cognitive_complexity = "allow"
 # Allow non-const functions during initial development (may need runtime features later)
 missing_const_for_fn = "allow"
 
-# Pin ant-protocol to the perf/chunk-put-bytes branch so ChunkPutRequest's
-# `content` field is `Bytes` (not `Vec<u8>`). The storage handler reads the
-# field but holds it as a slice / converts to Vec at the boundary, so the
-# wire-level type swap is transparent to existing logic.
-# Remove once https://github.com/WithAutonomi/ant-protocol/pull/6 lands and a
-# crates.io release containing it is published.
+# Pin ant-protocol to the WithAutonomi `fix/stability-improvements` branch
+# until a crates.io release containing the matching stability fixes is
+# published.
 #
-# Two patch tables are needed:
-#   * `[patch.crates-io]` overrides ant-protocol on `main`, which consumes
-#     from crates.io.
-#   * `[patch."https://github.com/WithAutonomi/ant-protocol"]` overrides it
-#     on testnet branches where saorsa-core / saorsa-transport pin
-#     ant-protocol to a WithAutonomi git branch.
-# Whichever table doesn't match the active resolution path emits a benign
-# "patch not used in the crate graph" warning.
+# `[patch.crates-io]` overrides ant-protocol/saorsa-core where transitive deps
+# (e.g. evmlib, saorsa-transport) pull them from crates.io, so they unify
+# with our direct git branch pins instead of producing two versions in the
+# graph (which would split `MultiAddr` / DHT types).
 [patch.crates-io]
-ant-protocol = { git = "https://github.com/jacderida/ant-protocol.git", rev = "4aac7d35b69a5d0906a6f2acd5d1d0beb52dcbb8" }
-
-[patch."https://github.com/WithAutonomi/ant-protocol"]
-ant-protocol = { git = "https://github.com/jacderida/ant-protocol.git", rev = "4aac7d35b69a5d0906a6f2acd5d1d0beb52dcbb8" }
+ant-protocol = { git = "https://github.com/WithAutonomi/ant-protocol", branch = "main" }
+saorsa-core = { git = "https://github.com/saorsa-labs/saorsa-core", branch = "fix/stability-improvements" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,10 @@ path = "src/bin/ant-devnet/main.rs"
 # Until then, the git pin tracks the matching saorsa-core lineage
 # (the rc-2026.4.2 branch) so Cargo can unify the wire types here
 # with ant-protocol's re-exports.
-ant-protocol = "2.0.3"
+ant-protocol = { git = "https://github.com/WithAutonomi/ant-protocol", branch = "fix/stability-improvements" }
 
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
-saorsa-core = "0.24.2"
+saorsa-core = { git = "https://github.com/saorsa-labs/saorsa-core", branch = "fix/stability-improvements" }
 saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment

--- a/src/devnet.rs
+++ b/src/devnet.rs
@@ -623,6 +623,7 @@ impl Devnet {
                         topic,
                         source: Some(source),
                         data,
+                        ..
                     } = event
                     {
                         if topic == CHUNK_PROTOCOL_ID {

--- a/src/node.rs
+++ b/src/node.rs
@@ -803,6 +803,7 @@ impl RunningNode {
                     topic,
                     source: Some(source),
                     data,
+                    ..
                 } = event
                 {
                     let handler_info: Option<(&str, &str)> = if topic == CHUNK_PROTOCOL_ID {

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -358,6 +358,7 @@ impl ReplicationEngine {
                             topic,
                             source: Some(source),
                             data,
+                            ..
                         } = event {
                             // Determine if this is a replication message
                             // and whether it arrived via the /rr/ request-response

--- a/tests/e2e/testnet.rs
+++ b/tests/e2e/testnet.rs
@@ -1197,6 +1197,7 @@ impl TestNetwork {
                         topic,
                         source: Some(source),
                         data,
+                        ..
                     } = event
                     {
                         if topic == CHUNK_PROTOCOL_ID {


### PR DESCRIPTION
## Summary
- switch ant-protocol and saorsa-core to their fix/stability-improvements git branches
- refresh Cargo.lock for the updated dependency graph, including the matching saorsa-transport git source
- pick up current transitive dependency updates from the resolved lockfile

## Testing
- Not run; PR opened from existing branch.