### PR TITLE
fix(replication): harden paid-list repair flow

### DIFF
--- a/docs/REPLICATION_DESIGN.md
+++ b/docs/REPLICATION_DESIGN.md
@@ -100,7 +100,7 @@ Parameter safety constraints (MUST hold):
 15. `PaidForList(N)` MUST be persisted to stable storage and is bounded: node `N` tracks only keys for which `N` is in `PaidCloseGroup(K)` (plus short-lived transition slack).
 16. Fresh-replication paid-list propagation is mandatory: sender MUST attempt `PaidNotify(K)` delivery to every peer in `PaidCloseGroup(K)` (reference profile: up to 20 peers when available), not a subset.
 17. A `PaidNotify(K)` only whitelists key `K` after receiver-side proof verification succeeds; sender assertions never whitelist by themselves.
-18. Neighbor-sync paid hints are non-authoritative and carry no PoP; receivers MUST only whitelist by paid-list majority verification (`>= ConfirmNeeded(K)`) or close-group replica majority (Section 7.2 rule 4), never by hint claims alone, and paid-hint-only processing MUST NOT enqueue record fetch.
+18. Neighbor-sync paid hints are non-authoritative and carry no PoP; receivers MUST only whitelist by paid-list majority verification (`>= ConfirmNeeded(K)`) or close-group replica majority (Section 7.2 rule 4), never by hint claims alone. Paid-hint-only processing MAY enqueue record fetch only after authorization succeeds and `IsResponsible(self, K)` is true; otherwise it updates `PaidForList(self)` only.
 19. Storage-proof audits start only after `BootstrapDrained(self)` becomes true.
 20. Storage-proof audits target only peers derived from closest-peer lookups for sampled local keys, filtered through local authenticated routing state (`LocalRT(self)`), and further filtered to peers for which `RepairOpportunity` holds; random global peers and never-synced peers are never audited.
 21. Verification-request batching is mandatory for unknown-key neighbor-sync verification and preserves per-key quorum semantics: each key receives explicit per-key evidence, and missing/timeout evidence is unresolved per key.
@@ -152,7 +152,7 @@ Rules:
 10. Receiver diffs replica hints against local store and pending sets, then runs per-key admission rules before quorum logic.
 11. Receiver launches quorum checks exactly once per admitted unknown replica key.
 12. Only admitted unknown replica keys that pass presence quorum or paid-list authorization are queued for fetch.
-13. Receiver processes unknown paid hints via Section 7.2 majority checks in a paid-list pipeline: successful checks may update `PaidForList(self)` but MUST NOT queue record fetch. If the same key is also present in replica hints, rule 9 drops the paid-hint duplicate and fetch behavior is governed only by the replica-hint pipeline.
+13. Receiver processes unknown paid hints via Section 7.2 majority checks in a paid-list pipeline: successful checks may update `PaidForList(self)`. If the receiver is also storage-responsible for `K`, successful verification may queue record fetch using verified `Present` sources from the same round. If the same key is also present in replica hints, rule 9 drops the paid-hint duplicate and fetch behavior is governed by the replica-hint pipeline.
 14. Sync payloads MUST NOT include PoP material; PoP remains fresh-replication-only.
 15. Nodes SHOULD use ongoing neighbor sync rounds to re-announce paid hints for locally paid keys to improve paid-list convergence.
 16. After each round, node sets `NeighborSyncCursor(self)` to the position after the last scanned peer in the (possibly shrunk) snapshot. Peers removed during scanning (cooldown or unreachable) do not occupy cursor positions — the cursor reflects the snapshot's state after removals.
@@ -172,7 +172,7 @@ For each hinted key `K`, receiver accepts the hint into verification only if bot
 1. Sender is authenticated and currently in `LocalRT(self)`.
 2. Key is relevant to the receiver:
     - Replica hint: receiver is currently responsible (`IsResponsible(self, K)`) or key already exists in local store/pending pipeline.
-    - Paid hint: receiver is currently in `PaidCloseGroup(K)` (or key is already in local `PaidForList` pending cleanup). This admission is paid-list-tracking only and does not make the key fetch-eligible by itself.
+    - Paid hint: receiver is currently in `PaidCloseGroup(K)` (or key is already in local `PaidForList` pending cleanup). This admission is paid-list-tracking first; it becomes fetch-eligible only if verification succeeds and the receiver is also storage-responsible for `K`.
 
 Notes:
 
@@ -181,7 +181,7 @@ Notes:
 - For inbound sync sessions from peers outside `LocalRT(self)`, receiver may send outbound hints but does not accept inbound hints.
 - Mixed hint sets are valid: process admitted keys, drop non-admitted keys.
 - Cross-set precedence is strict: if key `K` is present in both admitted replica hints and admitted paid hints, process `K` only in the replica-hint pipeline and drop the paid-hint duplicate.
-- Admitted paid hints can update `PaidForList(self)` after verification but never enqueue record fetch. If the same key is also in replica hints, the paid-hint duplicate is discarded and fetch eligibility is decided only by the replica-hint pipeline.
+- Admitted paid hints can update `PaidForList(self)` after verification. They may enqueue record fetch only when `IsResponsible(self, K)` is true and verified `Present` sources exist. If the same key is also in replica hints, the paid-hint duplicate is discarded and fetch eligibility is decided by the replica-hint pipeline.
 - Receiver MAY return rejected-key metadata to help sender avoid repeating obviously invalid hints in immediate subsequent sync attempts.
 
 ### 7.2 Paid-List Authorization (Per Key)
