### PR TITLE
fix(replication): guard prune confirmation safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,8 @@ cobertura.xml
 test_data/
 tmp/
 temp/
+/test-*.bin
+/test-*.datamap
 
 # Benchmark results
 criterion/

--- a/docs/REPLICATION_DESIGN.md
+++ b/docs/REPLICATION_DESIGN.md
@@ -73,7 +73,7 @@ All parameters are configurable. Values below are a reference profile used for l
 | *(dynamic)* | Audit sample count per round: `floor(sqrt(local_key_count))` | scales with store size |
 | `AUDIT_RESPONSE_TIMEOUT` | Audit response deadline | `12s`                               |
 | `BOOTSTRAP_CLAIM_GRACE_PERIOD` | Max duration a peer may claim bootstrap status before penalties apply | `24h`                               |
-| `PRUNE_HYSTERESIS_DURATION` | Minimum continuous out-of-range duration before pruning a key | `6h`                                |
+| `PRUNE_HYSTERESIS_DURATION` | Minimum continuous out-of-range duration before pruning a key | `3 days`                            |
 
 Parameter safety constraints (MUST hold):
 
@@ -104,7 +104,7 @@ Parameter safety constraints (MUST hold):
 19. Storage-proof audits start only after `BootstrapDrained(self)` becomes true.
 20. Storage-proof audits target only peers derived from closest-peer lookups for sampled local keys, filtered through local authenticated routing state (`LocalRT(self)`), and further filtered to peers for which `RepairOpportunity` holds; random global peers and never-synced peers are never audited.
 21. Verification-request batching is mandatory for unknown-key neighbor-sync verification and preserves per-key quorum semantics: each key receives explicit per-key evidence, and missing/timeout evidence is unresolved per key.
-22. On every `NeighborSyncCycleComplete(self)`, node MUST run a prune pass using current `SelfInclusiveRT(self)`: for stored records where `IsResponsible(self, K)` is false, record `RecordOutOfRangeFirstSeen` if not already set and delete only when `now - RecordOutOfRangeFirstSeen >= PRUNE_HYSTERESIS_DURATION`; clear `RecordOutOfRangeFirstSeen` when back in range. For `PaidForList` entries where `self ∉ PaidCloseGroup(K)`, record `PaidOutOfRangeFirstSeen` if not already set and delete only when `now - PaidOutOfRangeFirstSeen >= PRUNE_HYSTERESIS_DURATION`; clear `PaidOutOfRangeFirstSeen` when back in range. The two timestamps are independent.
+22. On every `NeighborSyncCycleComplete(self)`, node MUST run a prune pass using current `SelfInclusiveRT(self)`: for stored records where `IsResponsible(self, K)` is false, record `RecordOutOfRangeFirstSeen` if not already set and delete only when `now - RecordOutOfRangeFirstSeen >= PRUNE_HYSTERESIS_DURATION` and every currently-known `CloseGroup(K)` member returns a positive nonce-bound audit proof for the record. If any close-group peer does not prove storage, pruning is deferred and the retained local record continues participating in normal neighbor-sync repair. Prune-confirmation failures emit trust penalties after fresh responsibility confirmation; bootstrap claims use the same `BOOTSTRAP_CLAIM_GRACE_PERIOD` tracking before abuse penalties apply. Clear `RecordOutOfRangeFirstSeen` when back in range. For `PaidForList` entries where `self ∉ PaidCloseGroup(K)`, record `PaidOutOfRangeFirstSeen` if not already set and delete only when `now - PaidOutOfRangeFirstSeen >= PRUNE_HYSTERESIS_DURATION`; clear `PaidOutOfRangeFirstSeen` when back in range. The two timestamps are independent.
 23. Peers claiming bootstrap status are skipped for sync and audit without penalty for up to `BOOTSTRAP_CLAIM_GRACE_PERIOD` from first observation. After the grace period, each continued bootstrap claim emits `BootstrapClaimAbuse` evidence to `TrustEngine` (via `report_trust_event` with `ApplicationFailure(weight)`).
 24. Audit trust-penalty signals require responsibility confirmation: on audit failure, challenger MUST perform fresh local RT closest-peer lookups for each challenged key and only penalize the peer for keys where it is confirmed responsible.
 
