### PR TITLE
perf(storage): track ant-protocol ChunkPutRequest content: Bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,8 +891,7 @@ dependencies = [
 [[package]]
 name = "ant-protocol"
 version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edaf05019466da9ff9055dbbc1428db3414440a8f0a1ac929febcf4fb0608a6d"
+source = "git+https://github.com/jacderida/ant-protocol.git?rev=4aac7d35b69a5d0906a6f2acd5d1d0beb52dcbb8#4aac7d35b69a5d0906a6f2acd5d1d0beb52dcbb8"
 dependencies = [
  "blake3",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,3 +170,24 @@ unused_async = "allow"
 cognitive_complexity = "allow"
 # Allow non-const functions during initial development (may need runtime features later)
 missing_const_for_fn = "allow"
+
+# Pin ant-protocol to the perf/chunk-put-bytes branch so ChunkPutRequest's
+# `content` field is `Bytes` (not `Vec<u8>`). The storage handler reads the
+# field but holds it as a slice / converts to Vec at the boundary, so the
+# wire-level type swap is transparent to existing logic.
+# Remove once https://github.com/WithAutonomi/ant-protocol/pull/6 lands and a
+# crates.io release containing it is published.
+#
+# Two patch tables are needed:
+#   * `[patch.crates-io]` overrides ant-protocol on `main`, which consumes
+#     from crates.io.
+#   * `[patch."https://github.com/WithAutonomi/ant-protocol"]` overrides it
+#     on testnet branches where saorsa-core / saorsa-transport pin
+#     ant-protocol to a WithAutonomi git branch.
+# Whichever table doesn't match the active resolution path emits a benign
+# "patch not used in the crate graph" warning.
+[patch.crates-io]
+ant-protocol = { git = "https://github.com/jacderida/ant-protocol.git", rev = "4aac7d35b69a5d0906a6f2acd5d1d0beb52dcbb8" }
+
+[patch."https://github.com/WithAutonomi/ant-protocol"]
+ant-protocol = { git = "https://github.com/jacderida/ant-protocol.git", rev = "4aac7d35b69a5d0906a6f2acd5d1d0beb52dcbb8" }

--- a/src/storage/handler.rs
+++ b/src/storage/handler.rs
@@ -234,9 +234,14 @@ impl AntProtocol {
                 //    PUTs have no proof to forward, and the chunk would have
                 //    already replicated on the original write that carried one.
                 if let (Some(ref tx), Some(proof)) = (&self.fresh_write_tx, request.payment_proof) {
+                    // `request.content` is now `bytes::Bytes`; FreshWriteEvent
+                    // still carries the chunk as `Vec<u8>` for compatibility
+                    // with the replication wire format, so materialise once
+                    // here. Done only on the success path, where storage has
+                    // already accepted the chunk.
                     let event = FreshWriteEvent {
                         key: address,
-                        data: request.content,
+                        data: request.content.to_vec(),
                         payment_proof: proof,
                     };
                     if tx.send(event).is_err() {
@@ -495,7 +500,7 @@ mod tests {
         // Pre-populate payment cache so EVM verification is bypassed
         protocol.payment_verifier().cache_insert(address);
 
-        let put_request = ChunkPutRequest::new(address, content.to_vec());
+        let put_request = ChunkPutRequest::new(address, Bytes::copy_from_slice(content));
         let put_msg = ChunkMessage {
             request_id: 1,
             body: ChunkMessageBody::PutRequest(put_request),
@@ -587,7 +592,7 @@ mod tests {
         // Pre-populate cache for the wrong address so we test address mismatch, not payment
         protocol.payment_verifier().cache_insert(wrong_address);
 
-        let put_request = ChunkPutRequest::new(wrong_address, content.to_vec());
+        let put_request = ChunkPutRequest::new(wrong_address, Bytes::copy_from_slice(content));
         let put_msg = ChunkMessage {
             request_id: 20,
             body: ChunkMessageBody::PutRequest(put_request),
@@ -620,7 +625,7 @@ mod tests {
         let content = vec![0u8; MAX_CHUNK_SIZE + 1];
         let address = LmdbStorage::compute_address(&content);
 
-        let put_request = ChunkPutRequest::new(address, content);
+        let put_request = ChunkPutRequest::new(address, Bytes::from(content));
         let put_msg = ChunkMessage {
             request_id: 30,
             body: ChunkMessageBody::PutRequest(put_request),
@@ -655,7 +660,7 @@ mod tests {
         // Pre-populate cache so EVM verification is bypassed
         protocol.payment_verifier().cache_insert(address);
 
-        let put_request = ChunkPutRequest::new(address, content.to_vec());
+        let put_request = ChunkPutRequest::new(address, Bytes::copy_from_slice(content));
         let put_msg = ChunkMessage {
             request_id: 40,
             body: ChunkMessageBody::PutRequest(put_request),
@@ -730,7 +735,7 @@ mod tests {
         assert_eq!(stats_after.additions, 1);
 
         // PUT should succeed (cache hit)
-        let put_request = ChunkPutRequest::new(address, content.to_vec());
+        let put_request = ChunkPutRequest::new(address, Bytes::copy_from_slice(content));
         let put_msg = ChunkMessage {
             request_id: 100,
             body: ChunkMessageBody::PutRequest(put_request),
@@ -761,7 +766,7 @@ mod tests {
         protocol.payment_verifier().cache_insert(address);
 
         // First PUT
-        let put_request = ChunkPutRequest::new(address, content.to_vec());
+        let put_request = ChunkPutRequest::new(address, Bytes::copy_from_slice(content));
         let put_msg = ChunkMessage {
             request_id: 110,
             body: ChunkMessageBody::PutRequest(put_request),
@@ -802,7 +807,7 @@ mod tests {
         let address = LmdbStorage::compute_address(content);
         protocol.payment_verifier().cache_insert(address);
 
-        let put_request = ChunkPutRequest::new(address, content.to_vec());
+        let put_request = ChunkPutRequest::new(address, Bytes::copy_from_slice(content));
         let put_msg = ChunkMessage {
             request_id: 120,
             body: ChunkMessageBody::PutRequest(put_request),
@@ -912,7 +917,7 @@ mod tests {
 
         // Store the chunk first
         protocol.payment_verifier().cache_insert(address);
-        let put_request = ChunkPutRequest::new(address, content.to_vec());
+        let put_request = ChunkPutRequest::new(address, Bytes::copy_from_slice(content));
         let put_msg = ChunkMessage {
             request_id: 300,
             body: ChunkMessageBody::PutRequest(put_request),

--- a/tests/e2e/data_types/chunk.rs
+++ b/tests/e2e/data_types/chunk.rs
@@ -485,7 +485,11 @@ mod tests {
 
         // Create PUT request with empty payment
         let request_id: u64 = rand::random();
-        let request = ChunkPutRequest::with_payment(address, data.to_vec(), empty_payment);
+        let request = ChunkPutRequest::with_payment(
+            address,
+            bytes::Bytes::copy_from_slice(data),
+            empty_payment,
+        );
         let message = ChunkMessage {
             request_id,
             body: ChunkMessageBody::PutRequest(request),

--- a/tests/e2e/merkle_payment.rs
+++ b/tests/e2e/merkle_payment.rs
@@ -23,6 +23,7 @@ use ant_node::compute_address;
 use ant_node::payment::{
     serialize_merkle_proof, MAX_PAYMENT_PROOF_SIZE_BYTES, MIN_PAYMENT_PROOF_SIZE_BYTES,
 };
+use bytes::Bytes;
 use evmlib::common::Amount;
 use evmlib::merkle_payments::{
     MerklePaymentCandidateNode, MerklePaymentCandidatePool, MerklePaymentProof, MerkleTree,
@@ -220,7 +221,8 @@ async fn test_attack_merkle_tagged_garbage() -> Result<(), Box<dyn std::error::E
         garbage.push(0x00);
     }
 
-    let request = ChunkPutRequest::with_payment(address, test_data.to_vec(), garbage);
+    let request =
+        ChunkPutRequest::with_payment(address, Bytes::copy_from_slice(test_data), garbage);
 
     let response = send_put_to_node(&harness, 0, request)
         .await
@@ -256,8 +258,11 @@ async fn test_attack_merkle_proof_wrong_xorname() -> Result<(), Box<dyn std::err
     let wrong_data = b"This chunk was never paid for via this merkle proof";
     let wrong_address = compute_address(wrong_data);
 
-    let request =
-        ChunkPutRequest::with_payment(wrong_address, wrong_data.to_vec(), proof.tagged_proof);
+    let request = ChunkPutRequest::with_payment(
+        wrong_address,
+        Bytes::copy_from_slice(wrong_data),
+        proof.tagged_proof,
+    );
 
     let response = send_put_to_node(&harness, 0, request)
         .await
@@ -304,7 +309,7 @@ async fn test_attack_merkle_tampered_candidate_signature() -> Result<(), Box<dyn
     // Build request with correct content whose BLAKE3 hash matches the proof address
     let content = proof.target.content;
     let address = proof.target.address.0;
-    let request = ChunkPutRequest::with_payment(address, content, tagged_proof);
+    let request = ChunkPutRequest::with_payment(address, Bytes::from(content), tagged_proof);
 
     let response = send_put_to_node(&harness, 0, request)
         .await
@@ -391,8 +396,11 @@ async fn test_attack_merkle_garbage_all_nodes_concurrent() -> Result<(), Box<dyn
 
     for i in 0..node_count {
         if harness.test_node(i).is_some() {
-            let request =
-                ChunkPutRequest::with_payment(address, test_data.to_vec(), garbage.clone());
+            let request = ChunkPutRequest::with_payment(
+                address,
+                Bytes::copy_from_slice(test_data),
+                garbage.clone(),
+            );
             let msg = ChunkMessage {
                 request_id: rand::thread_rng().gen(),
                 body: ChunkMessageBody::PutRequest(request),
@@ -458,8 +466,11 @@ async fn test_attack_merkle_proof_cross_address_replay() -> Result<(), Box<dyn s
 
     // Build request with second entry's correct content/address pair,
     // but using the proof that was bound to entries[0].
-    let request =
-        ChunkPutRequest::with_payment(second.address.0, second.content.clone(), proof.tagged_proof);
+    let request = ChunkPutRequest::with_payment(
+        second.address.0,
+        Bytes::from(second.content.clone()),
+        proof.tagged_proof,
+    );
 
     let response = send_put_to_node(&harness, 0, request)
         .await
@@ -555,7 +566,7 @@ async fn test_attack_merkle_pay_yourself_fabricated_pool() -> Result<(), Box<dyn
 
     let request = ChunkPutRequest::with_payment(
         proof.target.address.0,
-        proof.target.content.clone(),
+        Bytes::from(proof.target.content.clone()),
         proof.tagged_proof,
     );
 

--- a/tests/e2e/security_attacks.rs
+++ b/tests/e2e/security_attacks.rs
@@ -15,6 +15,7 @@ use ant_node::ant_protocol::{
 };
 use ant_node::compute_address;
 use ant_node::payment::PaymentProof;
+use bytes::Bytes;
 use evmlib::testnet::Testnet;
 use evmlib::ProofOfPayment;
 use rand::Rng;
@@ -96,7 +97,7 @@ async fn test_attack_no_payment_proof() -> Result<(), Box<dyn std::error::Error>
 
     let test_data = b"Attack: no payment proof whatsoever";
     let address = compute_address(test_data);
-    let request = ChunkPutRequest::new(address, test_data.to_vec());
+    let request = ChunkPutRequest::new(address, Bytes::copy_from_slice(test_data));
 
     let response = send_put_to_node(&harness, 0, request)
         .await
@@ -123,7 +124,7 @@ async fn test_attack_empty_proof_bytes() -> Result<(), Box<dyn std::error::Error
 
     let test_data = b"Attack: empty proof bytes";
     let address = compute_address(test_data);
-    let request = ChunkPutRequest::with_payment(address, test_data.to_vec(), vec![]);
+    let request = ChunkPutRequest::with_payment(address, Bytes::copy_from_slice(test_data), vec![]);
 
     let response = send_put_to_node(&harness, 0, request)
         .await
@@ -151,7 +152,8 @@ async fn test_attack_garbage_bytes_as_proof() -> Result<(), Box<dyn std::error::
     let test_data = b"Attack: garbage bytes as proof";
     let address = compute_address(test_data);
     let garbage: Vec<u8> = (0..64).map(|_| rand::thread_rng().gen()).collect();
-    let request = ChunkPutRequest::with_payment(address, test_data.to_vec(), garbage);
+    let request =
+        ChunkPutRequest::with_payment(address, Bytes::copy_from_slice(test_data), garbage);
 
     let response = send_put_to_node(&harness, 0, request)
         .await
@@ -195,7 +197,7 @@ async fn test_attack_valid_msgpack_empty_quotes() -> Result<(), Box<dyn std::err
         padded.push(0);
     }
 
-    let request = ChunkPutRequest::with_payment(address, test_data.to_vec(), padded);
+    let request = ChunkPutRequest::with_payment(address, Bytes::copy_from_slice(test_data), padded);
 
     let response = send_put_to_node(&harness, 0, request)
         .await
@@ -223,7 +225,8 @@ async fn test_attack_proof_too_large() -> Result<(), Box<dyn std::error::Error>>
     let test_data = b"Attack: oversized proof bytes";
     let address = compute_address(test_data);
     let oversized: Vec<u8> = vec![0xAA; 200 * 1024]; // 200KB of junk
-    let request = ChunkPutRequest::with_payment(address, test_data.to_vec(), oversized);
+    let request =
+        ChunkPutRequest::with_payment(address, Bytes::copy_from_slice(test_data), oversized);
 
     let response = send_put_to_node(&harness, 0, request)
         .await

--- a/tests/e2e/testnet.rs
+++ b/tests/e2e/testnet.rs
@@ -499,7 +499,7 @@ impl TestNode {
         protocol.payment_verifier().cache_insert(address);
 
         let request_id: u64 = rand::thread_rng().gen();
-        let request = ChunkPutRequest::new(address, data.to_vec());
+        let request = ChunkPutRequest::new(address, Bytes::copy_from_slice(data));
         let message = ChunkMessage {
             request_id,
             body: ChunkMessageBody::PutRequest(request),
@@ -669,7 +669,7 @@ impl TestNode {
         let address = Self::compute_chunk_address(data);
 
         let request_id: u64 = rand::thread_rng().gen();
-        let request = ChunkPutRequest::new(address, data.to_vec());
+        let request = ChunkPutRequest::new(address, Bytes::copy_from_slice(data));
         let message = ChunkMessage {
             request_id,
             body: ChunkMessageBody::PutRequest(request),


### PR DESCRIPTION
## Summary

Companion PR to https://github.com/WithAutonomi/ant-protocol/pull/6 and https://github.com/WithAutonomi/ant-client/pull/82. ant-protocol#6 changes `ChunkPutRequest.content` from `Vec<u8>` to `bytes::Bytes` so the ant-client side can share one refcounted backing buffer across the N close-group peer sends per chunk (instead of deep-copying the 4 MB payload N times). ant-node is on the receiving side of that wire format and needs to compile against the new field type.

## Changes

- `[patch.crates-io]` **and** `[patch."https://github.com/WithAutonomi/ant-protocol"]` pin `ant-protocol` to the jacderida fork commit on the perf branch. Two patch tables so the override applies whether ant-protocol is resolved from crates.io (`main`) or from a git source (testnet branches like `fix/stability-improvements`, where saorsa-core pins ant-protocol to a WithAutonomi branch). The unused table emits a benign "patch not used" warning. The pin should be removed once a crates.io release containing the protocol change is published.
- `src/storage/handler.rs:239`: when emitting a `FreshWriteEvent`, materialise `request.content` (now `Bytes`) into `Vec<u8>` with `.to_vec()`. `FreshWriteEvent.data` is still `Vec<u8>` for compatibility with the replication wire format; propagating `Bytes` deeper into the replication path is a worthwhile follow-up but out of scope here. The materialisation happens only on the success path (after storage has accepted the chunk), so it's one copy per successful PUT — node VMs are not memory-constrained the way client VMs are.
- Test sites: `ChunkPutRequest::new(addr, content.to_vec())` from byte-string literals now uses `Bytes::copy_from_slice(content)`; the one site with an owned `Vec<u8>` uses `Bytes::from(content)`.

## Why no other consumer site needs to change

The other reads of `request.content` in the handler all coerce `Bytes`/`&Bytes` to `&[u8]` transparently:

- `request.content.len()` (lines 173, 175, 226) — `Bytes::len()` is identical.
- `compute_address(&request.content)` — takes `&[u8]`; `&Bytes` derefs.
- `self.storage.put(&address, &request.content)` — takes `&[u8]`; `&Bytes` derefs.

## Test plan

- [x] `cargo check --lib` — clean
- [x] `cargo test --lib storage::handler` — 14/14 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)