@@ -192,7 +192,7 @@ When handling an admitted unknown key `K` from neighbor sync:
 2. Otherwise run the single verification round defined in Section 9 and collect paid-list responses from peers in `PaidCloseGroup(K)` (same round as presence evidence; no separate paid-list-only round).
 3. If paid confirmations from `PaidCloseGroup(K)` are `>= ConfirmNeeded(K)`, add `K` to local `PaidForList` and treat `K` as paid-authorized.
 4. If presence positives from `QuorumTargets` (the node's local approximation of `CloseGroup(K)`, computed in Section 9 step 3) during the same verification round reach `>= QuorumNeeded(K)` (close-group replica majority), add `K` to local `PaidForList` and treat `K` as paid-authorized. Close-group replica majority constitutes derived evidence of prior authorization and serves as a paid-list recovery path after cold starts or persistence failures.
-5. Fetch gating is strict: only keys in the admitted replica-hint pipeline are fetch-eligible. Keys admitted only via paid hints MUST NOT be queued for fetch, even when rules 1, 3, or 4 succeed.
+5. Fetch gating is strict: replica-hint keys are fetch-eligible after authorization; paid-hint-only keys are fetch-eligible only when rules 1, 3, or 4 succeed and `IsResponsible(self, K)` is true. Paid-hint-only keys that are not storage-responsible update authorization state only and MUST NOT be queued for fetch.
 6. If neither paid-list confirmations (rule 3) nor close-group replica majority via presence evidence (rule 4) are met, paid-list authorization fails for this verification round.
 7. Nodes answering paid-list queries MUST answer from local `PaidForList` state only; they MUST NOT infer paid status from record presence alone. (Derived paid-list entries from rule 4 are added to `PaidForList` and are thereafter indistinguishable from PoP-derived entries when answering queries.)
 8. If a node learns `K` is paid-authorized by majority or close-group replica majority, it SHOULD include `K` in outbound `PaidHintsForPeer` for relevant neighbors so peers can re-check and converge.
@@ -277,9 +277,9 @@ Transition requirements:
 - `OfferReceived -> PendingVerify` only for unknown admitted keys: replica-hint keys must satisfy replica relevance (`IsResponsible(self, K)` or already local/pending), and paid-hint-only keys must satisfy paid relevance (`self ∈ PaidCloseGroup(K)` or already in local `PaidForList` pending cleanup).
 - `PendingVerify -> QuorumVerified` only for keys in the admitted replica-hint pipeline, and only if presence positives from the current verification round reach `>= QuorumNeeded(K)`. On success, record the set of positive responders as verified fetch sources and add `K` to local `PaidForList(self)` (close-group replica majority derives paid-list authorization).
 - `PendingVerify -> PaidListVerified` if paid confirmations from the current verification round reach `>= ConfirmNeeded(K)`, or if a paid-hint-only key reaches presence quorum in the same round (derived paid-list authorization). On success, mark key as paid-authorized locally and record peers that responded `Present` as verified fetch sources.
-- `PaidListVerified -> QueuedForFetch` only for keys in the admitted replica-hint pipeline and only when at least one peer responded `Present` (verified fetch source exists).
-- `PaidListVerified -> FetchAbandoned` for keys in the admitted replica-hint pipeline when the presence-only probe completes with zero `Present` responses (no fetch source available). This transition is abnormal: paid-list authorization implies the record was previously stored, so zero holders suggests severe churn or data loss. Implementations SHOULD log this at warning level. Key is forgotten and requires a new offer to re-enter.
-- `PaidListVerified -> Idle` for keys admitted only via paid hints (no record fetch).
+- `PaidListVerified -> QueuedForFetch` only for keys that are fetch-eligible and have at least one peer that responded `Present` (verified fetch source exists). Fetch-eligible means either the admitted replica-hint pipeline, or the paid-hint-only pipeline with `IsResponsible(self, K)=true`.
+- `PaidListVerified -> FetchAbandoned` for fetch-eligible keys when the presence probe completes with zero `Present` responses (no fetch source available). This transition is abnormal: paid-list authorization implies the record was previously stored, so zero holders suggests severe churn or data loss. Implementations SHOULD log this at warning level. Key is forgotten and requires a new offer to re-enter.
+- `PaidListVerified -> Idle` for paid-hint-only keys where `IsResponsible(self, K)=false` (no record fetch).
 - `PendingVerify -> QuorumInconclusive` when neither quorum nor paid-list success is reached and unresolved outcomes (timeout/no-response) keep both outcomes undecidable in this round.
 - `Fetching -> Stored` only after all storage validation checks pass.
 - `Fetching -> FetchRetryable` when fetch fails (timeout, corrupt response, connection error), the transport classifies the attempt as retryable, and at least one untried verified source remains. Mark the failed source as tried so it is not selected again.
@@ -295,8 +295,9 @@ For each unknown key:
 1. Deduplicate key in pending-verification table.
 2. Determine fetch eligibility from admission context:
     - Apply cross-set precedence first (Section 6.2 rule 9): a key present in both hint sets is treated as replica-hint pipeline only.
-    - `FetchEligible = true` only if `K` is in the admitted replica-hint pipeline.
-    - `FetchEligible = false` for paid-hint-only keys.
+    - `FetchEligible = true` if `K` is in the admitted replica-hint pipeline.
+    - `FetchEligible = true` for a paid-hint-only key only if `IsResponsible(self, K)` is true.
+    - `FetchEligible = false` for paid-hint-only keys where `IsResponsible(self, K)` is false.
 3. Compute `QuorumTargets` as up to `CLOSE_GROUP_SIZE` nearest known peers for `K` in `LocalRT(self)` (excluding self).
 4. If `K` is already in local `PaidForList`:
     - If `FetchEligible`, mark `PaidListVerified`. Run a presence-only probe to `QuorumTargets` to discover holders (no paid-list or authorization verification needed). Enqueue fetch using peers that responded `Present`; if no peer responds `Present`, transition to `FetchAbandoned`.
@@ -306,7 +307,7 @@ For each unknown key:
 7. Compute `VerifyTargets = PaidTargets ∪ QuorumTargets`.
 8. Send verification requests to peers in `VerifyTargets` and continue the round until either success/fail-fast is reached or a local adaptive verification deadline for this round expires. Responses carry binary presence semantics (Section 7.6); peers in `PaidTargets` also return paid-list presence for `K`.
 9. As soon as paid confirmations from `PaidTargets` reach `>= ConfirmNeeded(K)`, add `K` to local `PaidForList(self)` and mark `PaidListVerified`. Fetch sources are peers from the same round that responded `Present` (not all paid-confirming peers).
-10. As soon as presence positives from `QuorumTargets` reach `>= QuorumNeeded(K)`, add `K` to local `PaidForList(self)` (derived paid-list authorization; Section 7.2 rule 4). If `FetchEligible`, mark `QuorumVerified`; otherwise mark `PaidListVerified`.
+10. As soon as presence positives from `QuorumTargets` reach `>= QuorumNeeded(K)`, add `K` to local `PaidForList(self)` (derived paid-list authorization; Section 7.2 rule 4). If the key came from the replica-hint pipeline, mark `QuorumVerified`; otherwise mark `PaidListVerified`.
 11. Verification succeeds as soon as either step 9 or step 10 condition is met (logical OR).
 12. If verification succeeded and `FetchEligible`, enqueue fetch using verified sources (peers that responded `Present` during the verification round). If no peer responded `Present`, transition to `FetchAbandoned` (same abnormal condition as Section 9 step 4). The hint sender is a fetch source only if it also responded `Present`; non-holder forwarders are excluded to avoid false `ReplicationFailure` evidence.
 13. If verification succeeded and `FetchEligible = false`, terminate lifecycle without fetch (`PaidListVerified -> Idle`).
@@ -491,7 +492,7 @@ A joining node performs active sync:
 3. Request replica hints (keys peers think self should hold) and paid hints (keys peers think self should track) in round-robin batches of up to `NEIGHBOR_SYNC_PEER_COUNT` peers at a time. If the same key appears in both hint types, collapse to replica-hint processing only.
 4. For each discovered key `K`, compute `QuorumTargets` as up to `CLOSE_GROUP_SIZE` nearest known peers for `K` (excluding self), and compute `QuorumNeeded(K) = min(QUORUM_THRESHOLD, floor(|QuorumTargets|/2)+1)`.
 5. Aggregate paid-list reports and add key `K` to local `PaidForList` only if paid reports are `>= ConfirmNeeded(K)`.
-6. Aggregate key-presence reports and accept only replica-hint-discovered keys observed from `>= QuorumNeeded(K)` peers, or replica-hint-discovered keys that are now paid-authorized locally. Keys discovered only via paid hints are never accepted for fetch; they only update `PaidForList`. When a key meets presence quorum, also add `K` to local `PaidForList(self)` (close-group replica majority derives paid-list authorization per Section 7.2 rule 4).
+6. Aggregate key-presence reports and accept replica-hint-discovered keys observed from `>= QuorumNeeded(K)` peers, replica-hint-discovered keys that are now paid-authorized locally, and paid-hint-only keys where `IsResponsible(self, K)` is true and verified `Present` sources exist. Paid-hint-only keys where self is not storage-responsible only update `PaidForList`. When a key meets presence quorum, also add `K` to local `PaidForList(self)` (close-group replica majority derives paid-list authorization per Section 7.2 rule 4).
 7. Fetch accepted keys with bootstrap concurrency.
 8. Fall back to normal concurrency after `BootstrapDrained(self)` is true.
 9. Set `BootstrapDrained(self)=true` only when both conditions hold:
@@ -575,7 +576,7 @@ Each scenario should assert exact expected outcomes and state transitions.
 20. Paid-list local hit:
 - Admitted unknown replica key with local paid-list entry bypasses presence quorum and enters fetch pipeline.
 21. Paid-list majority confirmation:
-- Admitted unknown replica key not in local paid list is accepted for fetch only after `>= ConfirmNeeded(K)` confirmations from `PaidCloseGroup(K)`. For a paid-hint-only key, the same confirmation updates `PaidForList` but does not enqueue fetch.
+- Admitted unknown replica key not in local paid list is accepted for fetch only after `>= ConfirmNeeded(K)` confirmations from `PaidCloseGroup(K)`. For a paid-hint-only key, the same confirmation updates `PaidForList`; it also allows fetch when self is storage-responsible and a verified `Present` source exists.
 22. Paid-list rejection:
 - Admitted unknown replica key is rejected when paid confirmations are below threshold and presence quorum also fails.
 23. Paid-list cleanup after churn:

--- a/docs/REPLICATION_DESIGN.md
+++ b/docs/REPLICATION_DESIGN.md
@@ -251,9 +251,9 @@ PendingVerify
 QuorumVerified
   -> QueuedForFetch
 PaidListVerified
-  -> QueuedForFetch     (admitted replica-hint pipeline only; at least one source responded Present)
-  -> FetchAbandoned     (admitted replica-hint pipeline; no peer responded Present — indicates possible data loss, see note below)
-  -> Idle               (paid-hint-only pipeline; `PaidForList` updated)
+  -> QueuedForFetch     (fetch-eligible key; at least one source responded Present)
+  -> FetchAbandoned     (fetch-eligible key; no peer responded Present — indicates possible data loss, see note below)
+  -> Idle               (not fetch-eligible; `PaidForList` updated)
 QueuedForFetch
   -> Fetching
 Fetching

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -75,6 +75,18 @@ const RR_PREFIX: &str = "/rr/";
 /// Boxed future type for in-flight fetch tasks.
 type FetchFuture = Pin<Box<dyn Future<Output = (XorName, Option<FetchOutcome>)> + Send>>;
 
+/// Shared dependencies for one verification worker cycle.
+struct VerificationCycleContext<'a> {
+    p2p_node: &'a Arc<P2PNode>,
+    paid_list: &'a Arc<PaidList>,
+    storage: &'a Arc<LmdbStorage>,
+    queues: &'a Arc<RwLock<ReplicationQueues>>,
+    config: &'a ReplicationConfig,
+    bootstrap_state: &'a Arc<RwLock<BootstrapState>>,
+    is_bootstrapping: &'a Arc<RwLock<bool>>,
+    bootstrap_complete_notify: &'a Arc<Notify>,
+}
+
 /// Fetch worker polling interval in milliseconds.
 const FETCH_WORKER_POLL_MS: u64 = 100;
 