@@ -359,11 +359,11 @@ Post-cycle responsibility pruning (triggered by `NeighborSyncCycleComplete(self)
 
 1. For each locally stored key `K`, recompute `IsResponsible(self, K)` using current `SelfInclusiveRT(self)`:
    a. If in range: clear `RecordOutOfRangeFirstSeen(self, K)` (set to `None`).
-   b. If out of range: if `RecordOutOfRangeFirstSeen(self, K)` is `None`, set it to `now`. Delete the record only when `now - RecordOutOfRangeFirstSeen(self, K) >= PRUNE_HYSTERESIS_DURATION`.
+   b. If out of range: if `RecordOutOfRangeFirstSeen(self, K)` is `None`, set it to `now`. Once the hysteresis duration has elapsed, request a nonce-bound audit proof from every current `CloseGroup(K)` peer, subject to a bounded per-pass prune-confirmation budget. If any peer does not prove storage, defer pruning and emit trust penalties after fresh responsibility confirmation; valid bootstrap claims are penalized only after the bootstrap grace period. Delete the local record only when `now - RecordOutOfRangeFirstSeen(self, K) >= PRUNE_HYSTERESIS_DURATION` and every current close-group peer proves storage for `K`.
 2. For each key `K` in `PaidForList(self)`, recompute `PaidCloseGroup(K)` membership using current `SelfInclusiveRT(self)`:
    a. If `self ∈ PaidCloseGroup(K)`: clear `PaidOutOfRangeFirstSeen(self, K)` (set to `None`).
    b. If `self ∉ PaidCloseGroup(K)`: if `PaidOutOfRangeFirstSeen(self, K)` is `None`, set it to `now`. Delete the entry only when `now - PaidOutOfRangeFirstSeen(self, K) >= PRUNE_HYSTERESIS_DURATION`.
-3. This prune pass is local-state-only and MUST NOT require remote confirmations.
+3. Paid-list entry pruning remains local-state-only and does not require remote confirmations.
 
 Effect:
 
@@ -605,7 +605,7 @@ Each scenario should assert exact expected outcomes and state transitions.
 35. Neighbor-sync round-robin batch selection with cooldown skip:
 - With more than `NEIGHBOR_SYNC_PEER_COUNT` eligible peers, consecutive rounds scan forward from cursor, skip and remove cooldown peers, and sync the next batch of up to `NEIGHBOR_SYNC_PEER_COUNT` non-cooldown peers. Cycle completes when all snapshot peers have been synced, skipped (cooldown), or removed (unreachable).
 36. Post-cycle responsibility pruning with time-based hysteresis:
-- When a full neighbor-sync round-robin cycle completes, node runs one prune pass using current `SelfInclusiveRT(self)` (`LocalRT(self) ∪ {self}`): stored keys with `IsResponsible(self, K)=false` have `RecordOutOfRangeFirstSeen` recorded (if not already set) but are deleted only when `now - RecordOutOfRangeFirstSeen >= PRUNE_HYSTERESIS_DURATION`. Keys that are in range have their `RecordOutOfRangeFirstSeen` cleared. Same logic applies independently to `PaidForList` entries where `self ∉ PaidCloseGroup(K)` using `PaidOutOfRangeFirstSeen`.
+- When a full neighbor-sync round-robin cycle completes, node runs one prune pass using current `SelfInclusiveRT(self)` (`LocalRT(self) ∪ {self}`): stored keys with `IsResponsible(self, K)=false` have `RecordOutOfRangeFirstSeen` recorded (if not already set) but are deleted only when `now - RecordOutOfRangeFirstSeen >= PRUNE_HYSTERESIS_DURATION` and every current close-group peer returns a positive nonce-bound audit proof for the key. Missing or failed proofs defer pruning and emit trust penalties after fresh responsibility confirmation; valid bootstrap claims are penalized only after the bootstrap grace period. Prune-confirmation work is bounded per pass. Keys that are in range have their `RecordOutOfRangeFirstSeen` cleared. Same hysteresis timing applies independently to `PaidForList` entries where `self ∉ PaidCloseGroup(K)` using `PaidOutOfRangeFirstSeen`, but paid-list pruning does not require remote storage confirmation.
 37. Non-`LocalRT` inbound sync behavior:
 - If a peer opens sync while not in receiver `LocalRT(self)`, receiver may still send hints to that peer, but receiver drops all inbound replica/paid hints from that peer.
 38. Neighbor-sync snapshot stability under peer join:
@@ -633,7 +633,7 @@ Each scenario should assert exact expected outcomes and state transitions.
 49. Bootstrap claim cleared on normal response:
 - Peer `P` previously claimed bootstrapping. `P` later responds normally to a sync or audit request. Node clears `BootstrapClaimFirstSeen(self, P)`. No residual penalty tracking.
 50. Prune hysteresis prevents premature deletion:
-- Key `K` goes out of range at time `T`. `RecordOutOfRangeFirstSeen(self, K)` is set to `T`. Key is NOT deleted. At `T + 3h` (less than `PRUNE_HYSTERESIS_DURATION`), key is still retained. At `T + 6h` (`>= PRUNE_HYSTERESIS_DURATION`), key is deleted on the next prune pass.
+- Key `K` goes out of range at time `T`. `RecordOutOfRangeFirstSeen(self, K)` is set to `T`. Key is NOT deleted. At `T + 24h` (less than `PRUNE_HYSTERESIS_DURATION`), key is still retained. At `T + 3 days` (`>= PRUNE_HYSTERESIS_DURATION`), key is eligible for deletion on the next prune pass only if all current close-group peers return positive nonce-bound audit proofs.
 51. Prune hysteresis timestamp reset on partition heal:
 - Key `K` goes out of range at time `T`. `RecordOutOfRangeFirstSeen(self, K)` is set to `T`. At `T + 4h`, partition heals, peers return, `K` is back in range. `RecordOutOfRangeFirstSeen` is cleared. Key is retained. If `K` later goes out of range again, the clock restarts from zero.
 52. Prune hysteresis applies to paid-list entries:

--- a/docs/REPLICATION_DESIGN.md
+++ b/docs/REPLICATION_DESIGN.md
@@ -50,7 +50,7 @@ Primary goal: validate correctness, safety, and liveness of replication logic be
 - `QuorumNeeded(K)`: effective presence confirmation count for key `K`, defined as `min(QUORUM_THRESHOLD, floor(|QuorumTargets(K)|/2)+1)`.
 - `BootstrapDrained(N)`: bootstrap-completion gate for node `N`; true only when peer discovery closest to `N`'s own address has populated `LocalRT(N)`, bootstrap peer requests are finished (response or timeout), and bootstrap work queues are empty (`PendingVerify`, `FetchQueue`, `InFlightFetch` for bootstrap-discovered keys).
 - `RepairOpportunity(P, KSet)`: evidence that peer `P` has previously received replication hints/offers for keys in `KSet` and had at least one subsequent neighbor-sync cycle to repair before audit evaluation.
-- `BootstrapClaimFirstSeen(N, P)`: timestamp when node `N` first observed peer `P` responding with a bootstrapping claim to a sync or audit request. Reset when `P` stops claiming bootstrap status.
+- `BootstrapClaimFirstSeen(N, P)`: timestamp when node `N` first observed peer `P` responding with a bootstrapping claim to a sync, audit, or prune-confirmation request. Each peer gets at most one bootstrap-claim grace window. When `P` stops claiming bootstrap status, the active claim is cleared but the first-seen history is retained; any later bootstrap claim by the same peer is `BootstrapClaimAbuse`.
 - `TrustEngine`: local trust subsystem (EMA-based response-rate scoring with time decay) that consumes replication evidence events via `AdaptiveDHT::report_trust_event`, updates peer trust scores, and triggers peer eviction when scores fall below `block_threshold`. Consumer-reported events use `TrustEvent::ApplicationSuccess(weight)` / `TrustEvent::ApplicationFailure(weight)` with weight clamped to `MAX_CONSUMER_WEIGHT` (5.0).
 
 ## 4. Tunable Parameters
@@ -72,7 +72,7 @@ All parameters are configurable. Values below are a reference profile used for l
 | `AUDIT_TICK_INTERVAL` | Audit scheduler cadence | random in `[30 min, 1 hour]`        |
 | *(dynamic)* | Audit sample count per round: `floor(sqrt(local_key_count))` | scales with store size |
 | `AUDIT_RESPONSE_TIMEOUT` | Audit response deadline | `12s`                               |
-| `BOOTSTRAP_CLAIM_GRACE_PERIOD` | Max duration a peer may claim bootstrap status before penalties apply | `24h`                               |
+| `BOOTSTRAP_CLAIM_GRACE_PERIOD` | Max duration a peer may claim bootstrap status during its one allowed grace window before penalties apply | `24h`                               |
 | `PRUNE_HYSTERESIS_DURATION` | Minimum continuous out-of-range duration before pruning a key | `3 days`                            |
 
 Parameter safety constraints (MUST hold):
@@ -104,8 +104,8 @@ Parameter safety constraints (MUST hold):
 19. Storage-proof audits start only after `BootstrapDrained(self)` becomes true.
 20. Storage-proof audits target only peers derived from closest-peer lookups for sampled local keys, filtered through local authenticated routing state (`LocalRT(self)`), and further filtered to peers for which `RepairOpportunity` holds; random global peers and never-synced peers are never audited.
 21. Verification-request batching is mandatory for unknown-key neighbor-sync verification and preserves per-key quorum semantics: each key receives explicit per-key evidence, and missing/timeout evidence is unresolved per key.
-22. On every `NeighborSyncCycleComplete(self)`, node MUST run a prune pass using current `SelfInclusiveRT(self)`: for stored records where `IsResponsible(self, K)` is false, record `RecordOutOfRangeFirstSeen` if not already set and delete only when `now - RecordOutOfRangeFirstSeen >= PRUNE_HYSTERESIS_DURATION` and every currently-known `CloseGroup(K)` member returns a positive nonce-bound audit proof for the record. If any close-group peer does not prove storage, pruning is deferred and the retained local record continues participating in normal neighbor-sync repair. Prune-confirmation failures emit trust penalties after fresh responsibility confirmation; bootstrap claims use the same `BOOTSTRAP_CLAIM_GRACE_PERIOD` tracking before abuse penalties apply. Clear `RecordOutOfRangeFirstSeen` when back in range. For `PaidForList` entries where `self ∉ PaidCloseGroup(K)`, record `PaidOutOfRangeFirstSeen` if not already set and delete only when `now - PaidOutOfRangeFirstSeen >= PRUNE_HYSTERESIS_DURATION`; clear `PaidOutOfRangeFirstSeen` when back in range. The two timestamps are independent.
-23. Peers claiming bootstrap status are skipped for sync and audit without penalty for up to `BOOTSTRAP_CLAIM_GRACE_PERIOD` from first observation. After the grace period, each continued bootstrap claim emits `BootstrapClaimAbuse` evidence to `TrustEngine` (via `report_trust_event` with `ApplicationFailure(weight)`).
+22. On every `NeighborSyncCycleComplete(self)`, node MUST run a prune pass using current `SelfInclusiveRT(self)`: for stored records where `IsResponsible(self, K)` is false, record `RecordOutOfRangeFirstSeen` if not already set and delete only when `now - RecordOutOfRangeFirstSeen >= PRUNE_HYSTERESIS_DURATION` and every currently-known `CloseGroup(K)` member returns a positive nonce-bound audit proof for the record. If any close-group peer does not prove storage, pruning is deferred and the retained local record continues participating in normal neighbor-sync repair. Prune-confirmation failures emit trust penalties after fresh responsibility confirmation; first-time bootstrap claims use the same one-time `BOOTSTRAP_CLAIM_GRACE_PERIOD` tracking before abuse penalties apply. Clear `RecordOutOfRangeFirstSeen` when back in range. For `PaidForList` entries where `self ∉ PaidCloseGroup(K)`, record `PaidOutOfRangeFirstSeen` if not already set and delete only when `now - PaidOutOfRangeFirstSeen >= PRUNE_HYSTERESIS_DURATION`; clear `PaidOutOfRangeFirstSeen` when back in range. The two timestamps are independent.
+23. Peers claiming bootstrap status are skipped for sync and audit without penalty for up to `BOOTSTRAP_CLAIM_GRACE_PERIOD` from first observation. After the grace period, each continued bootstrap claim emits `BootstrapClaimAbuse` evidence to `TrustEngine` (via `report_trust_event` with `ApplicationFailure(weight)`). If a peer stops claiming bootstrap and later claims bootstrap again, the repeated claim emits `BootstrapClaimAbuse` immediately; the grace period is not reset.
 24. Audit trust-penalty signals require responsibility confirmation: on audit failure, challenger MUST perform fresh local RT closest-peer lookups for each challenged key and only penalize the peer for keys where it is confirmed responsible.
 
 ## 6. Replication
@@ -140,7 +140,7 @@ Rules:
    c. Stop when `|NeighborSyncSet(self)| = NEIGHBOR_SYNC_PEER_COUNT` or no unscanned peers remain in the snapshot.
 3. Node initiates sync with each peer in `NeighborSyncSet(self)`. If a peer cannot be synced, remove it from `NeighborSyncOrder(self)` and attempt to fill the vacated slot by resuming the scan from where rule 2 left off. A peer cannot be synced if:
    a. Unreachable (connection failure/timeout).
-   b. Peer responds with a bootstrapping claim. On first observation, record `BootstrapClaimFirstSeen(self, peer)`. If `now - BootstrapClaimFirstSeen(self, peer) <= BOOTSTRAP_CLAIM_GRACE_PERIOD`, accept the claim and skip without penalty. If the grace period has elapsed, emit `BootstrapClaimAbuse` evidence to `TrustEngine` (via `report_trust_event` with `ApplicationFailure(weight)`) and skip.
+   b. Peer responds with a bootstrapping claim. On first observation, record `BootstrapClaimFirstSeen(self, peer)`. If `now - BootstrapClaimFirstSeen(self, peer) <= BOOTSTRAP_CLAIM_GRACE_PERIOD`, accept the claim and skip without penalty. If the grace period has elapsed, emit `BootstrapClaimAbuse` evidence to `TrustEngine` (via `report_trust_event` with `ApplicationFailure(weight)`) and skip. If the peer had previously stopped claiming bootstrap, emit `BootstrapClaimAbuse` immediately for the repeated claim and skip.
 4. On any sync session open (outbound or inbound), receiver validates peer authentication and checks current local route membership (`peer ∈ LocalRT(self)`).
 5. If `peer ∈ LocalRT(self)`, sync is bidirectional: both sides send and receive peer-targeted hint sets.
 6. If `peer ∉ LocalRT(self)`, sync is outbound-only from receiver perspective: receiver MAY send hints to that peer, but MUST NOT accept replica or paid-list hints from that peer.
@@ -359,7 +359,7 @@ Post-cycle responsibility pruning (triggered by `NeighborSyncCycleComplete(self)
 
 1. For each locally stored key `K`, recompute `IsResponsible(self, K)` using current `SelfInclusiveRT(self)`:
    a. If in range: clear `RecordOutOfRangeFirstSeen(self, K)` (set to `None`).
-   b. If out of range: if `RecordOutOfRangeFirstSeen(self, K)` is `None`, set it to `now`. Once the hysteresis duration has elapsed, request a nonce-bound audit proof from every current `CloseGroup(K)` peer, subject to a bounded per-pass prune-confirmation budget. If any peer does not prove storage, defer pruning and emit trust penalties after fresh responsibility confirmation; valid bootstrap claims are penalized only after the bootstrap grace period. Delete the local record only when `now - RecordOutOfRangeFirstSeen(self, K) >= PRUNE_HYSTERESIS_DURATION` and every current close-group peer proves storage for `K`.
+   b. If out of range: if `RecordOutOfRangeFirstSeen(self, K)` is `None`, set it to `now`. Once the hysteresis duration has elapsed, request a nonce-bound audit proof from every current `CloseGroup(K)` peer, subject to a bounded per-pass prune-confirmation budget. If any peer does not prove storage, defer pruning and emit trust penalties after fresh responsibility confirmation; first-time bootstrap claims are penalized only after the bootstrap grace period, while repeated bootstrap claims are penalized immediately. Delete the local record only when `now - RecordOutOfRangeFirstSeen(self, K) >= PRUNE_HYSTERESIS_DURATION` and every current close-group peer proves storage for `K`.
 2. For each key `K` in `PaidForList(self)`, recompute `PaidCloseGroup(K)` membership using current `SelfInclusiveRT(self)`:
    a. If `self ∈ PaidCloseGroup(K)`: clear `PaidOutOfRangeFirstSeen(self, K)` (set to `None`).
    b. If `self ∉ PaidCloseGroup(K)`: if `PaidOutOfRangeFirstSeen(self, K)` is `None`, set it to `now`. Delete the entry only when `now - PaidOutOfRangeFirstSeen(self, K) >= PRUNE_HYSTERESIS_DURATION`.
@@ -420,7 +420,7 @@ Failure evidence types include:
 
 - `ReplicationFailure`: failed fetch attempt from a source peer.
 - `AuditFailure`: timeout, malformed response, or per-key `AuditKeyDigest` mismatch/absence (emitted per confirmed failed key).
-- `BootstrapClaimAbuse`: peer continues claiming bootstrap status after `BOOTSTRAP_CLAIM_GRACE_PERIOD` has elapsed since `BootstrapClaimFirstSeen`.
+- `BootstrapClaimAbuse`: peer continues claiming bootstrap status after `BOOTSTRAP_CLAIM_GRACE_PERIOD` has elapsed since `BootstrapClaimFirstSeen`, or claims bootstrap status again after previously stopping.
 
 Rules:
 
@@ -430,8 +430,8 @@ Rules:
 4. Replication SHOULD mark fetch-failure evidence as stale/low-confidence if the key later succeeds via an alternate verified source.
 5. On audit failure, replication MUST first run the responsibility confirmation (Section 15 step 9). If the confirmed failure set is non-empty, emit `AuditFailure` evidence with `challenge_id`, `challenged_peer_id`, confirmed failure keys, and failure reason. If the confirmed failure set is empty, no `AuditFailure` is emitted.
 6. Replication MUST emit a trust-penalty signal to `TrustEngine` (via `report_trust_event` with `ApplicationFailure(weight)`) for audit failure only when both conditions hold: the confirmed failure set from responsibility confirmation is non-empty (Section 15 step 9d) AND `RepairOpportunity(challenged_peer_id, confirmed_failure_keys)` is true.
-7. On bootstrap claim past grace period, replication MUST emit `BootstrapClaimAbuse` evidence with `peer_id` and `BootstrapClaimFirstSeen` timestamp. Evidence is emitted on each sync or audit attempt where the peer claims bootstrapping after `BOOTSTRAP_CLAIM_GRACE_PERIOD`.
-8. When a peer that previously claimed bootstrap status stops claiming it (responds normally to sync or audit), node MUST clear `BootstrapClaimFirstSeen(self, peer)`.
+7. On bootstrap claim past grace period, replication MUST emit `BootstrapClaimAbuse` evidence with `peer_id` and `BootstrapClaimFirstSeen` timestamp. Evidence is emitted on each sync or audit attempt where the peer claims bootstrapping after `BOOTSTRAP_CLAIM_GRACE_PERIOD`. A repeated bootstrap claim after the peer previously stopped claiming bootstrap also MUST emit `BootstrapClaimAbuse` immediately.
+8. When a peer that previously claimed bootstrap status stops claiming it (responds normally to sync or audit), node MUST clear the active bootstrap claim but MUST retain the first-seen history. The peer MUST NOT receive a second bootstrap grace window.
 9. Final trust-score updates and any eventual peer eviction are determined by `TrustEngine` / `AdaptiveDHT`, not by replication logic.
 
 ## 15. Storage Audit Protocol (Anti-Outsourcing)
@@ -446,7 +446,7 @@ Challenge-response for claimed holders:
 6. Challenger sends `challenged_peer_id` an ordered challenge key set equal to `PeerKeySet(challenged_peer_id)`.
 7. Target responds with either per-key `AuditKeyDigest` values or a bootstrapping claim:
     a. Per-key digests: for each challenged key `K_i` (in challenge order), target computes `AuditKeyDigest(K_i) = H(nonce || challenged_peer_id || K_i || record_bytes_i)`, where `record_bytes_i` is the full raw bytes of the record for `K_i`. Target returns the ordered list of per-key digests. If the target does not hold a challenged key, it MUST signal absence for that position (e.g., a sentinel/empty digest); it MUST NOT omit the position silently.
-    b. Bootstrapping claim: target asserts it is still bootstrapping. Challenger applies the bootstrap-claim grace logic (Section 6.2 rule 3b): record `BootstrapClaimFirstSeen` if first observation, accept without penalty within `BOOTSTRAP_CLAIM_GRACE_PERIOD`, emit `BootstrapClaimAbuse` evidence if past grace period. Audit tick ends (no digest verification).
+    b. Bootstrapping claim: target asserts it is still bootstrapping. Challenger applies the bootstrap-claim grace logic (Section 6.2 rule 3b): record `BootstrapClaimFirstSeen` if first observation, accept without penalty within the one-time `BOOTSTRAP_CLAIM_GRACE_PERIOD`, emit `BootstrapClaimAbuse` evidence if past grace period or if this is a repeated claim after the peer previously stopped claiming bootstrap. Audit tick ends (no digest verification).
 8. On per-key digest response, challenger recomputes the expected `AuditKeyDigest(K_i)` for each challenged key from local copies and verifies equality per key before deadline. Each key is independently classified as passed (digest matches) or failed (mismatch, absent, or malformed).
 9. On any per-key audit failures (timeout, malformed response, or one or more `AuditKeyDigest` mismatches/absences), challenger MUST perform a responsibility confirmation for each failed key before emitting penalty evidence:
     a. For each failed key `K` in `PeerKeySet(challenged_peer_id)`, perform a fresh local RT closest-peer lookup for `K`.
@@ -471,7 +471,7 @@ Audit challenge bound:
 Failure conditions:
 
 - Timeout, malformed response, or per-key `AuditKeyDigest` mismatch/absence — subject to responsibility confirmation (step 9) before penalty.
-- Bootstrapping claim past `BOOTSTRAP_CLAIM_GRACE_PERIOD` (emits `BootstrapClaimAbuse`, not `AuditFailure`).
+- Bootstrapping claim past `BOOTSTRAP_CLAIM_GRACE_PERIOD`, or repeated after the peer previously stopped claiming bootstrap (emits `BootstrapClaimAbuse`, not `AuditFailure`).
 
 Audit trigger and target selection:
 
@@ -605,7 +605,7 @@ Each scenario should assert exact expected outcomes and state transitions.
 35. Neighbor-sync round-robin batch selection with cooldown skip:
 - With more than `NEIGHBOR_SYNC_PEER_COUNT` eligible peers, consecutive rounds scan forward from cursor, skip and remove cooldown peers, and sync the next batch of up to `NEIGHBOR_SYNC_PEER_COUNT` non-cooldown peers. Cycle completes when all snapshot peers have been synced, skipped (cooldown), or removed (unreachable).
 36. Post-cycle responsibility pruning with time-based hysteresis:
-- When a full neighbor-sync round-robin cycle completes, node runs one prune pass using current `SelfInclusiveRT(self)` (`LocalRT(self) ∪ {self}`): stored keys with `IsResponsible(self, K)=false` have `RecordOutOfRangeFirstSeen` recorded (if not already set) but are deleted only when `now - RecordOutOfRangeFirstSeen >= PRUNE_HYSTERESIS_DURATION` and every current close-group peer returns a positive nonce-bound audit proof for the key. Missing or failed proofs defer pruning and emit trust penalties after fresh responsibility confirmation; valid bootstrap claims are penalized only after the bootstrap grace period. Prune-confirmation work is bounded per pass. Keys that are in range have their `RecordOutOfRangeFirstSeen` cleared. Same hysteresis timing applies independently to `PaidForList` entries where `self ∉ PaidCloseGroup(K)` using `PaidOutOfRangeFirstSeen`, but paid-list pruning does not require remote storage confirmation.
+- When a full neighbor-sync round-robin cycle completes, node runs one prune pass using current `SelfInclusiveRT(self)` (`LocalRT(self) ∪ {self}`): stored keys with `IsResponsible(self, K)=false` have `RecordOutOfRangeFirstSeen` recorded (if not already set) but are deleted only when `now - RecordOutOfRangeFirstSeen >= PRUNE_HYSTERESIS_DURATION` and every current close-group peer returns a positive nonce-bound audit proof for the key. Missing or failed proofs defer pruning and emit trust penalties after fresh responsibility confirmation; first-time bootstrap claims are penalized only after the bootstrap grace period, while repeated bootstrap claims are penalized immediately. Prune-confirmation work is bounded per pass. Keys that are in range have their `RecordOutOfRangeFirstSeen` cleared. Same hysteresis timing applies independently to `PaidForList` entries where `self ∉ PaidCloseGroup(K)` using `PaidOutOfRangeFirstSeen`, but paid-list pruning does not require remote storage confirmation.
 37. Non-`LocalRT` inbound sync behavior:
 - If a peer opens sync while not in receiver `LocalRT(self)`, receiver may still send hints to that peer, but receiver drops all inbound replica/paid hints from that peer.
 38. Neighbor-sync snapshot stability under peer join:
@@ -630,8 +630,8 @@ Each scenario should assert exact expected outcomes and state transitions.
 - Challenged peer responds with bootstrapping claim during audit. Node records `BootstrapClaimFirstSeen`. Audit tick ends without `AuditFailure`. No penalty emitted.
 48. Bootstrap claim abuse after grace period:
 - Peer `P` first claimed bootstrapping 25 hours ago (`> BOOTSTRAP_CLAIM_GRACE_PERIOD`). On next sync or audit attempt where `P` still claims bootstrapping, node emits `BootstrapClaimAbuse` evidence to `TrustEngine` (via `report_trust_event` with `ApplicationFailure(weight)`) with `peer_id` and `BootstrapClaimFirstSeen` timestamp.
-49. Bootstrap claim cleared on normal response:
-- Peer `P` previously claimed bootstrapping. `P` later responds normally to a sync or audit request. Node clears `BootstrapClaimFirstSeen(self, P)`. No residual penalty tracking.
+49. Bootstrap active claim cleared on normal response, with history retained:
+- Peer `P` previously claimed bootstrapping. `P` later responds normally to a sync or audit request. Node clears the active bootstrap claim but retains `BootstrapClaimFirstSeen(self, P)` history. If `P` later claims bootstrapping again, node emits `BootstrapClaimAbuse` immediately instead of granting a second grace period.
 50. Prune hysteresis prevents premature deletion:
 - Key `K` goes out of range at time `T`. `RecordOutOfRangeFirstSeen(self, K)` is set to `T`. Key is NOT deleted. At `T + 24h` (less than `PRUNE_HYSTERESIS_DURATION`), key is still retained. At `T + 3 days` (`>= PRUNE_HYSTERESIS_DURATION`), key is eligible for deletion on the next prune pass only if all current close-group peers return positive nonce-bound audit proofs.
 51. Prune hysteresis timestamp reset on partition heal:

--- a/src/replication/audit.rs
+++ b/src/replication/audit.rs
@@ -558,7 +558,7 @@ pub async fn handle_audit_challenge(
 mod tests {
     use super::*;
     use crate::replication::protocol::compute_audit_digest;
-    use crate::replication::types::NeighborSyncState;
+    use crate::replication::types::{BootstrapClaimObservation, NeighborSyncState};
     use crate::storage::LmdbStorageConfig;
     use tempfile::TempDir;
 
@@ -1354,11 +1354,23 @@ mod tests {
         let peer = PeerId::from_bytes([0x47; 32]);
         let mut state = NeighborSyncState::new_cycle(vec![peer]);
         let now = Instant::now();
-        state.bootstrap_claims.entry(peer).or_insert(now);
+        let observed = state.observe_bootstrap_claim(
+            peer,
+            now,
+            crate::replication::config::BOOTSTRAP_CLAIM_GRACE_PERIOD,
+        );
 
+        assert_eq!(
+            observed,
+            BootstrapClaimObservation::WithinGrace { first_seen: now }
+        );
         assert!(
             state.bootstrap_claims.contains_key(&peer),
             "BootstrapClaimFirstSeen should be recorded after grace-period claim"
+        );
+        assert!(
+            state.bootstrap_claim_history.contains_key(&peer),
+            "Bootstrap claim history should remember that the grace window was used"
         );
     }
 

--- a/src/replication/audit.rs
+++ b/src/replication/audit.rs
@@ -4,7 +4,6 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Instant;
 
 use crate::logging::{debug, info, warn};
 use rand::seq::SliceRandom;
@@ -68,7 +67,6 @@ pub async fn audit_tick(
     storage: &Arc<LmdbStorage>,
     config: &ReplicationConfig,
     sync_history: &HashMap<PeerId, PeerSyncRecord>,
-    bootstrap_claims: &HashMap<PeerId, Instant>,
     is_bootstrapping: bool,
 ) -> AuditTickResult {
     // Invariant 19: never audit while still bootstrapping.
@@ -77,22 +75,11 @@ pub async fn audit_tick(
     }
 
     let dht = p2p_node.dht_manager();
-    let now = Instant::now();
 
     // Step 2: Select one eligible peer (has RepairOpportunity) at random.
-    // Exclude peers whose bootstrap claim has exceeded the grace period —
-    // they are already penalized in handle_audit_result and should not
-    // consume an audit slot.
-    let eligible_peers: Vec<PeerId> = sync_history
-        .iter()
-        .filter(|(_, record)| record.has_repair_opportunity())
-        .filter(|(peer, _)| {
-            bootstrap_claims.get(peer).map_or(true, |first_seen| {
-                now.duration_since(*first_seen) <= config.bootstrap_claim_grace_period
-            })
-        })
-        .map(|(peer, _)| *peer)
-        .collect();
+    // Peers with active bootstrap claims remain eligible. A follow-up audit is
+    // how we observe a continued claim and apply past-grace abuse handling.
+    let eligible_peers = eligible_audit_peers(sync_history);
 
     if eligible_peers.is_empty() {
         return AuditTickResult::Idle;
@@ -302,6 +289,14 @@ pub async fn audit_tick(
             .await
         }
     }
+}
+
+fn eligible_audit_peers(sync_history: &HashMap<PeerId, PeerSyncRecord>) -> Vec<PeerId> {
+    sync_history
+        .iter()
+        .filter(|(_, record)| record.has_repair_opportunity())
+        .map(|(peer, _)| *peer)
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -560,6 +555,7 @@ mod tests {
     use crate::replication::protocol::compute_audit_digest;
     use crate::replication::types::{BootstrapClaimObservation, NeighborSyncState};
     use crate::storage::LmdbStorageConfig;
+    use std::time::Instant;
     use tempfile::TempDir;
 
     /// Simulated stored chunk count for tests. Large enough that the dynamic
@@ -1105,6 +1101,36 @@ mod tests {
             cycles_since_sync: 1,
         };
         assert!(synced_with_cycle.has_repair_opportunity());
+    }
+
+    #[test]
+    fn expired_bootstrap_claim_does_not_remove_peer_from_audit_eligibility() {
+        let peer = peer_id_from_bytes([0x57; 32]);
+        let mut sync_history = HashMap::new();
+        sync_history.insert(
+            peer,
+            PeerSyncRecord {
+                last_sync: Some(Instant::now()),
+                cycles_since_sync: 1,
+            },
+        );
+
+        let mut bootstrap_claims = HashMap::new();
+        let first_seen = Instant::now()
+            .checked_sub(
+                crate::replication::config::BOOTSTRAP_CLAIM_GRACE_PERIOD
+                    + std::time::Duration::from_secs(1),
+            )
+            .unwrap_or_else(Instant::now);
+        bootstrap_claims.insert(peer, first_seen);
+
+        let eligible = eligible_audit_peers(&sync_history);
+
+        assert!(bootstrap_claims.contains_key(&peer));
+        assert!(
+            eligible.contains(&peer),
+            "continued bootstrap claims must remain auditable so past-grace abuse can be observed"
+        );
     }
 
     // -- Audit response must match key count --------------------------------------

--- a/src/replication/config.rs
+++ b/src/replication/config.rs
@@ -116,7 +116,7 @@ pub const BOOTSTRAP_CLAIM_GRACE_PERIOD: Duration =
     Duration::from_secs(BOOTSTRAP_CLAIM_GRACE_PERIOD_SECS);
 
 /// Minimum continuous out-of-range duration before pruning a key.
-const PRUNE_HYSTERESIS_DURATION_SECS: u64 = 6 * 60 * 60; // 6 h
+const PRUNE_HYSTERESIS_DURATION_SECS: u64 = 3 * 24 * 60 * 60; // 3 days
 /// Minimum continuous out-of-range duration before pruning a key.
 pub const PRUNE_HYSTERESIS_DURATION: Duration = Duration::from_secs(PRUNE_HYSTERESIS_DURATION_SECS);
 
@@ -146,6 +146,9 @@ pub const PENDING_VERIFY_MAX_AGE: Duration = Duration::from_secs(PENDING_VERIFY_
 
 /// Trust event weight for confirmed audit failures.
 pub const AUDIT_FAILURE_TRUST_WEIGHT: f64 = 2.0;
+
+/// Maximum number of prune-confirmation audit challenges sent per prune pass.
+pub const MAX_PRUNE_AUDIT_CHALLENGES_PER_PASS: usize = 64;
 
 /// Seconds to wait for `DhtNetworkEvent::BootstrapComplete` before proceeding
 /// with bootstrap sync. Covers bootstrap nodes with no peers to connect to.
@@ -243,6 +246,12 @@ impl ReplicationConfig {
             return Err(format!(
                 "quorum_threshold ({}) must satisfy 1 <= quorum_threshold <= close_group_size ({})",
                 self.quorum_threshold, self.close_group_size,
+            ));
+        }
+        if self.close_group_size > MAX_PRUNE_AUDIT_CHALLENGES_PER_PASS {
+            return Err(format!(
+                "close_group_size ({}) must be <= MAX_PRUNE_AUDIT_CHALLENGES_PER_PASS ({})",
+                self.close_group_size, MAX_PRUNE_AUDIT_CHALLENGES_PER_PASS,
             ));
         }
         if self.paid_list_close_group_size == 0 {
@@ -387,6 +396,15 @@ mod tests {
     }
 
     #[test]
+    fn default_prune_hysteresis_is_three_days() {
+        let config = ReplicationConfig::default();
+        assert_eq!(
+            config.prune_hysteresis_duration,
+            Duration::from_secs(3 * 24 * 60 * 60)
+        );
+    }
+
+    #[test]
     fn quorum_threshold_zero_rejected() {
         let config = ReplicationConfig {
             quorum_threshold: 0,
@@ -412,6 +430,22 @@ mod tests {
             ..ReplicationConfig::default()
         };
         assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn close_group_size_exceeding_prune_audit_budget_rejected() {
+        let config = ReplicationConfig {
+            close_group_size: MAX_PRUNE_AUDIT_CHALLENGES_PER_PASS + 1,
+            quorum_threshold: QUORUM_THRESHOLD,
+            ..ReplicationConfig::default()
+        };
+
+        let err = config.validate().unwrap_err();
+
+        assert!(
+            err.contains("MAX_PRUNE_AUDIT_CHALLENGES_PER_PASS"),
+            "error should mention prune audit budget: {err}"
+        );
     }
 
     #[test]

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -1503,7 +1503,19 @@ async fn run_neighbor_sync_round(
     let cycle_complete = sync_state.read().await.is_cycle_complete();
     if cycle_complete {
         // Post-cycle pruning (Section 11) — runs without holding sync_state.
-        pruning::run_prune_pass(&self_id, storage, paid_list, p2p_node, config).await;
+        // Remote prune-confirmation audits are storage-proof audits and only
+        // run after bootstrap has drained.
+        let allow_remote_prune_audits = !bootstrapping && bootstrap_state.read().await.is_drained();
+        pruning::run_prune_pass(
+            &self_id,
+            storage,
+            paid_list,
+            p2p_node,
+            config,
+            sync_state,
+            allow_remote_prune_audits,
+        )
+        .await;
 
         // Increment `cycles_since_sync` for all peers.
         {
@@ -1526,9 +1538,11 @@ async fn run_neighbor_sync_round(
             // would reset the abuse detection timer every cycle.
             let old_sync_times = std::mem::take(&mut state.last_sync_times);
             let old_bootstrap_claims = std::mem::take(&mut state.bootstrap_claims);
+            let old_prune_cursor = state.prune_cursor;
             *state = NeighborSyncState::new_cycle(neighbors);
             state.last_sync_times = old_sync_times;
             state.bootstrap_claims = old_bootstrap_claims;
+            state.prune_cursor = old_prune_cursor;
         }
     }
 

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -58,8 +58,8 @@ use crate::replication::protocol::{
 use crate::replication::quorum::KeyVerificationOutcome;
 use crate::replication::scheduling::ReplicationQueues;
 use crate::replication::types::{
-    BootstrapClaimObservation, BootstrapState, FailureEvidence, HintPipeline, NeighborSyncState,
-    PeerSyncRecord, VerificationEntry, VerificationState,
+    AuditFailureReason, BootstrapClaimObservation, BootstrapState, FailureEvidence, HintPipeline,
+    NeighborSyncState, PeerSyncRecord, VerificationEntry, VerificationState,
 };
 use crate::storage::LmdbStorage;
 use saorsa_core::identity::PeerId;
@@ -518,20 +518,9 @@ impl ReplicationEngine {
             // Run one audit tick immediately after bootstrap drain.
             {
                 let bootstrapping = *is_bootstrapping.read().await;
-                // Lock ordering: sync_state before sync_history (consistent
-                // with run_neighbor_sync_round and handle_sync_response).
                 let result = {
-                    let claims = sync_state.read().await;
                     let history = sync_history.read().await;
-                    audit::audit_tick(
-                        &p2p,
-                        &storage,
-                        &config,
-                        &history,
-                        &claims.bootstrap_claims,
-                        bootstrapping,
-                    )
-                    .await
+                    audit::audit_tick(&p2p, &storage, &config, &history, bootstrapping).await
                 };
                 handle_audit_result(&result, &p2p, &sync_state, &config).await;
             }
@@ -543,13 +532,13 @@ impl ReplicationEngine {
                     () = shutdown.cancelled() => break,
                     () = tokio::time::sleep(interval) => {
                         let bootstrapping = *is_bootstrapping.read().await;
-                        // Lock ordering: sync_state before sync_history.
                         let result = {
-                            let claims = sync_state.read().await;
                             let history = sync_history.read().await;
                             audit::audit_tick(
-                                &p2p, &storage, &config, &history,
-                                &claims.bootstrap_claims,
+                                &p2p,
+                                &storage,
+                                &config,
+                                &history,
                                 bootstrapping,
                             )
                             .await
@@ -2236,6 +2225,7 @@ async fn handle_audit_result(
             if let FailureEvidence::AuditFailure {
                 challenged_peer,
                 confirmed_failed_keys,
+                reason,
                 ..
             } = evidence
             {
@@ -2243,11 +2233,13 @@ async fn handle_audit_result(
                     "Audit failure for {challenged_peer}: {} confirmed failed keys",
                     confirmed_failed_keys.len()
                 );
-                // Peer responded with digests (not a bootstrap claim) — clear
-                // the active claim while retaining claim history.
-                {
+                if audit_failure_clears_bootstrap_claim(reason) {
+                    // Peer returned a non-bootstrap response — clear the active
+                    // claim while retaining claim history.
                     let mut state = sync_state.write().await;
                     state.clear_active_bootstrap_claim(challenged_peer);
+                } else {
+                    debug!("Audit timeout for {challenged_peer}; retaining active bootstrap claim");
                 }
                 p2p_node
                     .report_trust_event(
@@ -2302,4 +2294,37 @@ async fn handle_audit_result(
     }
 }
 
+fn audit_failure_clears_bootstrap_claim(reason: &AuditFailureReason) -> bool {
+    !matches!(reason, AuditFailureReason::Timeout)
+}
+
 // `admit_bootstrap_hints` was consolidated into `admit_and_queue_hints`.
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::audit_failure_clears_bootstrap_claim;
+    use crate::replication::types::AuditFailureReason;
+
+    #[test]
+    fn audit_timeout_preserves_active_bootstrap_claim() {
+        assert!(!audit_failure_clears_bootstrap_claim(
+            &AuditFailureReason::Timeout
+        ));
+    }
+
+    #[test]
+    fn decoded_audit_failures_clear_active_bootstrap_claim() {
+        for reason in [
+            AuditFailureReason::MalformedResponse,
+            AuditFailureReason::DigestMismatch,
+            AuditFailureReason::KeyAbsent,
+            AuditFailureReason::Rejected,
+        ] {
+            assert!(
+                audit_failure_clears_bootstrap_claim(&reason),
+                "decoded non-bootstrap failure {reason:?} should clear active claim"
+            );
+        }
+    }
+}

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -58,8 +58,8 @@ use crate::replication::protocol::{
 use crate::replication::quorum::KeyVerificationOutcome;
 use crate::replication::scheduling::ReplicationQueues;
 use crate::replication::types::{
-    BootstrapState, FailureEvidence, HintPipeline, NeighborSyncState, PeerSyncRecord,
-    VerificationEntry, VerificationState,
+    BootstrapClaimObservation, BootstrapState, FailureEvidence, HintPipeline, NeighborSyncState,
+    PeerSyncRecord, VerificationEntry, VerificationState,
 };
 use crate::storage::LmdbStorage;
 use saorsa_core::identity::PeerId;
@@ -1533,15 +1533,17 @@ async fn run_neighbor_sync_round(
         // Now re-acquire write lock and re-check before swapping cycle.
         let mut state = sync_state.write().await;
         if state.is_cycle_complete() {
-            // Preserve last_sync_times and bootstrap_claims across cycles.
+            // Preserve cooldown and bootstrap-claim tracking across cycles.
             // Claims have a 24h lifecycle vs 10-20 min cycles — dropping them
             // would reset the abuse detection timer every cycle.
             let old_sync_times = std::mem::take(&mut state.last_sync_times);
             let old_bootstrap_claims = std::mem::take(&mut state.bootstrap_claims);
+            let old_bootstrap_claim_history = std::mem::take(&mut state.bootstrap_claim_history);
             let old_prune_cursor = state.prune_cursor;
             *state = NeighborSyncState::new_cycle(neighbors);
             state.last_sync_times = old_sync_times;
             state.bootstrap_claims = old_bootstrap_claims;
+            state.bootstrap_claim_history = old_bootstrap_claim_history;
             state.prune_cursor = old_prune_cursor;
         }
     }
@@ -1671,17 +1673,25 @@ async fn handle_sync_response(
         let should_report = {
             let now = Instant::now();
             let mut state = sync_state.write().await;
-            let first_seen = state.bootstrap_claims.entry(*peer).or_insert(now);
-            let claim_age = now.duration_since(*first_seen);
-            if claim_age > config.bootstrap_claim_grace_period {
-                warn!(
-                    "Peer {peer} has been claiming bootstrap for {:?}, \
-                     exceeding grace period of {:?} — reporting abuse",
-                    claim_age, config.bootstrap_claim_grace_period,
-                );
-                true
-            } else {
-                false
+            match state.observe_bootstrap_claim(*peer, now, config.bootstrap_claim_grace_period) {
+                BootstrapClaimObservation::WithinGrace { .. } => false,
+                BootstrapClaimObservation::PastGrace { first_seen } => {
+                    warn!(
+                        "Peer {peer} has been claiming bootstrap for {:?}, \
+                         exceeding grace period of {:?} — reporting abuse",
+                        now.duration_since(first_seen),
+                        config.bootstrap_claim_grace_period,
+                    );
+                    true
+                }
+                BootstrapClaimObservation::Repeated { first_seen } => {
+                    warn!(
+                        "Peer {peer} repeated bootstrap claim after previously stopping; \
+                         first claim was {:?} ago — reporting abuse",
+                        now.duration_since(first_seen),
+                    );
+                    true
+                }
             }
         };
         if should_report {
@@ -1693,10 +1703,11 @@ async fn handle_sync_response(
                 .await;
         }
     } else {
-        // Peer is not claiming bootstrap; clear any prior claim.
+        // Peer is not claiming bootstrap; clear active claim while retaining
+        // history so the peer cannot start a second grace window later.
         {
             let mut state = sync_state.write().await;
-            state.bootstrap_claims.remove(peer);
+            state.clear_active_bootstrap_claim(peer);
         }
         let admitted_keys = admit_and_queue_hints(
             self_id,
@@ -2208,11 +2219,11 @@ async fn handle_audit_result(
             keys_checked,
         } => {
             debug!("Audit passed for {challenged_peer} ({keys_checked} keys)");
-            // Peer responded normally — clear any stale bootstrap claim so
-            // a future legitimate bootstrap claim starts with a fresh timer.
+            // Peer responded normally — clear the active bootstrap claim while
+            // retaining history so a later claim is treated as repeated abuse.
             {
                 let mut state = sync_state.write().await;
-                state.bootstrap_claims.remove(challenged_peer);
+                state.clear_active_bootstrap_claim(challenged_peer);
             }
             p2p_node
                 .report_trust_event(
@@ -2233,10 +2244,10 @@ async fn handle_audit_result(
                     confirmed_failed_keys.len()
                 );
                 // Peer responded with digests (not a bootstrap claim) — clear
-                // any stale bootstrap claim timestamp.
+                // the active claim while retaining claim history.
                 {
                     let mut state = sync_state.write().await;
-                    state.bootstrap_claims.remove(challenged_peer);
+                    state.clear_active_bootstrap_claim(challenged_peer);
                 }
                 p2p_node
                     .report_trust_event(
@@ -2253,18 +2264,29 @@ async fn handle_audit_result(
             let should_report = {
                 let now = Instant::now();
                 let mut state = sync_state.write().await;
-                let first_seen = state.bootstrap_claims.entry(*peer).or_insert(now);
-                let claim_age = now.duration_since(*first_seen);
-                if claim_age > config.bootstrap_claim_grace_period {
-                    warn!(
-                        "Audit: peer {peer} claiming bootstrap past grace period \
-                         ({:?} > {:?}), reporting abuse",
-                        claim_age, config.bootstrap_claim_grace_period,
-                    );
-                    true
-                } else {
-                    debug!("Audit: peer {peer} claims bootstrapping (within grace period)");
-                    false
+                match state.observe_bootstrap_claim(*peer, now, config.bootstrap_claim_grace_period)
+                {
+                    BootstrapClaimObservation::WithinGrace { .. } => {
+                        debug!("Audit: peer {peer} claims bootstrapping (within grace period)");
+                        false
+                    }
+                    BootstrapClaimObservation::PastGrace { first_seen } => {
+                        warn!(
+                            "Audit: peer {peer} claiming bootstrap past grace period \
+                             ({:?} > {:?}), reporting abuse",
+                            now.duration_since(first_seen),
+                            config.bootstrap_claim_grace_period,
+                        );
+                        true
+                    }
+                    BootstrapClaimObservation::Repeated { first_seen } => {
+                        warn!(
+                            "Audit: peer {peer} repeated bootstrap claim after previously \
+                             stopping; first claim was {:?} ago, reporting abuse",
+                            now.duration_since(first_seen),
+                        );
+                        true
+                    }
                 }
             };
             if should_report {

--- a/src/replication/neighbor_sync.rs
+++ b/src/replication/neighbor_sync.rs
@@ -24,6 +24,11 @@ use crate::storage::LmdbStorage;
 ///
 /// Returns keys that we believe the peer should hold (peer is among the
 /// `CLOSE_GROUP_SIZE` nearest to `K` in our `SelfInclusiveRT`).
+///
+/// This intentionally scans all locally stored records, not only records for
+/// which this node is still responsible. Out-of-range records retained by
+/// prune hysteresis therefore continue to repair their new close group before
+/// this node is allowed to delete them.
 pub async fn build_replica_hints_for_peer(
     peer: &PeerId,
     storage: &Arc<LmdbStorage>,

--- a/src/replication/paid_list.rs
+++ b/src/replication/paid_list.rs
@@ -394,7 +394,9 @@ impl PaidList {
 mod tests {
     use super::*;
     use crate::replication::config::{BOOTSTRAP_CLAIM_GRACE_PERIOD, PRUNE_HYSTERESIS_DURATION};
-    use crate::replication::types::{FailureEvidence, NeighborSyncState};
+    use crate::replication::types::{
+        BootstrapClaimObservation, FailureEvidence, NeighborSyncState,
+    };
     use saorsa_core::identity::PeerId;
     use tempfile::TempDir;
 
@@ -824,11 +826,16 @@ mod tests {
         let peer = PeerId::from_bytes([0x46; 32]);
         let mut state = NeighborSyncState::new_cycle(vec![peer]);
 
-        // Insert a first-seen timestamp.
         let first_ts = Instant::now()
             .checked_sub(std::time::Duration::from_secs(3))
             .unwrap_or_else(Instant::now);
-        state.bootstrap_claims.insert(peer, first_ts);
+        let observed = state.observe_bootstrap_claim(peer, first_ts, BOOTSTRAP_CLAIM_GRACE_PERIOD);
+        assert_eq!(
+            observed,
+            BootstrapClaimObservation::WithinGrace {
+                first_seen: first_ts
+            }
+        );
 
         // Verify recorded.
         assert_eq!(
@@ -836,10 +843,22 @@ mod tests {
             Some(&first_ts),
             "first-seen timestamp should be recorded"
         );
+        assert_eq!(
+            state.bootstrap_claim_history.get(&peer),
+            Some(&first_ts),
+            "first-ever timestamp should be retained"
+        );
 
-        // Insert again — must NOT overwrite (first-observation-wins).
+        // Observe again while still active — must NOT overwrite
+        // (first-observation-wins).
         let later_ts = Instant::now();
-        state.bootstrap_claims.entry(peer).or_insert(later_ts);
+        let observed = state.observe_bootstrap_claim(peer, later_ts, BOOTSTRAP_CLAIM_GRACE_PERIOD);
+        assert_eq!(
+            observed,
+            BootstrapClaimObservation::WithinGrace {
+                first_seen: first_ts
+            }
+        );
         assert_eq!(
             state.bootstrap_claims.get(&peer),
             Some(&first_ts),
@@ -866,6 +885,7 @@ mod tests {
             .checked_sub(grace_plus_margin)
             .unwrap_or_else(Instant::now);
         state.bootstrap_claims.insert(peer, first_seen);
+        state.bootstrap_claim_history.insert(peer, first_seen);
 
         // On platforms that support the backdated instant, verify claim age.
         let claim_age = Instant::now().duration_since(first_seen);
@@ -897,17 +917,30 @@ mod tests {
         let mut state = NeighborSyncState::new_cycle(vec![peer]);
 
         // Record a bootstrap claim.
-        state.bootstrap_claims.insert(peer, Instant::now());
+        let first_seen = Instant::now();
+        let _ = state.observe_bootstrap_claim(peer, first_seen, BOOTSTRAP_CLAIM_GRACE_PERIOD);
         assert!(
             state.bootstrap_claims.contains_key(&peer),
             "claim should exist after insert"
         );
 
-        // Peer responded normally — clear the claim.
-        state.bootstrap_claims.remove(&peer);
+        // Peer responded normally — clear only the active claim.
+        state.clear_active_bootstrap_claim(&peer);
         assert!(
             !state.bootstrap_claims.contains_key(&peer),
             "claim should be gone after normal response"
+        );
+        assert!(
+            state.bootstrap_claim_history.contains_key(&peer),
+            "claim history should remain so the peer cannot claim bootstrapping again"
+        );
+
+        let repeated =
+            state.observe_bootstrap_claim(peer, Instant::now(), BOOTSTRAP_CLAIM_GRACE_PERIOD);
+        assert_eq!(
+            repeated,
+            BootstrapClaimObservation::Repeated { first_seen },
+            "a second bootstrap claim should be classified as repeated abuse"
         );
     }
 }

--- a/src/replication/pruning.rs
+++ b/src/replication/pruning.rs
@@ -536,30 +536,35 @@ async fn peer_proves_record(
     let encoded = encode_prune_audit_challenge(&peer, key, challenge_id, nonce)?;
     let Some(decoded) = send_prune_audit_challenge(&peer, &key, encoded, p2p_node, config).await
     else {
-        let reported =
-            report_prune_audit_failure_once(&peer, &key, p2p_node, config, report_state).await;
-        if reported {
-            clear_prune_bootstrap_claim(&peer, sync_state).await;
-        }
+        // No decoded response means we did not observe the peer stop claiming
+        // bootstrap status. Preserve any active claim so a later claim is not
+        // misclassified as repeated abuse.
+        report_prune_audit_failure_once(&peer, &key, p2p_node, config, report_state).await;
         return None;
     };
 
-    match prune_audit_response_status(decoded, challenge_id, &peer, &key, &nonce, &local_bytes) {
-        PruneAuditStatus::Proven => {
-            clear_prune_bootstrap_claim(&peer, sync_state).await;
-            Some((peer, key))
-        }
+    let status =
+        prune_audit_response_status(decoded, challenge_id, &peer, &key, &nonce, &local_bytes);
+    if prune_audit_response_clears_bootstrap_claim(status) {
+        clear_prune_bootstrap_claim(&peer, sync_state).await;
+    }
+
+    match status {
+        PruneAuditStatus::Proven => Some((peer, key)),
         PruneAuditStatus::Bootstrapping => {
             report_prune_bootstrap_claim(&peer, &key, p2p_node, config, sync_state, report_state)
                 .await;
             None
         }
         PruneAuditStatus::Failed => {
-            clear_prune_bootstrap_claim(&peer, sync_state).await;
             report_prune_audit_failure_once(&peer, &key, p2p_node, config, report_state).await;
             None
         }
     }
+}
+
+fn prune_audit_response_clears_bootstrap_claim(status: PruneAuditStatus) -> bool {
+    matches!(status, PruneAuditStatus::Proven | PruneAuditStatus::Failed)
 }
 
 fn encode_prune_audit_challenge(
@@ -1012,6 +1017,19 @@ mod tests {
         let state = state.read().await;
         assert!(!state.bootstrap_claims.contains_key(&peer));
         assert!(state.bootstrap_claim_history.contains_key(&peer));
+    }
+
+    #[test]
+    fn prune_audit_clear_policy_requires_decoded_non_bootstrap_response() {
+        assert!(prune_audit_response_clears_bootstrap_claim(
+            PruneAuditStatus::Proven
+        ));
+        assert!(prune_audit_response_clears_bootstrap_claim(
+            PruneAuditStatus::Failed
+        ));
+        assert!(!prune_audit_response_clears_bootstrap_claim(
+            PruneAuditStatus::Bootstrapping
+        ));
     }
 
     #[tokio::test]

--- a/src/replication/pruning.rs
+++ b/src/replication/pruning.rs
@@ -4,17 +4,34 @@
 //! entries that have been continuously out of range for at least
 //! `PRUNE_HYSTERESIS_DURATION`.
 
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::logging::{debug, info, warn};
 
+use futures::{stream, StreamExt};
+use rand::Rng;
 use saorsa_core::identity::PeerId;
 use saorsa_core::{DHTNode, P2PNode};
+use tokio::sync::RwLock;
 
-use crate::replication::config::ReplicationConfig;
+use crate::ant_protocol::XorName;
+use crate::replication::config::{
+    ReplicationConfig, AUDIT_FAILURE_TRUST_WEIGHT, MAX_PRUNE_AUDIT_CHALLENGES_PER_PASS,
+    REPLICATION_PROTOCOL_ID,
+};
 use crate::replication::paid_list::PaidList;
+use crate::replication::protocol::{
+    compute_audit_digest, AuditChallenge, AuditResponse, ReplicationMessage,
+    ReplicationMessageBody, ABSENT_KEY_DIGEST,
+};
+use crate::replication::types::NeighborSyncState;
 use crate::storage::LmdbStorage;
+
+use super::REPLICATION_TRUST_WEIGHT;
+
+const MAX_CONCURRENT_PRUNE_AUDIT_CHALLENGES: usize = 32;
 
 // ---------------------------------------------------------------------------
 // Result type
@@ -37,6 +54,39 @@ pub struct PruneResult {
     pub paid_entries_cleared: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PruneAuditStatus {
+    Proven,
+    Failed,
+    Bootstrapping,
+}
+
+#[derive(Debug, Default)]
+struct RecordPruneStats {
+    marked: usize,
+    cleared: usize,
+    pruned: usize,
+}
+
+#[derive(Debug, Default)]
+struct PaidPruneStats {
+    marked: usize,
+    cleared: usize,
+    pruned: usize,
+}
+
+#[derive(Debug, Clone)]
+struct RecordPruneCandidate {
+    key: XorName,
+    target_peers: Vec<PeerId>,
+}
+
+#[derive(Default)]
+struct PruneAuditReportState {
+    audit_failures: RwLock<HashSet<PeerId>>,
+    bootstrap_abuse: RwLock<HashSet<PeerId>>,
+}
+
 // ---------------------------------------------------------------------------
 // Prune pass
 // ---------------------------------------------------------------------------
@@ -46,7 +96,8 @@ pub struct PruneResult {
 /// For each stored record K:
 /// - If `IsResponsible(self, K)`: clear `RecordOutOfRangeFirstSeen`.
 /// - If not responsible: set timestamp if not already set; delete if the
-///   timestamp is at least `PRUNE_HYSTERESIS_DURATION` old.
+///   timestamp is at least `PRUNE_HYSTERESIS_DURATION` old and the current
+///   close group proves it stores the record.
 ///
 /// For each `PaidForList` entry K:
 /// - If self is in `PaidCloseGroup(K)`: clear `PaidOutOfRangeFirstSeen`.
@@ -58,24 +109,69 @@ pub async fn run_prune_pass(
     paid_list: &Arc<PaidList>,
     p2p_node: &Arc<P2PNode>,
     config: &ReplicationConfig,
+    sync_state: &Arc<RwLock<NeighborSyncState>>,
+    allow_remote_prune_audits: bool,
 ) -> PruneResult {
-    let dht = p2p_node.dht_manager();
-    let mut result = PruneResult::default();
+    let (stored_count, record_stats) = prune_stored_records(
+        self_id,
+        storage,
+        paid_list,
+        p2p_node,
+        config,
+        sync_state,
+        allow_remote_prune_audits,
+    )
+    .await;
     let now = Instant::now();
+    let (paid_count, paid_stats) =
+        prune_paid_entries(self_id, paid_list, p2p_node, config, now).await;
 
-    // -- Prune stored records ---------------------------------------------
+    let result = PruneResult {
+        records_pruned: record_stats.pruned,
+        records_marked_out_of_range: record_stats.marked,
+        records_cleared: record_stats.cleared,
+        paid_entries_pruned: paid_stats.pruned,
+        paid_entries_marked: paid_stats.marked,
+        paid_entries_cleared: paid_stats.cleared,
+    };
 
+    info!(
+        "Prune pass complete: records={}/{} pruned, paid={}/{} pruned",
+        result.records_pruned, stored_count, result.paid_entries_pruned, paid_count,
+    );
+
+    result
+}
+
+async fn prune_stored_records(
+    self_id: &PeerId,
+    storage: &Arc<LmdbStorage>,
+    paid_list: &Arc<PaidList>,
+    p2p_node: &Arc<P2PNode>,
+    config: &ReplicationConfig,
+    sync_state: &Arc<RwLock<NeighborSyncState>>,
+    allow_remote_prune_audits: bool,
+) -> (usize, RecordPruneStats) {
     let stored_keys = match storage.all_keys().await {
         Ok(keys) => keys,
         Err(e) => {
             warn!("Failed to read stored keys for pruning: {e}");
-            return result;
+            return (0, RecordPruneStats::default());
         }
     };
 
-    let mut keys_to_delete = Vec::new();
+    let now = Instant::now();
+    let dht = p2p_node.dht_manager();
+    let mut stats = RecordPruneStats::default();
+    let mut candidates = Vec::new();
+    let mut audit_challenge_budget = MAX_PRUNE_AUDIT_CHALLENGES_PER_PASS;
+    let mut budget_deferred = 0usize;
+    let mut bootstrap_deferred = 0usize;
+    let scan_start = prune_scan_start(sync_state, stored_keys.len()).await;
+    let mut last_selected_offset = None;
 
-    for key in &stored_keys {
+    for offset in 0..stored_keys.len() {
+        let key = &stored_keys[(scan_start + offset) % stored_keys.len()];
         let closest: Vec<DHTNode> = dht
             .find_closest_nodes_local_with_self(key, config.close_group_size)
             .await;
@@ -84,11 +180,11 @@ pub async fn run_prune_pass(
         if is_responsible {
             if paid_list.record_out_of_range_since(key).is_some() {
                 paid_list.clear_record_out_of_range(key);
-                result.records_cleared += 1;
+                stats.cleared += 1;
             }
         } else {
             if paid_list.record_out_of_range_since(key).is_none() {
-                result.records_marked_out_of_range += 1;
+                stats.marked += 1;
             }
             paid_list.set_record_out_of_range(key);
 
@@ -97,36 +193,89 @@ pub async fn run_prune_pass(
                     .checked_duration_since(first_seen)
                     .unwrap_or(Duration::ZERO);
                 if elapsed >= config.prune_hysteresis_duration {
-                    keys_to_delete.push(*key);
+                    if !allow_remote_prune_audits {
+                        bootstrap_deferred = bootstrap_deferred.saturating_add(1);
+                        continue;
+                    }
+                    let target_peers = remote_close_group_peers(&closest, self_id);
+                    if target_peers.is_empty() {
+                        warn!(
+                            "Cannot prune {}: current close group has no remote peers",
+                            hex::encode(key)
+                        );
+                        continue;
+                    }
+                    if target_peers.len() > audit_challenge_budget {
+                        budget_deferred = budget_deferred.saturating_add(1);
+                        continue;
+                    }
+                    audit_challenge_budget -= target_peers.len();
+                    last_selected_offset = Some(offset);
+                    candidates.push(RecordPruneCandidate {
+                        key: *key,
+                        target_peers,
+                    });
                 }
             }
         }
     }
 
-    for key in &keys_to_delete {
-        if let Err(e) = storage.delete(key).await {
-            warn!("Failed to prune record {}: {e}", hex::encode(key));
-        } else {
-            result.records_pruned += 1;
-            paid_list.clear_record_out_of_range(key);
-            // Seed the PaidForList out-of-range timer so the second pass can
-            // prune the entry sooner, closing the re-admission window between
-            // the storage delete and the PaidForList prune pass.
-            paid_list.set_paid_out_of_range(key);
-            debug!("Pruned out-of-range record {}", hex::encode(key));
-        }
+    advance_prune_cursor(
+        sync_state,
+        stored_keys.len(),
+        scan_start,
+        last_selected_offset,
+    )
+    .await;
+
+    if bootstrap_deferred > 0 {
+        debug!(
+            "Deferred {bootstrap_deferred} prune candidates until bootstrap drain allows \
+             remote prune-confirmation audits"
+        );
     }
 
-    // -- Prune PaidForList entries -----------------------------------------
+    if budget_deferred > 0 {
+        debug!(
+            "Deferred {budget_deferred} prune candidates due to per-pass audit budget \
+             ({MAX_PRUNE_AUDIT_CHALLENGES_PER_PASS} challenges)"
+        );
+    }
 
+    let present_by_key =
+        collect_record_prune_proofs(&candidates, storage, p2p_node, config, sync_state).await;
+    let (keys_to_delete, revalidated_cleared) = revalidated_record_prune_keys(
+        &candidates,
+        &present_by_key,
+        self_id,
+        paid_list,
+        p2p_node,
+        config,
+    )
+    .await;
+    stats.cleared += revalidated_cleared;
+    stats.pruned = delete_stored_records(&keys_to_delete, storage, paid_list).await;
+
+    (stored_keys.len(), stats)
+}
+
+async fn prune_paid_entries(
+    self_id: &PeerId,
+    paid_list: &Arc<PaidList>,
+    p2p_node: &Arc<P2PNode>,
+    config: &ReplicationConfig,
+    now: Instant,
+) -> (usize, PaidPruneStats) {
     let paid_keys = match paid_list.all_keys() {
         Ok(keys) => keys,
         Err(e) => {
             warn!("Failed to read PaidForList for pruning: {e}");
-            return result;
+            return (0, PaidPruneStats::default());
         }
     };
 
+    let dht = p2p_node.dht_manager();
+    let mut stats = PaidPruneStats::default();
     let mut paid_keys_to_delete = Vec::new();
 
     for key in &paid_keys {
@@ -138,11 +287,11 @@ pub async fn run_prune_pass(
         if in_paid_group {
             if paid_list.paid_out_of_range_since(key).is_some() {
                 paid_list.clear_paid_out_of_range(key);
-                result.paid_entries_cleared += 1;
+                stats.cleared += 1;
             }
         } else {
             if paid_list.paid_out_of_range_since(key).is_none() {
-                result.paid_entries_marked += 1;
+                stats.marked += 1;
             }
             paid_list.set_paid_out_of_range(key);
 
@@ -160,7 +309,7 @@ pub async fn run_prune_pass(
     if !paid_keys_to_delete.is_empty() {
         match paid_list.remove_batch(&paid_keys_to_delete).await {
             Ok(count) => {
-                result.paid_entries_pruned = count;
+                stats.pruned = count;
                 debug!("Pruned {count} out-of-range PaidForList entries");
             }
             Err(e) => {
@@ -169,13 +318,709 @@ pub async fn run_prune_pass(
         }
     }
 
-    info!(
-        "Prune pass complete: records={}/{} pruned, paid={}/{} pruned",
-        result.records_pruned,
-        stored_keys.len(),
-        result.paid_entries_pruned,
-        paid_keys.len(),
-    );
+    (paid_keys.len(), stats)
+}
 
-    result
+fn remote_close_group_peers(close_group: &[DHTNode], self_id: &PeerId) -> Vec<PeerId> {
+    close_group
+        .iter()
+        .filter(|node| node.peer_id != *self_id)
+        .map(|node| node.peer_id)
+        .collect()
+}
+
+async fn prune_scan_start(
+    sync_state: &Arc<RwLock<NeighborSyncState>>,
+    stored_key_count: usize,
+) -> usize {
+    if stored_key_count == 0 {
+        return 0;
+    }
+    sync_state.read().await.prune_cursor % stored_key_count
+}
+
+async fn advance_prune_cursor(
+    sync_state: &Arc<RwLock<NeighborSyncState>>,
+    stored_key_count: usize,
+    scan_start: usize,
+    last_selected_offset: Option<usize>,
+) {
+    if stored_key_count == 0 {
+        sync_state.write().await.prune_cursor = 0;
+        return;
+    }
+
+    let advance_by = last_selected_offset.map_or(1, |offset| offset.saturating_add(1));
+    sync_state.write().await.prune_cursor = (scan_start + advance_by) % stored_key_count;
+}
+
+async fn delete_stored_records(
+    keys_to_delete: &[XorName],
+    storage: &Arc<LmdbStorage>,
+    paid_list: &Arc<PaidList>,
+) -> usize {
+    let mut pruned = 0;
+
+    for key in keys_to_delete {
+        if let Err(e) = storage.delete(key).await {
+            warn!("Failed to prune record {}: {e}", hex::encode(key));
+        } else {
+            pruned += 1;
+            paid_list.clear_record_out_of_range(key);
+            // Seed the PaidForList out-of-range timer so the second pass can
+            // prune the entry sooner, closing the re-admission window between
+            // the storage delete and the PaidForList prune pass.
+            paid_list.set_paid_out_of_range(key);
+            debug!("Pruned out-of-range record {}", hex::encode(key));
+        }
+    }
+
+    pruned
+}
+
+/// Collect positive presence reports for prune candidates.
+///
+/// Peers that fail to prove storage block pruning for their keys. The
+/// retained local record continues to participate in normal neighbor-sync
+/// repair because replica hint construction walks all locally stored keys,
+/// including out-of-range keys retained by hysteresis.
+async fn collect_record_prune_proofs(
+    candidates: &[RecordPruneCandidate],
+    storage: &Arc<LmdbStorage>,
+    p2p_node: &Arc<P2PNode>,
+    config: &ReplicationConfig,
+    sync_state: &Arc<RwLock<NeighborSyncState>>,
+) -> HashMap<XorName, HashSet<PeerId>> {
+    if candidates.is_empty() {
+        return HashMap::new();
+    }
+
+    let report_state = PruneAuditReportState::default();
+    let mut requests = stream::iter(build_peer_audit_challenges(candidates))
+        .map(|(peer, key)| {
+            peer_proves_record(
+                peer,
+                key,
+                storage,
+                p2p_node,
+                config,
+                sync_state,
+                &report_state,
+            )
+        })
+        .buffer_unordered(MAX_CONCURRENT_PRUNE_AUDIT_CHALLENGES);
+
+    let mut present_by_key = HashMap::<XorName, HashSet<PeerId>>::new();
+    while let Some(proof) = requests.next().await {
+        if let Some((peer, key)) = proof {
+            present_by_key.entry(key).or_default().insert(peer);
+        }
+    }
+
+    present_by_key
+}
+
+async fn revalidated_record_prune_keys(
+    candidates: &[RecordPruneCandidate],
+    present_by_key: &HashMap<XorName, HashSet<PeerId>>,
+    self_id: &PeerId,
+    paid_list: &Arc<PaidList>,
+    p2p_node: &Arc<P2PNode>,
+    config: &ReplicationConfig,
+) -> (Vec<XorName>, usize) {
+    let dht = p2p_node.dht_manager();
+    let mut keys_to_delete = Vec::new();
+    let mut cleared = 0;
+    let now = Instant::now();
+
+    for candidate in candidates {
+        let closest: Vec<DHTNode> = dht
+            .find_closest_nodes_local_with_self(&candidate.key, config.close_group_size)
+            .await;
+
+        if closest.iter().any(|n| n.peer_id == *self_id) {
+            if paid_list
+                .record_out_of_range_since(&candidate.key)
+                .is_some()
+            {
+                paid_list.clear_record_out_of_range(&candidate.key);
+                cleared += 1;
+            }
+            continue;
+        }
+
+        let Some(first_seen) = paid_list.record_out_of_range_since(&candidate.key) else {
+            continue;
+        };
+        let elapsed = now
+            .checked_duration_since(first_seen)
+            .unwrap_or(Duration::ZERO);
+        if elapsed < config.prune_hysteresis_duration {
+            continue;
+        }
+
+        let current_target_peers = remote_close_group_peers(&closest, self_id);
+        if current_target_peers.is_empty() {
+            warn!(
+                "Cannot prune {}: current close group has no remote peers",
+                hex::encode(candidate.key)
+            );
+            continue;
+        }
+
+        if target_peers_reported_present(&candidate.key, &current_target_peers, present_by_key) {
+            keys_to_delete.push(candidate.key);
+        } else {
+            debug!(
+                "Deferring prune for {} until current close group reports it",
+                hex::encode(candidate.key)
+            );
+        }
+    }
+
+    (keys_to_delete, cleared)
+}
+
+fn build_peer_audit_challenges(candidates: &[RecordPruneCandidate]) -> Vec<(PeerId, XorName)> {
+    let mut challenges = Vec::new();
+    for candidate in candidates {
+        for peer in &candidate.target_peers {
+            challenges.push((*peer, candidate.key));
+        }
+    }
+    challenges
+}
+
+#[cfg(test)]
+fn confirmed_keys_from_presence(
+    candidates: &[RecordPruneCandidate],
+    present_by_key: &HashMap<XorName, HashSet<PeerId>>,
+) -> Vec<XorName> {
+    candidates
+        .iter()
+        .filter(|candidate| {
+            target_peers_reported_present(&candidate.key, &candidate.target_peers, present_by_key)
+        })
+        .map(|candidate| candidate.key)
+        .collect()
+}
+
+fn target_peers_reported_present(
+    key: &XorName,
+    target_peers: &[PeerId],
+    present_by_key: &HashMap<XorName, HashSet<PeerId>>,
+) -> bool {
+    let Some(present_peers) = present_by_key.get(key) else {
+        return false;
+    };
+    target_peers.iter().all(|peer| present_peers.contains(peer))
+}
+
+/// Challenge a peer to prove it holds the exact record bytes for `key`.
+/// `None` means the peer failed to provide usable proof.
+async fn peer_proves_record(
+    peer: PeerId,
+    key: XorName,
+    storage: &Arc<LmdbStorage>,
+    p2p_node: &Arc<P2PNode>,
+    config: &ReplicationConfig,
+    sync_state: &Arc<RwLock<NeighborSyncState>>,
+    report_state: &PruneAuditReportState,
+) -> Option<(PeerId, XorName)> {
+    let local_bytes = local_record_bytes(&key, storage).await?;
+
+    let (challenge_id, nonce) = {
+        let mut rng = rand::thread_rng();
+        (rng.gen::<u64>(), rng.gen::<[u8; 32]>())
+    };
+    let encoded = encode_prune_audit_challenge(&peer, key, challenge_id, nonce)?;
+    let Some(decoded) = send_prune_audit_challenge(&peer, &key, encoded, p2p_node, config).await
+    else {
+        let reported =
+            report_prune_audit_failure_once(&peer, &key, p2p_node, config, report_state).await;
+        if reported {
+            clear_prune_bootstrap_claim(&peer, sync_state).await;
+        }
+        return None;
+    };
+
+    match prune_audit_response_status(decoded, challenge_id, &peer, &key, &nonce, &local_bytes) {
+        PruneAuditStatus::Proven => {
+            clear_prune_bootstrap_claim(&peer, sync_state).await;
+            Some((peer, key))
+        }
+        PruneAuditStatus::Bootstrapping => {
+            report_prune_bootstrap_claim(&peer, &key, p2p_node, config, sync_state, report_state)
+                .await;
+            None
+        }
+        PruneAuditStatus::Failed => {
+            clear_prune_bootstrap_claim(&peer, sync_state).await;
+            report_prune_audit_failure_once(&peer, &key, p2p_node, config, report_state).await;
+            None
+        }
+    }
+}
+
+fn encode_prune_audit_challenge(
+    peer: &PeerId,
+    key: XorName,
+    challenge_id: u64,
+    nonce: [u8; 32],
+) -> Option<Vec<u8>> {
+    let challenge = AuditChallenge {
+        challenge_id,
+        nonce,
+        challenged_peer_id: *peer.as_bytes(),
+        keys: vec![key],
+    };
+    let msg = ReplicationMessage {
+        request_id: challenge_id,
+        body: ReplicationMessageBody::AuditChallenge(challenge),
+    };
+    let encoded = match msg.encode() {
+        Ok(data) => data,
+        Err(e) => {
+            warn!(
+                "Failed to encode prune audit challenge for {} against {peer}: {e}",
+                hex::encode(key),
+            );
+            return None;
+        }
+    };
+    Some(encoded)
+}
+
+async fn send_prune_audit_challenge(
+    peer: &PeerId,
+    key: &XorName,
+    encoded: Vec<u8>,
+    p2p_node: &Arc<P2PNode>,
+    config: &ReplicationConfig,
+) -> Option<ReplicationMessage> {
+    let response = match p2p_node
+        .send_request(
+            peer,
+            REPLICATION_PROTOCOL_ID,
+            encoded,
+            config.audit_response_timeout(1),
+        )
+        .await
+    {
+        Ok(response) => response,
+        Err(e) => {
+            debug!(
+                "Prune audit challenge for {} against {peer} failed: {e}",
+                hex::encode(key)
+            );
+            return None;
+        }
+    };
+
+    let decoded = match ReplicationMessage::decode(&response.data) {
+        Ok(msg) => msg,
+        Err(e) => {
+            warn!("Failed to decode prune audit response from {peer}: {e}");
+            return None;
+        }
+    };
+
+    Some(decoded)
+}
+
+fn prune_audit_response_status(
+    decoded: ReplicationMessage,
+    challenge_id: u64,
+    peer: &PeerId,
+    key: &XorName,
+    nonce: &[u8; 32],
+    local_bytes: &[u8],
+) -> PruneAuditStatus {
+    match decoded.body {
+        ReplicationMessageBody::AuditResponse(AuditResponse::Digests {
+            challenge_id: resp_id,
+            digests,
+        }) => {
+            if resp_id != challenge_id {
+                warn!("Prune audit challenge ID mismatch from {peer}");
+                return PruneAuditStatus::Failed;
+            }
+            if digests.len() != 1 {
+                warn!(
+                    "Prune audit response from {peer} returned {} digests for one challenged key",
+                    digests.len(),
+                );
+                return PruneAuditStatus::Failed;
+            }
+
+            if audit_digest_proves_key(peer, key, nonce, local_bytes, &digests[0]) {
+                PruneAuditStatus::Proven
+            } else {
+                warn!(
+                    "Prune audit proof from {peer} failed for {}",
+                    hex::encode(key)
+                );
+                PruneAuditStatus::Failed
+            }
+        }
+        ReplicationMessageBody::AuditResponse(AuditResponse::Bootstrapping {
+            challenge_id: resp_id,
+        }) => {
+            if resp_id == challenge_id {
+                warn!(
+                    "Prune audit proof for {} blocked by bootstrap claim from {peer}",
+                    hex::encode(key)
+                );
+                PruneAuditStatus::Bootstrapping
+            } else {
+                warn!("Prune audit challenge ID mismatch on Bootstrapping from {peer}");
+                PruneAuditStatus::Failed
+            }
+        }
+        ReplicationMessageBody::AuditResponse(AuditResponse::Rejected {
+            challenge_id: resp_id,
+            reason,
+        }) => {
+            if resp_id == challenge_id {
+                warn!(
+                    "Prune audit proof for {} rejected by {peer}: {reason}",
+                    hex::encode(key)
+                );
+            } else {
+                warn!("Prune audit challenge ID mismatch on Rejected from {peer}");
+            }
+            PruneAuditStatus::Failed
+        }
+        _ => {
+            warn!("Unexpected prune audit response type from {peer}");
+            PruneAuditStatus::Failed
+        }
+    }
+}
+
+async fn local_record_bytes(key: &XorName, storage: &Arc<LmdbStorage>) -> Option<Vec<u8>> {
+    match storage.get_raw(key).await {
+        Ok(Some(bytes)) => Some(bytes),
+        Ok(None) => {
+            debug!(
+                "Cannot prune-audit {}: local record disappeared",
+                hex::encode(key)
+            );
+            None
+        }
+        Err(e) => {
+            warn!(
+                "Cannot prune-audit {}: failed to read local record: {e}",
+                hex::encode(key)
+            );
+            None
+        }
+    }
+}
+
+fn audit_digest_proves_key(
+    peer: &PeerId,
+    key: &XorName,
+    nonce: &[u8; 32],
+    local_bytes: &[u8],
+    digest: &[u8; 32],
+) -> bool {
+    if *digest == ABSENT_KEY_DIGEST {
+        return false;
+    }
+    let expected = compute_audit_digest(nonce, peer.as_bytes(), key, local_bytes);
+    *digest == expected
+}
+
+async fn report_prune_audit_failure_once(
+    peer: &PeerId,
+    key: &XorName,
+    p2p_node: &Arc<P2PNode>,
+    config: &ReplicationConfig,
+    report_state: &PruneAuditReportState,
+) -> bool {
+    let should_report = peer_is_currently_responsible(peer, key, p2p_node, config).await
+        && reserve_prune_audit_failure_report(report_state, peer).await;
+    if !should_report {
+        return false;
+    }
+
+    p2p_node
+        .report_trust_event(
+            peer,
+            saorsa_core::TrustEvent::ApplicationFailure(AUDIT_FAILURE_TRUST_WEIGHT),
+        )
+        .await;
+    true
+}
+
+async fn reserve_prune_audit_failure_report(
+    report_state: &PruneAuditReportState,
+    peer: &PeerId,
+) -> bool {
+    report_state.audit_failures.write().await.insert(*peer)
+}
+
+async fn reserve_prune_bootstrap_abuse_report(
+    report_state: &PruneAuditReportState,
+    peer: &PeerId,
+) -> bool {
+    report_state.bootstrap_abuse.write().await.insert(*peer)
+}
+
+async fn report_prune_bootstrap_claim(
+    peer: &PeerId,
+    key: &XorName,
+    p2p_node: &Arc<P2PNode>,
+    config: &ReplicationConfig,
+    sync_state: &Arc<RwLock<NeighborSyncState>>,
+    report_state: &PruneAuditReportState,
+) {
+    if !peer_is_currently_responsible(peer, key, p2p_node, config).await {
+        return;
+    }
+
+    let claim_age = {
+        let now = Instant::now();
+        let mut state = sync_state.write().await;
+        let first_seen = state.bootstrap_claims.entry(*peer).or_insert(now);
+        let claim_age = now.duration_since(*first_seen);
+        if claim_age > config.bootstrap_claim_grace_period {
+            Some(claim_age)
+        } else {
+            debug!("Prune audit: peer {peer} claims bootstrapping (within grace period)");
+            None
+        }
+    };
+
+    let Some(claim_age) = claim_age else {
+        return;
+    };
+    if !reserve_prune_bootstrap_abuse_report(report_state, peer).await {
+        debug!("Prune audit: peer {peer} bootstrap abuse already reported this pass");
+        return;
+    }
+
+    warn!(
+        "Prune audit: peer {peer} claiming bootstrap past grace period \
+         ({:?} > {:?}), reporting abuse",
+        claim_age, config.bootstrap_claim_grace_period,
+    );
+    p2p_node
+        .report_trust_event(
+            peer,
+            saorsa_core::TrustEvent::ApplicationFailure(REPLICATION_TRUST_WEIGHT),
+        )
+        .await;
+}
+
+async fn clear_prune_bootstrap_claim(peer: &PeerId, sync_state: &Arc<RwLock<NeighborSyncState>>) {
+    let removed = {
+        let mut state = sync_state.write().await;
+        state.bootstrap_claims.remove(peer).is_some()
+    };
+    if removed {
+        debug!("Prune audit: cleared stale bootstrap claim for {peer}");
+    }
+}
+
+async fn peer_is_currently_responsible(
+    peer: &PeerId,
+    key: &XorName,
+    p2p_node: &Arc<P2PNode>,
+    config: &ReplicationConfig,
+) -> bool {
+    let closest = p2p_node
+        .dht_manager()
+        .find_closest_nodes_local_with_self(key, config.close_group_size)
+        .await;
+    closest.iter().any(|node| node.peer_id == *peer)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn peer_id_from_byte(b: u8) -> PeerId {
+        let mut bytes = [0u8; 32];
+        bytes[0] = b;
+        PeerId::from_bytes(bytes)
+    }
+
+    fn key_from_byte(b: u8) -> XorName {
+        [b; 32]
+    }
+
+    fn candidate(key: XorName, target_peers: Vec<PeerId>) -> RecordPruneCandidate {
+        RecordPruneCandidate { key, target_peers }
+    }
+
+    #[test]
+    fn prune_audit_challenges_are_one_per_candidate_peer() {
+        let peer_a = peer_id_from_byte(1);
+        let peer_b = peer_id_from_byte(2);
+        let key_a = key_from_byte(0xA);
+        let key_b = key_from_byte(0xB);
+        let candidates = vec![
+            candidate(key_a, vec![peer_a, peer_b]),
+            candidate(key_b, vec![peer_b]),
+        ];
+
+        let mut challenges = build_peer_audit_challenges(&candidates);
+        challenges.sort_unstable_by_key(|(peer, key)| (*peer.as_bytes(), *key));
+
+        let mut expected = vec![(peer_a, key_a), (peer_b, key_a), (peer_b, key_b)];
+        expected.sort_unstable_by_key(|(peer, key)| (*peer.as_bytes(), *key));
+        assert_eq!(challenges, expected);
+    }
+
+    #[test]
+    fn confirmed_keys_require_all_target_peers_present() {
+        let peer_a = peer_id_from_byte(1);
+        let peer_b = peer_id_from_byte(2);
+        let key = key_from_byte(0xC);
+        let candidates = vec![candidate(key, vec![peer_a, peer_b])];
+        let mut present_by_key = HashMap::new();
+        present_by_key.insert(key, HashSet::from([peer_a, peer_b]));
+
+        let confirmed = confirmed_keys_from_presence(&candidates, &present_by_key);
+
+        assert_eq!(confirmed, vec![key]);
+    }
+
+    #[test]
+    fn confirmed_keys_defer_absent_or_missing_peer_evidence() {
+        let peer_a = peer_id_from_byte(1);
+        let peer_b = peer_id_from_byte(2);
+        let complete_key = key_from_byte(0xD);
+        let absent_key = key_from_byte(0xE);
+        let missing_key = key_from_byte(0xF);
+        let candidates = vec![
+            candidate(complete_key, vec![peer_a, peer_b]),
+            candidate(absent_key, vec![peer_a, peer_b]),
+            candidate(missing_key, vec![peer_a, peer_b]),
+        ];
+        let mut present_by_key = HashMap::new();
+        present_by_key.insert(complete_key, HashSet::from([peer_a, peer_b]));
+        present_by_key.insert(absent_key, HashSet::from([peer_a]));
+
+        let confirmed = confirmed_keys_from_presence(&candidates, &present_by_key);
+
+        assert_eq!(confirmed, vec![complete_key]);
+    }
+
+    #[test]
+    fn audit_digest_proof_requires_matching_peer_key_nonce_and_bytes() {
+        let peer = peer_id_from_byte(1);
+        let other_peer = peer_id_from_byte(2);
+        let key = key_from_byte(0x11);
+        let other_key = key_from_byte(0x12);
+        let nonce = [0xAA; 32];
+        let other_nonce = [0xBB; 32];
+        let bytes = b"record bytes";
+        let digest = compute_audit_digest(&nonce, peer.as_bytes(), &key, bytes);
+
+        assert!(audit_digest_proves_key(&peer, &key, &nonce, bytes, &digest));
+        assert!(!audit_digest_proves_key(
+            &other_peer,
+            &key,
+            &nonce,
+            bytes,
+            &digest
+        ));
+        assert!(!audit_digest_proves_key(
+            &peer, &other_key, &nonce, bytes, &digest
+        ));
+        assert!(!audit_digest_proves_key(
+            &peer,
+            &key,
+            &other_nonce,
+            bytes,
+            &digest
+        ));
+        assert!(!audit_digest_proves_key(
+            &peer,
+            &key,
+            &nonce,
+            b"different bytes",
+            &digest
+        ));
+        assert!(!audit_digest_proves_key(
+            &peer,
+            &key,
+            &nonce,
+            bytes,
+            &ABSENT_KEY_DIGEST
+        ));
+    }
+
+    #[tokio::test]
+    async fn prune_cursor_advances_past_selected_budget_window() {
+        let state = Arc::new(RwLock::new(NeighborSyncState::new_cycle(vec![])));
+        state.write().await.prune_cursor = 2;
+
+        let start = prune_scan_start(&state, 10).await;
+        advance_prune_cursor(&state, 10, start, Some(3)).await;
+
+        assert_eq!(state.read().await.prune_cursor, 6);
+    }
+
+    #[tokio::test]
+    async fn prune_cursor_advances_even_when_no_candidate_selected() {
+        let state = Arc::new(RwLock::new(NeighborSyncState::new_cycle(vec![])));
+        state.write().await.prune_cursor = 9;
+
+        let start = prune_scan_start(&state, 10).await;
+        advance_prune_cursor(&state, 10, start, None).await;
+
+        assert_eq!(state.read().await.prune_cursor, 0);
+    }
+
+    #[tokio::test]
+    async fn prune_audit_normal_response_clears_stale_bootstrap_claim() {
+        let peer = peer_id_from_byte(1);
+        let state = Arc::new(RwLock::new(NeighborSyncState::new_cycle(vec![peer])));
+        state
+            .write()
+            .await
+            .bootstrap_claims
+            .insert(peer, Instant::now());
+
+        clear_prune_bootstrap_claim(&peer, &state).await;
+
+        assert!(!state.read().await.bootstrap_claims.contains_key(&peer));
+    }
+
+    #[tokio::test]
+    async fn prune_audit_failure_penalty_is_reserved_once_per_peer_per_pass() {
+        let peer = peer_id_from_byte(1);
+        let other_peer = peer_id_from_byte(2);
+        let report_state = PruneAuditReportState::default();
+
+        assert!(reserve_prune_audit_failure_report(&report_state, &peer).await);
+        assert!(!reserve_prune_audit_failure_report(&report_state, &peer).await);
+        assert!(reserve_prune_audit_failure_report(&report_state, &other_peer).await);
+
+        let reported = report_state.audit_failures.read().await;
+        assert_eq!(reported.len(), 2);
+        assert!(reported.contains(&peer));
+        assert!(reported.contains(&other_peer));
+    }
+
+    #[tokio::test]
+    async fn prune_bootstrap_abuse_penalty_is_reserved_once_per_peer_per_pass() {
+        let peer = peer_id_from_byte(1);
+        let other_peer = peer_id_from_byte(2);
+        let report_state = PruneAuditReportState::default();
+
+        assert!(reserve_prune_bootstrap_abuse_report(&report_state, &peer).await);
+        assert!(!reserve_prune_bootstrap_abuse_report(&report_state, &peer).await);
+        assert!(reserve_prune_bootstrap_abuse_report(&report_state, &other_peer).await);
+
+        let reported = report_state.bootstrap_abuse.read().await;
+        assert_eq!(reported.len(), 2);
+        assert!(reported.contains(&peer));
+        assert!(reported.contains(&other_peer));
+    }
 }

--- a/src/replication/pruning.rs
+++ b/src/replication/pruning.rs
@@ -26,7 +26,7 @@ use crate::replication::protocol::{
     compute_audit_digest, AuditChallenge, AuditResponse, ReplicationMessage,
     ReplicationMessageBody, ABSENT_KEY_DIGEST,
 };
-use crate::replication::types::NeighborSyncState;
+use crate::replication::types::{BootstrapClaimObservation, NeighborSyncState};
 use crate::storage::LmdbStorage;
 
 use super::REPLICATION_TRUST_WEIGHT;
@@ -780,32 +780,46 @@ async fn report_prune_bootstrap_claim(
         return;
     }
 
-    let claim_age = {
+    let observation = {
         let now = Instant::now();
         let mut state = sync_state.write().await;
-        let first_seen = state.bootstrap_claims.entry(*peer).or_insert(now);
-        let claim_age = now.duration_since(*first_seen);
-        if claim_age > config.bootstrap_claim_grace_period {
-            Some(claim_age)
-        } else {
-            debug!("Prune audit: peer {peer} claims bootstrapping (within grace period)");
-            None
-        }
+        (
+            now,
+            state.observe_bootstrap_claim(*peer, now, config.bootstrap_claim_grace_period),
+        )
     };
 
-    let Some(claim_age) = claim_age else {
-        return;
-    };
-    if !reserve_prune_bootstrap_abuse_report(report_state, peer).await {
-        debug!("Prune audit: peer {peer} bootstrap abuse already reported this pass");
-        return;
+    let (now, observation) = observation;
+    match observation {
+        BootstrapClaimObservation::WithinGrace { .. } => {
+            debug!("Prune audit: peer {peer} claims bootstrapping (within grace period)");
+            return;
+        }
+        BootstrapClaimObservation::PastGrace { first_seen } => {
+            if !reserve_prune_bootstrap_abuse_report(report_state, peer).await {
+                debug!("Prune audit: peer {peer} bootstrap abuse already reported this pass");
+                return;
+            }
+            warn!(
+                "Prune audit: peer {peer} claiming bootstrap past grace period \
+                 ({:?} > {:?}), reporting abuse",
+                now.duration_since(first_seen),
+                config.bootstrap_claim_grace_period,
+            );
+        }
+        BootstrapClaimObservation::Repeated { first_seen } => {
+            if !reserve_prune_bootstrap_abuse_report(report_state, peer).await {
+                debug!("Prune audit: peer {peer} bootstrap abuse already reported this pass");
+                return;
+            }
+            warn!(
+                "Prune audit: peer {peer} repeated bootstrap claim after previously stopping; \
+                 first claim was {:?} ago, reporting abuse",
+                now.duration_since(first_seen),
+            );
+        }
     }
 
-    warn!(
-        "Prune audit: peer {peer} claiming bootstrap past grace period \
-         ({:?} > {:?}), reporting abuse",
-        claim_age, config.bootstrap_claim_grace_period,
-    );
     p2p_node
         .report_trust_event(
             peer,
@@ -817,10 +831,10 @@ async fn report_prune_bootstrap_claim(
 async fn clear_prune_bootstrap_claim(peer: &PeerId, sync_state: &Arc<RwLock<NeighborSyncState>>) {
     let removed = {
         let mut state = sync_state.write().await;
-        state.bootstrap_claims.remove(peer).is_some()
+        state.clear_active_bootstrap_claim(peer)
     };
     if removed {
-        debug!("Prune audit: cleared stale bootstrap claim for {peer}");
+        debug!("Prune audit: cleared active bootstrap claim for {peer}");
     }
 }
 
@@ -981,15 +995,23 @@ mod tests {
     async fn prune_audit_normal_response_clears_stale_bootstrap_claim() {
         let peer = peer_id_from_byte(1);
         let state = Arc::new(RwLock::new(NeighborSyncState::new_cycle(vec![peer])));
+        let first_seen = Instant::now();
         state
             .write()
             .await
             .bootstrap_claims
-            .insert(peer, Instant::now());
+            .insert(peer, first_seen);
+        state
+            .write()
+            .await
+            .bootstrap_claim_history
+            .insert(peer, first_seen);
 
         clear_prune_bootstrap_claim(&peer, &state).await;
 
-        assert!(!state.read().await.bootstrap_claims.contains_key(&peer));
+        let state = state.read().await;
+        assert!(!state.bootstrap_claims.contains_key(&peer));
+        assert!(state.bootstrap_claim_history.contains_key(&peer));
     }
 
     #[tokio::test]

--- a/src/replication/types.rs
+++ b/src/replication/types.rs
@@ -270,6 +270,9 @@ pub struct NeighborSyncState {
     /// perpetually claiming bootstrap, this map grows unboundedly. In practice
     /// the trust engine limits Sybil impact before this becomes a memory issue.
     pub bootstrap_claims: HashMap<PeerId, Instant>,
+    /// Cursor used by post-cycle pruning to rotate through stored records when
+    /// the per-pass prune-confirmation budget is exhausted.
+    pub prune_cursor: usize,
 }
 
 impl NeighborSyncState {
@@ -281,6 +284,7 @@ impl NeighborSyncState {
             cursor: 0,
             last_sync_times: HashMap::new(),
             bootstrap_claims: HashMap::new(),
+            prune_cursor: 0,
         }
     }
 

--- a/src/replication/types.rs
+++ b/src/replication/types.rs
@@ -6,7 +6,7 @@
 
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
@@ -251,10 +251,31 @@ impl PeerSyncRecord {
 // Neighbor sync cycle state
 // ---------------------------------------------------------------------------
 
+/// Result of observing a peer's bootstrap claim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BootstrapClaimObservation {
+    /// The peer is inside its first and only bootstrap-claim grace window.
+    WithinGrace {
+        /// First time this peer claimed bootstrap status.
+        first_seen: Instant,
+    },
+    /// The peer has continuously claimed bootstrap status past the grace period.
+    PastGrace {
+        /// First time this peer claimed bootstrap status.
+        first_seen: Instant,
+    },
+    /// The peer previously stopped claiming bootstrap and then claimed it again.
+    Repeated {
+        /// First time this peer ever claimed bootstrap status.
+        first_seen: Instant,
+    },
+}
+
 /// Neighbor sync cycle state.
 ///
 /// Tracks a deterministic walk through the current close-group snapshot,
-/// per-peer cooldown times, and bootstrap claim first-seen timestamps.
+/// per-peer cooldown times, active bootstrap claims, and peers that have already
+/// used their one bootstrap-claim window.
 #[derive(Debug)]
 pub struct NeighborSyncState {
     /// Deterministic ordering of peers for the current cycle (snapshot).
@@ -263,13 +284,20 @@ pub struct NeighborSyncState {
     pub cursor: usize,
     /// Per-peer last successful sync time (for cooldown).
     pub last_sync_times: HashMap<PeerId, Instant>,
-    /// Bootstrap claim first-seen timestamps per peer.
+    /// Active bootstrap claim first-seen timestamps per peer.
     ///
-    /// Entries are removed when a peer passes or fails audit (i.e. stops
-    /// claiming bootstrap). Under Sybil attack with many distinct peer IDs
-    /// perpetually claiming bootstrap, this map grows unboundedly. In practice
-    /// the trust engine limits Sybil impact before this becomes a memory issue.
+    /// Entries are removed when a peer stops claiming bootstrap. The peer
+    /// remains in `bootstrap_claim_history`, so a later claim is repeated-claim
+    /// abuse instead of a fresh grace period.
     pub bootstrap_claims: HashMap<PeerId, Instant>,
+    /// First-ever bootstrap claim timestamp per peer.
+    ///
+    /// This is retained after active claims are cleared so each peer gets at
+    /// most one bootstrap-claim grace window. Under Sybil attack with many
+    /// distinct peer IDs claiming bootstrap, this map grows unboundedly. In
+    /// practice the trust engine limits Sybil impact before this becomes a
+    /// memory issue.
+    pub bootstrap_claim_history: HashMap<PeerId, Instant>,
     /// Cursor used by post-cycle pruning to rotate through stored records when
     /// the per-pass prune-confirmation budget is exhausted.
     pub prune_cursor: usize,
@@ -284,8 +312,42 @@ impl NeighborSyncState {
             cursor: 0,
             last_sync_times: HashMap::new(),
             bootstrap_claims: HashMap::new(),
+            bootstrap_claim_history: HashMap::new(),
             prune_cursor: 0,
         }
+    }
+
+    /// Observe a peer claiming bootstrap status.
+    ///
+    /// A peer receives one grace window from its first observed bootstrap claim.
+    /// If it later stops claiming bootstrap, callers should clear only the
+    /// active claim with [`Self::clear_active_bootstrap_claim`]. A subsequent
+    /// claim is then reported as [`BootstrapClaimObservation::Repeated`].
+    #[must_use]
+    pub fn observe_bootstrap_claim(
+        &mut self,
+        peer: PeerId,
+        now: Instant,
+        grace_period: Duration,
+    ) -> BootstrapClaimObservation {
+        if let Some(first_seen) = self.bootstrap_claims.get(&peer).copied() {
+            if now.duration_since(first_seen) > grace_period {
+                BootstrapClaimObservation::PastGrace { first_seen }
+            } else {
+                BootstrapClaimObservation::WithinGrace { first_seen }
+            }
+        } else if let Some(first_seen) = self.bootstrap_claim_history.get(&peer).copied() {
+            BootstrapClaimObservation::Repeated { first_seen }
+        } else {
+            self.bootstrap_claims.insert(peer, now);
+            self.bootstrap_claim_history.insert(peer, now);
+            BootstrapClaimObservation::WithinGrace { first_seen: now }
+        }
+    }
+
+    /// Clear the active bootstrap claim for a peer, retaining claim history.
+    pub fn clear_active_bootstrap_claim(&mut self, peer: &PeerId) -> bool {
+        self.bootstrap_claims.remove(peer).is_some()
     }
 
     /// Whether the current cycle is complete.
@@ -561,6 +623,50 @@ mod tests {
         assert!(
             state.is_cycle_complete(),
             "cursor past end should still report complete"
+        );
+    }
+
+    #[test]
+    fn bootstrap_claim_history_prevents_second_grace_window() {
+        let peer = peer_id_from_byte(9);
+        let mut state = NeighborSyncState::new_cycle(vec![peer]);
+        let first_seen = Instant::now();
+        let grace = Duration::from_secs(60);
+
+        assert_eq!(
+            state.observe_bootstrap_claim(peer, first_seen, grace),
+            BootstrapClaimObservation::WithinGrace { first_seen }
+        );
+        assert!(state.clear_active_bootstrap_claim(&peer));
+        assert!(!state.bootstrap_claims.contains_key(&peer));
+        assert!(state.bootstrap_claim_history.contains_key(&peer));
+
+        assert_eq!(
+            state.observe_bootstrap_claim(peer, first_seen + Duration::from_secs(1), grace),
+            BootstrapClaimObservation::Repeated { first_seen }
+        );
+        assert!(
+            !state.bootstrap_claims.contains_key(&peer),
+            "repeated claims must not recreate an active grace window"
+        );
+        assert_eq!(
+            state.observe_bootstrap_claim(peer, first_seen + Duration::from_secs(2), grace),
+            BootstrapClaimObservation::Repeated { first_seen }
+        );
+    }
+
+    #[test]
+    fn bootstrap_claim_active_window_reports_past_grace() {
+        let peer = peer_id_from_byte(10);
+        let mut state = NeighborSyncState::new_cycle(vec![peer]);
+        let first_seen = Instant::now();
+        let grace = Duration::from_secs(60);
+
+        let _ = state.observe_bootstrap_claim(peer, first_seen, grace);
+
+        assert_eq!(
+            state.observe_bootstrap_claim(peer, first_seen + grace + Duration::from_secs(1), grace),
+            BootstrapClaimObservation::PastGrace { first_seen }
         );
     }
 

--- a/tests/e2e/replication.rs
+++ b/tests/e2e/replication.rs
@@ -13,11 +13,16 @@ use ant_node::replication::protocol::{
     FreshReplicationOffer, FreshReplicationResponse, NeighborSyncRequest, ReplicationMessage,
     ReplicationMessageBody, VerificationRequest, ABSENT_KEY_DIGEST,
 };
+use ant_node::replication::pruning;
 use ant_node::replication::scheduling::ReplicationQueues;
+use ant_node::replication::types::NeighborSyncState;
+use ant_node::ReplicationConfig;
 use saorsa_core::identity::PeerId;
 use saorsa_core::{P2PNode, TrustEvent};
 use serial_test::serial;
+use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::RwLock;
 
 /// Maximum time to wait for replication propagation in tests.
 const PROPAGATION_TIMEOUT: Duration = Duration::from_secs(15);
@@ -42,6 +47,88 @@ async fn send_replication_request(
         .await
         .expect("send_request");
     ReplicationMessage::decode(&response.data).expect("decode replication response")
+}
+
+fn prune_test_config(close_group_size: usize) -> ReplicationConfig {
+    ReplicationConfig {
+        close_group_size,
+        quorum_threshold: 1,
+        paid_list_close_group_size: 1,
+        prune_hysteresis_duration: Duration::ZERO,
+        ..ReplicationConfig::default()
+    }
+}
+
+fn node_index_for_peer(harness: &TestHarness, peer: &PeerId) -> Option<usize> {
+    (0..harness.node_count()).find(|idx| {
+        harness
+            .test_node(*idx)
+            .and_then(|node| node.p2p_node.as_ref())
+            .is_some_and(|p2p| p2p.peer_id() == peer)
+    })
+}
+
+async fn find_remote_prune_candidate(
+    harness: &TestHarness,
+    pruner_idx: usize,
+    close_group_size: usize,
+    label: &str,
+) -> (Vec<u8>, [u8; 32], Vec<PeerId>) {
+    let pruner = harness.test_node(pruner_idx).expect("pruner");
+    let pruner_p2p = pruner.p2p_node.as_ref().expect("pruner p2p");
+    let pruner_peer = *pruner_p2p.peer_id();
+
+    for attempt in 0..10_000usize {
+        let content = format!("prune-confirmation-{label}-{attempt}").into_bytes();
+        let address = compute_address(&content);
+        let closest = pruner_p2p
+            .dht_manager()
+            .find_closest_nodes_local_with_self(&address, close_group_size)
+            .await;
+        if closest.len() != close_group_size {
+            continue;
+        }
+
+        let target_peers: Vec<PeerId> = closest.iter().map(|node| node.peer_id).collect();
+        if target_peers.contains(&pruner_peer) {
+            continue;
+        }
+        if target_peers
+            .iter()
+            .all(|peer| node_index_for_peer(harness, peer).is_some())
+        {
+            return (content, address, target_peers);
+        }
+    }
+
+    panic!("failed to find a {close_group_size}-peer prune candidate outside pruner {pruner_idx}");
+}
+
+async fn store_record_on_peer(
+    harness: &TestHarness,
+    peer: &PeerId,
+    address: &[u8; 32],
+    content: &[u8],
+) {
+    let idx = node_index_for_peer(harness, peer).expect("target peer should be in test harness");
+    let protocol = harness
+        .test_node(idx)
+        .expect("target node")
+        .ant_protocol
+        .as_ref()
+        .expect("target protocol");
+    protocol.storage().put(address, content).await.expect("put");
+}
+
+async fn store_record_on_peers(
+    harness: &TestHarness,
+    peers: &[PeerId],
+    address: &[u8; 32],
+    content: &[u8],
+) {
+    for peer in peers {
+        store_record_on_peer(harness, peer, address, content).await;
+    }
 }
 
 /// Fresh write happy path (Section 18 #1).
@@ -350,6 +437,135 @@ async fn test_audit_absent_key_returns_sentinel() {
     } else {
         panic!("Expected AuditResponse::Digests");
     }
+
+    harness.teardown().await.expect("teardown");
+}
+
+/// Prune pass requires remote storage proofs before deleting local records.
+///
+/// This drives `run_prune_pass` against live nodes so prune-confirmation audits
+/// travel over the real replication request/response path.
+#[tokio::test]
+#[serial]
+async fn test_prune_pass_requires_remote_confirmation_before_delete() {
+    let harness = TestHarness::setup_minimal().await.expect("setup");
+    harness.warmup_dht().await.expect("warmup");
+
+    let pruner_idx = 3;
+    let close_group_size = 2;
+    let config = prune_test_config(close_group_size);
+    let sync_state = Arc::new(RwLock::new(NeighborSyncState::new_cycle(vec![])));
+
+    let pruner = harness.test_node(pruner_idx).expect("pruner");
+    let pruner_p2p = Arc::clone(pruner.p2p_node.as_ref().expect("pruner p2p"));
+    let pruner_protocol = pruner.ant_protocol.as_ref().expect("pruner protocol");
+    let pruner_storage = pruner_protocol.storage();
+    let pruner_paid_list = Arc::clone(
+        pruner
+            .replication_engine
+            .as_ref()
+            .expect("pruner replication engine")
+            .paid_list(),
+    );
+    let pruner_peer = *pruner_p2p.peer_id();
+
+    // Even with all target peers storing the record, pruning must be blocked
+    // while remote prune audits are not allowed during bootstrap/drain.
+    let (gate_content, gate_address, gate_targets) =
+        find_remote_prune_candidate(&harness, pruner_idx, close_group_size, "bootstrap-gate").await;
+    pruner_storage
+        .put(&gate_address, &gate_content)
+        .await
+        .expect("put gate record on pruner");
+    store_record_on_peers(&harness, &gate_targets, &gate_address, &gate_content).await;
+
+    let blocked = pruning::run_prune_pass(
+        &pruner_peer,
+        &pruner_storage,
+        &pruner_paid_list,
+        &pruner_p2p,
+        &config,
+        &sync_state,
+        false,
+    )
+    .await;
+    assert_eq!(blocked.records_pruned, 0);
+    assert!(
+        pruner_storage.exists(&gate_address).expect("exists"),
+        "record must not be pruned before remote audits are allowed"
+    );
+
+    let confirmed = pruning::run_prune_pass(
+        &pruner_peer,
+        &pruner_storage,
+        &pruner_paid_list,
+        &pruner_p2p,
+        &config,
+        &sync_state,
+        true,
+    )
+    .await;
+    assert_eq!(confirmed.records_pruned, 1);
+    assert!(
+        !pruner_storage.exists(&gate_address).expect("exists"),
+        "record should be pruned after all target peers prove storage"
+    );
+
+    // If any current close-group peer lacks the record, the prune pass must
+    // retain the local copy until that peer can prove it stores the bytes.
+    let (missing_content, missing_address, missing_targets) =
+        find_remote_prune_candidate(&harness, pruner_idx, close_group_size, "missing-proof").await;
+    pruner_storage
+        .put(&missing_address, &missing_content)
+        .await
+        .expect("put missing-proof record on pruner");
+    store_record_on_peer(
+        &harness,
+        &missing_targets[0],
+        &missing_address,
+        &missing_content,
+    )
+    .await;
+
+    let incomplete = pruning::run_prune_pass(
+        &pruner_peer,
+        &pruner_storage,
+        &pruner_paid_list,
+        &pruner_p2p,
+        &config,
+        &sync_state,
+        true,
+    )
+    .await;
+    assert_eq!(incomplete.records_pruned, 0);
+    assert!(
+        pruner_storage.exists(&missing_address).expect("exists"),
+        "record must remain local while any target peer lacks proof"
+    );
+
+    store_record_on_peers(
+        &harness,
+        &missing_targets,
+        &missing_address,
+        &missing_content,
+    )
+    .await;
+
+    let complete = pruning::run_prune_pass(
+        &pruner_peer,
+        &pruner_storage,
+        &pruner_paid_list,
+        &pruner_p2p,
+        &config,
+        &sync_state,
+        true,
+    )
+    .await;
+    assert_eq!(complete.records_pruned, 1);
+    assert!(
+        !pruner_storage.exists(&missing_address).expect("exists"),
+        "record should prune once every current target peer proves storage"
+    );
 
     harness.teardown().await.expect("teardown");
 }


### PR DESCRIPTION
## Summary
- require remote prune-confirmation audit proofs before deleting out-of-range records
- increase prune hysteresis from 6 hours to 3 days before records or paid-list entries become prune-eligible
- preserve one bootstrap-claim grace window across sync, audit, and prune-confirmation paths
- keep expired active bootstrap claims audit-eligible so continued claims can be observed and penalized after the grace window
- avoid clearing active bootstrap claims on audit or prune-confirmation transport failures
- add focused unit coverage and a live e2e test for prune confirmation gating and missing peer proof deferral

## Tests
- cargo test --lib replication::audit
- cargo test --lib replication::pruning
- cargo test --lib replication::tests
- cargo test --lib bootstrap_claim
- cargo clippy --lib
- git diff --check
- cargo test --features test-utils --test e2e test_prune_pass_requires_remote_confirmation_before_delete