@@ -735,11 +747,17 @@ impl ReplicationEngine {
                     () = tokio::time::sleep(
                         std::time::Duration::from_millis(VERIFICATION_WORKER_POLL_MS)
                     ) => {
-                        run_verification_cycle(
-                            &p2p, &paid_list, &storage, &queues, &config,
-                            &bootstrap_state, &is_bootstrapping,
-                            &bootstrap_complete_notify,
-                        ).await;
+                        let ctx = VerificationCycleContext {
+                            p2p_node: &p2p,
+                            paid_list: &paid_list,
+                            storage: &storage,
+                            queues: &queues,
+                            config: &config,
+                            bootstrap_state: &bootstrap_state,
+                            is_bootstrapping: &is_bootstrapping,
+                            bootstrap_complete_notify: &bootstrap_complete_notify,
+                        };
+                        run_verification_cycle(ctx).await;
                     }
                 }
             }
@@ -1802,16 +1820,18 @@ async fn admit_and_queue_hints(
 
 /// Run one verification cycle: process pending keys through quorum checks.
 #[allow(clippy::too_many_lines)]
-async fn run_verification_cycle(
-    p2p_node: &Arc<P2PNode>,
-    paid_list: &Arc<PaidList>,
-    storage: &Arc<LmdbStorage>,
-    queues: &Arc<RwLock<ReplicationQueues>>,
-    config: &ReplicationConfig,
-    bootstrap_state: &Arc<RwLock<BootstrapState>>,
-    is_bootstrapping: &Arc<RwLock<bool>>,
-    bootstrap_complete_notify: &Arc<Notify>,
-) {
+async fn run_verification_cycle(ctx: VerificationCycleContext<'_>) {
+    let VerificationCycleContext {
+        p2p_node,
+        paid_list,
+        storage,
+        queues,
+        config,
+        bootstrap_state,
+        is_bootstrapping,
+        bootstrap_complete_notify,
+    } = ctx;
+
     // Evict stale entries that have been pending too long (e.g. unreachable
     // verification targets during a network partition).
     {

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -719,6 +719,7 @@ impl ReplicationEngine {
 
     fn start_verification_worker(&mut self) {
         let p2p = Arc::clone(&self.p2p_node);
+        let storage = Arc::clone(&self.storage);
         let queues = Arc::clone(&self.queues);
         let paid_list = Arc::clone(&self.paid_list);
         let config = Arc::clone(&self.config);
@@ -735,7 +736,7 @@ impl ReplicationEngine {
                         std::time::Duration::from_millis(VERIFICATION_WORKER_POLL_MS)
                     ) => {
                         run_verification_cycle(
-                            &p2p, &paid_list, &queues, &config,
+                            &p2p, &paid_list, &storage, &queues, &config,
                             &bootstrap_state, &is_bootstrapping,
                             &bootstrap_complete_notify,
                         ).await;
@@ -1804,6 +1805,7 @@ async fn admit_and_queue_hints(
 async fn run_verification_cycle(
     p2p_node: &Arc<P2PNode>,
     paid_list: &Arc<PaidList>,
+    storage: &Arc<LmdbStorage>,
     queues: &Arc<RwLock<ReplicationQueues>>,
     config: &ReplicationConfig,
     bootstrap_state: &Arc<RwLock<BootstrapState>>,
@@ -1864,27 +1866,31 @@ async fn run_verification_cycle(
     }
 
     if !local_paid_paid_only_keys.is_empty() {
-        let mut non_responsible_paid_only = Vec::new();
+        let mut terminal_paid_only = Vec::new();
         for key in local_paid_paid_only_keys {
-            if admission::is_responsible(&self_id, &key, p2p_node, config.close_group_size).await {
+            if storage.exists(&key).unwrap_or(false) {
+                terminal_paid_only.push(key);
+            } else if admission::is_responsible(&self_id, &key, p2p_node, config.close_group_size)
+                .await
+            {
                 local_paid_presence_probe_keys.push(key);
             } else {
-                non_responsible_paid_only.push(key);
+                terminal_paid_only.push(key);
             }
         }
 
-        if !non_responsible_paid_only.is_empty() {
+        if !terminal_paid_only.is_empty() {
             let mut q = queues.write().await;
-            for key in non_responsible_paid_only {
+            for key in terminal_paid_only {
                 q.remove_pending(&key);
                 terminal_keys.push(key);
             }
         }
     }
 
-    // Step 1b: Local paid-list hit for replica hints. Per Section 9 step 4,
-    // authorization succeeds immediately; run a presence-only probe to find
-    // any holder we can fetch from.
+    // Step 1b: Local paid-list hit for fetch-eligible keys. Per Section 9
+    // step 4, authorization succeeds immediately; run a presence-only probe
+    // to find any holder we can fetch from.
     if !local_paid_presence_probe_keys.is_empty() {
         let targets = quorum::compute_presence_targets(
             &local_paid_presence_probe_keys,
@@ -1903,6 +1909,11 @@ async fn run_verification_cycle(
 
         let mut q = queues.write().await;
         for key in local_paid_presence_probe_keys {
+            if storage.exists(&key).unwrap_or(false) {
+                q.remove_pending(&key);
+                terminal_keys.push(key);
+                continue;
+            }
             let sources = evidence.get(&key).map_or_else(Vec::new, |ev| {
                 quorum::present_sources_for_key(&key, ev, &targets)
             });
@@ -1976,6 +1987,7 @@ async fn run_verification_cycle(
                     KeyVerificationOutcome::QuorumVerified { .. }
                         | KeyVerificationOutcome::PaidListVerified { .. }
                 )
+                && !storage.exists(key).unwrap_or(false)
                 && admission::is_responsible(&self_id, key, p2p_node, config.close_group_size).await
             {
                 paid_only_fetch_keys.insert(*key);

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -1830,6 +1830,8 @@ async fn run_verification_cycle(
 
     // Step 1: Check local PaidForList for fast-path authorization (Section 9,
     // step 4).
+    let mut local_paid_presence_probe_keys = Vec::new();
+    let mut local_paid_paid_only_keys = Vec::new();
     let mut keys_needing_network = Vec::new();
     let mut terminal_keys: Vec<XorName> = Vec::new();
     {
@@ -1838,16 +1840,83 @@ async fn run_verification_cycle(
             if paid_list.contains(key).unwrap_or(false) {
                 if let Some(entry) = q.get_pending_mut(key) {
                     entry.state = VerificationState::PaidListVerified;
-                    if entry.pipeline == HintPipeline::PaidOnly {
-                        // Paid-only pipeline: PaidForList already updated, done.
-                        q.remove_pending(key);
-                        terminal_keys.push(*key);
-                        continue;
+                    match entry.pipeline {
+                        HintPipeline::PaidOnly => {
+                            // Paid-only + local paid state needs one more
+                            // responsibility check outside this lock: if we
+                            // are also in the storage close group, the hint
+                            // can repair a missing replica.
+                            local_paid_paid_only_keys.push(*key);
+                        }
+                        HintPipeline::Replica => {
+                            // Local paid-list membership authorizes the key.
+                            // We still need a presence probe to discover fetch
+                            // sources, but we must not require remote paid
+                            // majority or presence quorum.
+                            local_paid_presence_probe_keys.push(*key);
+                        }
                     }
                 }
+            } else {
+                keys_needing_network.push(*key);
             }
-            // Both branches (paid locally or not) need network verification.
-            keys_needing_network.push(*key);
+        }
+    }
+
+    if !local_paid_paid_only_keys.is_empty() {
+        let mut non_responsible_paid_only = Vec::new();
+        for key in local_paid_paid_only_keys {
+            if admission::is_responsible(&self_id, &key, p2p_node, config.close_group_size).await {
+                local_paid_presence_probe_keys.push(key);
+            } else {
+                non_responsible_paid_only.push(key);
+            }
+        }
+
+        if !non_responsible_paid_only.is_empty() {
+            let mut q = queues.write().await;
+            for key in non_responsible_paid_only {
+                q.remove_pending(&key);
+                terminal_keys.push(key);
+            }
+        }
+    }
+
+    // Step 1b: Local paid-list hit for replica hints. Per Section 9 step 4,
+    // authorization succeeds immediately; run a presence-only probe to find
+    // any holder we can fetch from.
+    if !local_paid_presence_probe_keys.is_empty() {
+        let targets = quorum::compute_presence_targets(
+            &local_paid_presence_probe_keys,
+            p2p_node,
+            config,
+            &self_id,
+        )
+        .await;
+        let evidence = quorum::run_verification_round(
+            &local_paid_presence_probe_keys,
+            &targets,
+            p2p_node,
+            config,
+        )
+        .await;
+
+        let mut q = queues.write().await;
+        for key in local_paid_presence_probe_keys {
+            let sources = evidence.get(&key).map_or_else(Vec::new, |ev| {
+                quorum::present_sources_for_key(&key, ev, &targets)
+            });
+            q.remove_pending(&key);
+            if sources.is_empty() {
+                warn!(
+                    "Locally paid key {} has no responding holders (possible data loss)",
+                    hex::encode(key)
+                );
+                terminal_keys.push(key);
+            } else {
+                let distance = crate::client::xor_distance(&key, p2p_node.peer_id().as_bytes());
+                q.enqueue_fetch(key, distance, sources);
+            }
         }
     }
 
@@ -1895,21 +1964,41 @@ async fn run_verification_cycle(
             }
         }
 
+        // Paid-only hints normally update PaidForList only. If this node is
+        // also storage-responsible for the key, a verified paid-only hint can
+        // safely repair a missing replica using sources from the same
+        // verification round.
+        let mut paid_only_fetch_keys: HashSet<XorName> = HashSet::new();
+        for (key, outcome, pipeline) in &evaluated {
+            if *pipeline == HintPipeline::PaidOnly
+                && matches!(
+                    outcome,
+                    KeyVerificationOutcome::QuorumVerified { .. }
+                        | KeyVerificationOutcome::PaidListVerified { .. }
+                )
+                && admission::is_responsible(&self_id, key, p2p_node, config.close_group_size).await
+            {
+                paid_only_fetch_keys.insert(*key);
+            }
+        }
+
         // Step 5: Update queues with the evaluated outcomes.
         let mut q = queues.write().await;
         for (key, outcome, pipeline) in evaluated {
             match outcome {
                 KeyVerificationOutcome::QuorumVerified { sources }
                 | KeyVerificationOutcome::PaidListVerified { sources } => {
-                    if pipeline == HintPipeline::Replica && !sources.is_empty() {
+                    let fetch_eligible =
+                        pipeline == HintPipeline::Replica || paid_only_fetch_keys.contains(&key);
+                    if fetch_eligible && !sources.is_empty() {
                         let distance =
                             crate::client::xor_distance(&key, p2p_node.peer_id().as_bytes());
                         q.remove_pending(&key);
                         q.enqueue_fetch(key, distance, sources);
                         // Not terminal — key moved to fetch queue.
-                    } else if pipeline == HintPipeline::Replica && sources.is_empty() {
+                    } else if fetch_eligible && sources.is_empty() {
                         warn!(
-                            "Verified key {} has no holders (possible data loss)",
+                            "Verified responsible key {} has no holders (possible data loss)",
                             hex::encode(key)
                         );
                         q.remove_pending(&key);
@@ -2137,9 +2226,21 @@ async fn execute_single_fetch(
                 ReplicationMessageBody::FetchResponse(protocol::FetchResponse::NotFound {
                     ..
                 }) => {
-                    // NotFound is a legitimate response (peer may have pruned
-                    // the data). No trust penalty — just retry another source.
-                    debug!("Fetch: peer {source} does not have {}", hex::encode(key));
+                    // This peer was selected as a fetch source because it
+                    // recently answered `Present` during verification. A
+                    // subsequent NotFound is evidence of a stale/false claim
+                    // or chunk wiping, so penalize lightly and try another
+                    // verified source.
+                    warn!(
+                        "Fetch: verified source {source} returned NotFound for {}",
+                        hex::encode(key)
+                    );
+                    p2p_node
+                        .report_trust_event(
+                            &source,
+                            TrustEvent::ApplicationFailure(REPLICATION_TRUST_WEIGHT),
+                        )
+                        .await;
                     FetchOutcome {
                         key,
                         result: FetchResult::SourceFailed,

--- a/src/replication/quorum.rs
+++ b/src/replication/quorum.rs
@@ -211,14 +211,10 @@ pub fn evaluate_key_evidence(
     // Count presence evidence from QuorumTargets.
     let mut presence_positive = 0usize;
     let mut presence_unresolved = 0usize;
-    let mut present_peers = Vec::new();
 
     for peer in quorum_peers {
         match evidence.presence.get(peer) {
-            Some(PresenceEvidence::Present) => {
-                presence_positive += 1;
-                present_peers.push(*peer);
-            }
+            Some(PresenceEvidence::Present) => presence_positive += 1,
             Some(PresenceEvidence::Absent) => {}
             Some(PresenceEvidence::Unresolved) | None => {
                 presence_unresolved += 1;
@@ -228,14 +224,7 @@ pub fn evaluate_key_evidence(
 
     // Also collect Present peers from paid targets for fetch sources.
     let paid_peers = targets.paid_targets.get(key).map_or(&[][..], Vec::as_slice);
-
-    for peer in paid_peers {
-        if matches!(evidence.presence.get(peer), Some(PresenceEvidence::Present))
-            && !present_peers.contains(peer)
-        {
-            present_peers.push(*peer);
-        }
-    }
+    let present_peers = collect_present_sources(evidence, quorum_peers, paid_peers);
 
     // Count paid-list evidence from PaidTargets.
     let mut paid_confirmed = 0usize;
@@ -297,23 +286,28 @@ pub fn present_sources_for_key(
     evidence: &KeyVerificationEvidence,
     targets: &VerificationTargets,
 ) -> Vec<PeerId> {
+    let quorum_peers = targets
+        .quorum_targets
+        .get(key)
+        .map_or(&[][..], Vec::as_slice);
+    let paid_peers = targets.paid_targets.get(key).map_or(&[][..], Vec::as_slice);
+
+    collect_present_sources(evidence, quorum_peers, paid_peers)
+}
+
+fn collect_present_sources(
+    evidence: &KeyVerificationEvidence,
+    quorum_peers: &[PeerId],
+    paid_peers: &[PeerId],
+) -> Vec<PeerId> {
     let mut present_peers = Vec::new();
+    let mut seen = HashSet::new();
 
-    if let Some(quorum_peers) = targets.quorum_targets.get(key) {
-        for peer in quorum_peers {
-            if matches!(evidence.presence.get(peer), Some(PresenceEvidence::Present)) {
-                present_peers.push(*peer);
-            }
-        }
-    }
-
-    if let Some(paid_peers) = targets.paid_targets.get(key) {
-        for peer in paid_peers {
-            if matches!(evidence.presence.get(peer), Some(PresenceEvidence::Present))
-                && !present_peers.contains(peer)
-            {
-                present_peers.push(*peer);
-            }
+    for peer in quorum_peers.iter().chain(paid_peers.iter()) {
+        if matches!(evidence.presence.get(peer), Some(PresenceEvidence::Present))
+            && seen.insert(*peer)
+        {
+            present_peers.push(*peer);
         }
     }
 
@@ -594,6 +588,44 @@ mod tests {
             presence: presence.into_iter().collect(),
             paid_list: paid_list.into_iter().collect(),
         }
+    }
+
+    #[test]
+    fn present_sources_for_key_filters_targets_and_deduplicates() {
+        let key = xor_name_from_byte(0x11);
+        let q_present = peer_id_from_byte(1);
+        let overlap = peer_id_from_byte(2);
+        let q_absent = peer_id_from_byte(3);
+        let q_unresolved = peer_id_from_byte(4);
+        let paid_present = peer_id_from_byte(5);
+        let paid_absent = peer_id_from_byte(6);
+        let outside_target = peer_id_from_byte(7);
+
+        let targets = single_key_targets(
+            &key,
+            vec![q_present, overlap, q_absent, q_unresolved],
+            vec![overlap, paid_present, paid_absent],
+        );
+        let evidence = build_evidence(
+            vec![
+                (q_present, PresenceEvidence::Present),
+                (overlap, PresenceEvidence::Present),
+                (q_absent, PresenceEvidence::Absent),
+                (q_unresolved, PresenceEvidence::Unresolved),
+                (paid_present, PresenceEvidence::Present),
+                (paid_absent, PresenceEvidence::Absent),
+                (outside_target, PresenceEvidence::Present),
+            ],
+            vec![],
+        );
+
+        let sources = present_sources_for_key(&key, &evidence, &targets);
+
+        assert_eq!(
+            sources,
+            vec![q_present, overlap, paid_present],
+            "sources should preserve quorum-first order, de-duplicate overlap, and ignore non-target/negative evidence"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/src/replication/quorum.rs
+++ b/src/replication/quorum.rs
@@ -29,6 +29,9 @@ pub struct VerificationTargets {
     pub quorum_targets: HashMap<XorName, Vec<PeerId>>,
     /// Per-key: `PaidCloseGroup` peers for paid-list majority.
     pub paid_targets: HashMap<XorName, Vec<PeerId>>,
+    /// Per-key: self-inclusive paid close-group size used to compute
+    /// `ConfirmNeeded(K)`.
+    pub paid_group_sizes: HashMap<XorName, usize>,
     /// Union of all target peers across all keys.
     pub all_peers: HashSet<PeerId>,
     /// Which keys each peer should be queried about.
@@ -52,6 +55,7 @@ pub async fn compute_verification_targets(
     let mut targets = VerificationTargets {
         quorum_targets: HashMap::new(),
         paid_targets: HashMap::new(),
+        paid_group_sizes: HashMap::new(),
         all_peers: HashSet::new(),
         peer_to_keys: HashMap::new(),
         peer_to_paid_keys: HashMap::new(),
@@ -73,6 +77,7 @@ pub async fn compute_verification_targets(
         let paid_closest = dht
             .find_closest_nodes_local_with_self(&key, config.paid_list_close_group_size)
             .await;
+        let paid_group_size = paid_closest.len();
         let paid_peers: Vec<PeerId> = paid_closest
             .iter()
             .filter(|n| n.peer_id != *self_id)
@@ -96,10 +101,57 @@ pub async fn compute_verification_targets(
 
         targets.quorum_targets.insert(key, quorum_peers);
         targets.paid_targets.insert(key, paid_peers);
+        targets.paid_group_sizes.insert(key, paid_group_size);
     }
 
     // Deduplicate keys per peer (a peer in both quorum and paid targets for
     // the same key would have it listed twice).
+    for keys_list in targets.peer_to_keys.values_mut() {
+        keys_list.sort_unstable();
+        keys_list.dedup();
+    }
+
+    targets
+}
+
+/// Compute presence-only verification targets for locally paid keys.
+///
+/// Local `PaidForList` membership authorizes the key already; this target set
+/// is only used to discover peers that can serve the record bytes.
+pub async fn compute_presence_targets(
+    keys: &[XorName],
+    p2p_node: &Arc<P2PNode>,
+    config: &ReplicationConfig,
+    self_id: &PeerId,
+) -> VerificationTargets {
+    let dht = p2p_node.dht_manager();
+    let mut targets = VerificationTargets {
+        quorum_targets: HashMap::new(),
+        paid_targets: HashMap::new(),
+        paid_group_sizes: HashMap::new(),
+        all_peers: HashSet::new(),
+        peer_to_keys: HashMap::new(),
+        peer_to_paid_keys: HashMap::new(),
+    };
+
+    for &key in keys {
+        let closest = dht
+            .find_closest_nodes_local(&key, config.close_group_size)
+            .await;
+        let quorum_peers: Vec<PeerId> = closest
+            .iter()
+            .filter(|n| n.peer_id != *self_id)
+            .map(|n| n.peer_id)
+            .collect();
+
+        for &peer in &quorum_peers {
+            targets.all_peers.insert(peer);
+            targets.peer_to_keys.entry(peer).or_default().push(key);
+        }
+
+        targets.quorum_targets.insert(key, quorum_peers);
+    }
+
     for keys_list in targets.peer_to_keys.values_mut() {
         keys_list.sort_unstable();
         keys_list.dedup();
@@ -198,7 +250,11 @@ pub fn evaluate_key_evidence(
     }
 
     let quorum_needed = config.quorum_needed(quorum_peers.len());
-    let paid_group_size = paid_peers.len();
+    let paid_group_size = targets
+        .paid_group_sizes
+        .get(key)
+        .copied()
+        .unwrap_or(paid_peers.len());
     let confirm_needed = ReplicationConfig::confirm_needed(paid_group_size);
 
     // Step 10: Presence quorum reached.
@@ -230,6 +286,38 @@ pub fn evaluate_key_evidence(
 
     // Step 15: Neither success nor fail-fast.
     KeyVerificationOutcome::QuorumInconclusive
+}
+
+/// Return peers that gave positive presence evidence for a key.
+///
+/// Only peers in the computed verification target sets are considered.
+#[must_use]
+pub fn present_sources_for_key(
+    key: &XorName,
+    evidence: &KeyVerificationEvidence,
+    targets: &VerificationTargets,
+) -> Vec<PeerId> {
+    let mut present_peers = Vec::new();
+
+    if let Some(quorum_peers) = targets.quorum_targets.get(key) {
+        for peer in quorum_peers {
+            if matches!(evidence.presence.get(peer), Some(PresenceEvidence::Present)) {
+                present_peers.push(*peer);
+            }
+        }
+    }
+
+    if let Some(paid_peers) = targets.paid_targets.get(key) {
+        for peer in paid_peers {
+            if matches!(evidence.presence.get(peer), Some(PresenceEvidence::Present))
+                && !present_peers.contains(peer)
+            {
+                present_peers.push(*peer);
+            }
+        }
+    }
+
+    present_peers
 }
 
 // ---------------------------------------------------------------------------
@@ -485,8 +573,10 @@ mod tests {
             keys_list.dedup();
         }
 
+        let paid_group_size = paid_peers.len();
         VerificationTargets {
             quorum_targets: std::iter::once((key.to_owned(), quorum_peers)).collect(),
+            paid_group_sizes: std::iter::once((key.to_owned(), paid_group_size)).collect(),
             paid_targets: std::iter::once((key.to_owned(), paid_peers)).collect(),
             all_peers,
             peer_to_keys,
@@ -710,6 +800,66 @@ mod tests {
     }
 
     #[test]
+    fn paid_list_majority_uses_self_inclusive_paid_group_size() {
+        let key = xor_name_from_byte(0x61);
+        let config = ReplicationConfig::default();
+
+        // Real target computation uses PaidCloseGroup(K), which is
+        // self-inclusive. If self is in a 20-node paid group and does not
+        // already have local paid-list state, 10 remote confirmations are not
+        // enough: ConfirmNeeded(20) is 11.
+        let paid_peers: Vec<PeerId> = (1..=19).map(peer_id_from_byte).collect();
+        let mut targets = single_key_targets(&key, vec![], paid_peers.clone());
+        targets.paid_group_sizes.insert(key, 20);
+
+        let ten_confirmations = build_evidence(
+            vec![],
+            paid_peers
+                .iter()
+                .enumerate()
+                .map(|(i, p)| {
+                    (
+                        *p,
+                        if i < 10 {
+                            PaidListEvidence::Confirmed
+                        } else {
+                            PaidListEvidence::NotFound
+                        },
+                    )
+                })
+                .collect(),
+        );
+        let outcome = evaluate_key_evidence(&key, &ten_confirmations, &targets, &config);
+        assert!(
+            matches!(outcome, KeyVerificationOutcome::QuorumFailed),
+            "10/20 paid confirmations must not authorize the key, got {outcome:?}"
+        );
+
+        let eleven_confirmations = build_evidence(
+            vec![],
+            paid_peers
+                .iter()
+                .enumerate()
+                .map(|(i, p)| {
+                    (
+                        *p,
+                        if i < 11 {
+                            PaidListEvidence::Confirmed
+                        } else {
+                            PaidListEvidence::NotFound
+                        },
+                    )
+                })
+                .collect(),
+        );
+        let outcome = evaluate_key_evidence(&key, &eleven_confirmations, &targets, &config);
+        assert!(
+            matches!(outcome, KeyVerificationOutcome::PaidListVerified { .. }),
+            "11/20 paid confirmations should authorize the key, got {outcome:?}"
+        );
+    }
+
+    #[test]
     fn quorum_fails_with_zero_targets_no_paid() {
         let key = xor_name_from_byte(0x70);
         let config = ReplicationConfig::default();
@@ -903,6 +1053,7 @@ mod tests {
         let targets = VerificationTargets {
             quorum_targets: std::iter::once((key_a, vec![peer])).collect(),
             paid_targets: std::iter::once((key_b, vec![peer])).collect(),
+            paid_group_sizes: [(key_a, 0), (key_b, 1)].into_iter().collect(),
             all_peers: std::iter::once(peer).collect(),
             peer_to_keys: std::iter::once((peer, vec![key_a, key_b])).collect(),
             peer_to_paid_keys: std::iter::once((peer, std::iter::once(key_b).collect())).collect(),
@@ -1131,12 +1282,17 @@ mod tests {
         quorum_targets.insert(*key_b, quorum_peers_b);
 
         let mut paid_targets = HashMap::new();
+        let paid_group_size_a = paid_peers_a.len();
+        let paid_group_size_b = paid_peers_b.len();
         paid_targets.insert(*key_a, paid_peers_a);
         paid_targets.insert(*key_b, paid_peers_b);
 
         VerificationTargets {
             quorum_targets,
             paid_targets,
+            paid_group_sizes: [(*key_a, paid_group_size_a), (*key_b, paid_group_size_b)]
+                .into_iter()
+                .collect(),
             all_peers,
             peer_to_keys,
             peer_to_paid_keys,


### PR DESCRIPTION
## Summary
- Count paid-list quorum against the self-inclusive paid close group.
- Allow verified paid-only hints to repair replicas only when the receiver is storage-responsible.
- Penalize verified fetch sources that later return `NotFound`.
- Update the replication design doc to match the paid-only repair rule.

## SemVer
- Patch: hardens replication repair behavior without changing public APIs.

## Validation
- `cargo check`
- `cargo test --lib replication`
- `git diff --check`