### PR TITLE
strip unused QuotingMetricsTracker surface, dead deps, and dead feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,42 +53,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "aes-gcm-siv"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "polyval",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -841,7 +811,6 @@ dependencies = [
 name = "ant-node"
 version = "0.11.4"
 dependencies = [
- "aes-gcm-siv",
  "alloy",
  "ant-protocol",
  "blake3",
@@ -856,7 +825,6 @@ dependencies = [
  "futures",
  "heed",
  "hex",
- "hkdf",
  "lru",
  "objc2",
  "objc2-foundation",
@@ -870,7 +838,6 @@ dependencies = [
  "saorsa-core",
  "saorsa-pqc 0.5.1",
  "self-replace",
- "self_encryption",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -1441,27 +1408,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "brotli"
-version = "3.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "2.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503a0bcf59056a66c55d8eefd05e9c0f00f9c9cdddbb6bd499623ce49100da43"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
 ]
 
 [[package]]
@@ -5215,28 +5161,6 @@ dependencies = [
  "fastrand",
  "tempfile",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "self_encryption"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11020d59e8e663ba591026c2b45a08caa74a3a654ac12b2532d5a7c5b97e510"
-dependencies = [
- "bincode",
- "blake3",
- "brotli",
- "bytes",
- "chacha20poly1305",
- "hex",
- "rand 0.8.6",
- "rand_chacha 0.3.1",
- "rayon",
- "serde",
- "tempfile",
- "thiserror 1.0.69",
- "tokio",
- "xor_name",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,11 +50,6 @@ parking_lot = "0.12"  # Efficient mutex for cache
 # Storage - LMDB via heed for content-addressed chunk store
 heed = "0.22"
 
-# Migration: Decrypt ant-node data (read-only)
-aes-gcm-siv = "0.11"
-hkdf = "0.12"
-
-self_encryption = "0.35.0"
 blake3 = "1"
 
 # Async runtime
@@ -137,8 +132,6 @@ default = ["logging"]
 # automatically. Release builds strip it:
 #   cargo build --release --no-default-features
 logging = ["tracing", "tracing-subscriber", "tracing-appender"]
-# Enable additional diagnostics for development
-dev = []
 # Expose test helpers (cache_insert, payment_verifier accessor) for
 # integration tests and downstream test harnesses.
 test-utils = []

--- a/src/payment/metrics.rs
+++ b/src/payment/metrics.rs
@@ -1,40 +1,18 @@
 //! Quoting metrics tracking for ant-node.
 //!
-//! Tracks metrics used for quote generation, including:
-//! - `received_payment_count` - number of payments received
-//! - Storage capacity and usage
-//! - Network liveness information
+//! Tracks the single piece of state that influences quote pricing today:
+//! the number of records currently stored in the node's close range.
+//! See `payment::pricing::calculate_price` for the formula.
 
-use crate::logging::{debug, info, warn};
-use evmlib::quoting_metrics::QuotingMetrics;
-use parking_lot::RwLock;
-use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use std::time::Instant;
-
-/// Number of operations between disk persists (debounce).
-const PERSIST_INTERVAL: usize = 10;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Tracker for quoting metrics.
 ///
-/// Maintains state that influences quote pricing, including payment history,
-/// storage usage, and network information.
+/// Holds the `close_records_stored` counter consumed by
+/// [`calculate_price`](crate::payment::pricing::calculate_price).
 #[derive(Debug)]
 pub struct QuotingMetricsTracker {
-    /// Number of payments received by this node.
-    received_payment_count: AtomicUsize,
-    /// Number of records currently stored.
     close_records_stored: AtomicUsize,
-    /// Records stored by type: `Vec<(data_type_index, count)>`.
-    records_per_type: RwLock<Vec<(u32, u32)>>,
-    /// Node start time for calculating `live_time`.
-    start_time: Instant,
-    /// Path for persisting metrics (optional).
-    persist_path: Option<PathBuf>,
-    /// Estimated network size.
-    network_size: AtomicU64,
-    /// Operations since last persist (for debouncing disk I/O).
-    ops_since_persist: AtomicUsize,
 }
 
 impl QuotingMetricsTracker {
@@ -46,76 +24,13 @@ impl QuotingMetricsTracker {
     #[must_use]
     pub fn new(initial_records: usize) -> Self {
         Self {
-            received_payment_count: AtomicUsize::new(0),
             close_records_stored: AtomicUsize::new(initial_records),
-            records_per_type: RwLock::new(Vec::new()),
-            start_time: Instant::now(),
-            persist_path: None,
-            network_size: AtomicU64::new(500), // Conservative default
-            ops_since_persist: AtomicUsize::new(0),
         }
     }
 
-    /// Create a new metrics tracker with persistence.
-    ///
-    /// # Arguments
-    ///
-    /// * `persist_path` - Path to persist metrics to disk
-    #[must_use]
-    pub fn with_persistence(persist_path: &std::path::Path) -> Self {
-        let mut tracker = Self::new(0);
-        tracker.persist_path = Some(persist_path.to_path_buf());
-
-        // Try to load existing metrics
-        if let Some(loaded) = Self::load_from_disk(persist_path) {
-            tracker
-                .received_payment_count
-                .store(loaded.received_payment_count, Ordering::SeqCst);
-            tracker
-                .close_records_stored
-                .store(loaded.close_records_stored, Ordering::SeqCst);
-            *tracker.records_per_type.write() = loaded.records_per_type;
-            info!(
-                "Loaded persisted metrics: {} payments received",
-                loaded.received_payment_count
-            );
-        }
-
-        tracker
-    }
-
-    /// Record a payment received.
-    pub fn record_payment(&self) {
-        let count = self.received_payment_count.fetch_add(1, Ordering::SeqCst) + 1;
-        debug!("Payment received, total count: {count}");
-        self.maybe_persist();
-    }
-
-    /// Record data stored.
-    ///
-    /// # Arguments
-    ///
-    /// * `data_type` - Type index of the data
-    pub fn record_store(&self, data_type: u32) {
+    /// Record that a record was stored.
+    pub fn record_store(&self) {
         self.close_records_stored.fetch_add(1, Ordering::SeqCst);
-
-        // Update per-type counts (scope the write lock)
-        {
-            let mut records = self.records_per_type.write();
-            if let Some(entry) = records.iter_mut().find(|(t, _)| *t == data_type) {
-                entry.1 = entry.1.saturating_add(1);
-            } else {
-                records.push((data_type, 1));
-            }
-        }
-
-        self.maybe_persist();
-    }
-
-    /// Get the number of payments received.
-    #[must_use]
-    pub fn payment_count(&self) -> usize {
-        self.received_payment_count.load(Ordering::SeqCst)
     }
 
     /// Get the number of records stored.
@@ -123,240 +38,28 @@ impl QuotingMetricsTracker {
     pub fn records_stored(&self) -> usize {
         self.close_records_stored.load(Ordering::SeqCst)
     }
-
-    /// Get the node's live time in hours.
-    #[must_use]
-    pub fn live_time_hours(&self) -> u64 {
-        self.start_time.elapsed().as_secs() / 3600
-    }
-
-    /// Update the estimated network size.
-    pub fn set_network_size(&self, size: u64) {
-        self.network_size.store(size, Ordering::SeqCst);
-    }
-
-    /// Get quoting metrics for quote generation.
-    ///
-    /// # Arguments
-    ///
-    /// * `data_size` - Size of the data being quoted
-    /// * `data_type` - Type index of the data
-    #[must_use]
-    pub fn get_metrics(&self, data_size: usize, data_type: u32) -> QuotingMetrics {
-        QuotingMetrics {
-            data_type,
-            data_size,
-            close_records_stored: self.close_records_stored.load(Ordering::SeqCst),
-            records_per_type: self.records_per_type.read().clone(),
-            received_payment_count: self.received_payment_count.load(Ordering::SeqCst),
-            live_time: self.live_time_hours(),
-            network_density: None, // Not used in pricing; reserved for future DHT range filtering
-            network_size: Some(self.network_size.load(Ordering::SeqCst)),
-        }
-    }
-
-    /// Debounced persist: only writes to disk every `PERSIST_INTERVAL` operations.
-    fn maybe_persist(&self) {
-        let ops = self.ops_since_persist.fetch_add(1, Ordering::Relaxed);
-        if ops % PERSIST_INTERVAL == 0 {
-            self.persist();
-        }
-    }
-
-    /// Persist metrics to disk.
-    fn persist(&self) {
-        if let Some(ref path) = self.persist_path {
-            let data = PersistedMetrics {
-                received_payment_count: self.received_payment_count.load(Ordering::SeqCst),
-                close_records_stored: self.close_records_stored.load(Ordering::SeqCst),
-                records_per_type: self.records_per_type.read().clone(),
-            };
-
-            if let Ok(bytes) = rmp_serde::to_vec(&data) {
-                if let Err(e) = std::fs::write(path, bytes) {
-                    warn!("Failed to persist metrics: {e}");
-                }
-            }
-        }
-    }
-
-    /// Load metrics from disk.
-    fn load_from_disk(path: &std::path::Path) -> Option<PersistedMetrics> {
-        let bytes = std::fs::read(path).ok()?;
-        rmp_serde::from_slice(&bytes).ok()
-    }
-}
-
-impl Drop for QuotingMetricsTracker {
-    fn drop(&mut self) {
-        self.persist();
-    }
-}
-
-/// Metrics persisted to disk.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-struct PersistedMetrics {
-    received_payment_count: usize,
-    close_records_stored: usize,
-    records_per_type: Vec<(u32, u32)>,
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
-    use tempfile::tempdir;
 
     #[test]
     fn test_new_tracker() {
         let tracker = QuotingMetricsTracker::new(50);
-        assert_eq!(tracker.payment_count(), 0);
         assert_eq!(tracker.records_stored(), 50);
     }
 
     #[test]
-    fn test_record_payment() {
-        let tracker = QuotingMetricsTracker::new(0);
-        assert_eq!(tracker.payment_count(), 0);
-
-        tracker.record_payment();
-        assert_eq!(tracker.payment_count(), 1);
-
-        tracker.record_payment();
-        assert_eq!(tracker.payment_count(), 2);
-    }
-
-    #[test]
-    fn test_record_store() {
+    fn test_record_store_increments_counter() {
         let tracker = QuotingMetricsTracker::new(0);
         assert_eq!(tracker.records_stored(), 0);
 
-        tracker.record_store(0); // Chunk type
+        tracker.record_store();
         assert_eq!(tracker.records_stored(), 1);
 
-        tracker.record_store(0);
-        tracker.record_store(1); // Different type
+        tracker.record_store();
+        tracker.record_store();
         assert_eq!(tracker.records_stored(), 3);
-
-        let metrics = tracker.get_metrics(1024, 0);
-        assert_eq!(metrics.records_per_type.len(), 2);
-    }
-
-    #[test]
-    fn test_get_metrics() {
-        let tracker = QuotingMetricsTracker::new(100);
-        tracker.record_payment();
-        tracker.record_payment();
-
-        let metrics = tracker.get_metrics(2048, 0);
-        assert_eq!(metrics.data_size, 2048);
-        assert_eq!(metrics.data_type, 0);
-        assert_eq!(metrics.close_records_stored, 100);
-        assert_eq!(metrics.received_payment_count, 2);
-    }
-
-    #[test]
-    fn test_persistence() {
-        let dir = tempdir().expect("tempdir");
-        let path = dir.path().join("metrics.bin");
-
-        // Create and populate tracker
-        {
-            let tracker = QuotingMetricsTracker::with_persistence(&path);
-            tracker.record_payment();
-            tracker.record_payment();
-            tracker.record_store(0);
-        }
-
-        // Load from disk
-        let tracker = QuotingMetricsTracker::with_persistence(&path);
-        assert_eq!(tracker.payment_count(), 2);
-        assert_eq!(tracker.records_stored(), 1);
-    }
-
-    #[test]
-    fn test_live_time_hours() {
-        let tracker = QuotingMetricsTracker::new(0);
-        // Just started, so live_time should be 0 hours
-        assert_eq!(tracker.live_time_hours(), 0);
-    }
-
-    #[test]
-    fn test_set_network_size() {
-        let tracker = QuotingMetricsTracker::new(0);
-        tracker.set_network_size(1000);
-
-        let metrics = tracker.get_metrics(0, 0);
-        assert_eq!(metrics.network_size, Some(1000));
-    }
-
-    #[test]
-    fn test_records_per_type_multiple_types() {
-        let tracker = QuotingMetricsTracker::new(0);
-
-        tracker.record_store(0);
-        tracker.record_store(0);
-        tracker.record_store(1);
-        tracker.record_store(2);
-        tracker.record_store(1);
-
-        let metrics = tracker.get_metrics(0, 0);
-        assert_eq!(metrics.records_per_type.len(), 3);
-
-        // Verify per-type counts
-        let type_0 = metrics.records_per_type.iter().find(|(t, _)| *t == 0);
-        let type_1 = metrics.records_per_type.iter().find(|(t, _)| *t == 1);
-        let type_2 = metrics.records_per_type.iter().find(|(t, _)| *t == 2);
-
-        assert_eq!(type_0.expect("type 0 exists").1, 2);
-        assert_eq!(type_1.expect("type 1 exists").1, 2);
-        assert_eq!(type_2.expect("type 2 exists").1, 1);
-    }
-
-    #[test]
-    fn test_persistence_round_trip_with_types() {
-        let dir = tempdir().expect("tempdir");
-        let path = dir.path().join("metrics_types.bin");
-
-        {
-            let tracker = QuotingMetricsTracker::with_persistence(&path);
-            tracker.record_store(0);
-            tracker.record_store(0);
-            tracker.record_store(1);
-            tracker.record_payment();
-        }
-
-        let tracker = QuotingMetricsTracker::with_persistence(&path);
-        assert_eq!(tracker.payment_count(), 1);
-        assert_eq!(tracker.records_stored(), 3); // 2 type-0 + 1 type-1
-
-        let metrics = tracker.get_metrics(0, 0);
-        assert_eq!(metrics.records_per_type.len(), 2);
-    }
-
-    #[test]
-    fn test_with_persistence_nonexistent_path() {
-        let dir = tempdir().expect("tempdir");
-        let path = dir.path().join("nonexistent_subdir").join("metrics.bin");
-
-        // Should not panic — just starts with defaults
-        let tracker = QuotingMetricsTracker::with_persistence(&path);
-        assert_eq!(tracker.payment_count(), 0);
-        assert_eq!(tracker.records_stored(), 0);
-    }
-
-    #[test]
-    fn test_get_metrics_passes_data_params() {
-        let tracker = QuotingMetricsTracker::new(0);
-        let metrics = tracker.get_metrics(4096, 3);
-        assert_eq!(metrics.data_size, 4096);
-        assert_eq!(metrics.data_type, 3);
-    }
-
-    #[test]
-    fn test_default_network_size() {
-        let tracker = QuotingMetricsTracker::new(0);
-        let metrics = tracker.get_metrics(0, 0);
-        assert_eq!(metrics.network_size, Some(500));
     }
 }

--- a/src/payment/pricing.rs
+++ b/src/payment/pricing.rs
@@ -1,12 +1,12 @@
-//! Quadratic pricing with a baseline floor for ant-node (Phase 1 recalibration).
+//! Quadratic pricing with a baseline floor for ant-node.
 //!
 //! Formula: `price_per_chunk_ANT(n) = BASELINE + K × (n / D)²`
 //!
-//! This recalibration introduces a non-zero `BASELINE` so that empty nodes
-//! charge a meaningful spam-barrier price, and re-anchors `K` so per-GB USD
-//! pricing matches real-world targets at the current ~$0.10/ANT token price.
-//! The legacy formula produced ~$25/GB at the lower stable boundary and ~$0/GB
-//! when nodes were empty — both unreasonable.
+//! The non-zero `BASELINE` makes empty nodes charge a meaningful spam-barrier
+//! price, and `K` is anchored so per-GB USD pricing matches real-world targets
+//! at the current ~$0.10/ANT token price. An earlier formula produced ~$25/GB
+//! at the lower stable boundary and ~$0/GB when nodes were empty — both
+//! unreasonable.
 //!
 //! ## Parameters
 //!

--- a/src/payment/quote.rs
+++ b/src/payment/quote.rs
@@ -175,14 +175,9 @@ impl QuoteGenerator {
         self.metrics_tracker.records_stored()
     }
 
-    /// Record a payment received (delegates to metrics tracker).
-    pub fn record_payment(&self) {
-        self.metrics_tracker.record_payment();
-    }
-
     /// Record data stored (delegates to metrics tracker).
-    pub fn record_store(&self, data_type: u32) {
-        self.metrics_tracker.record_store(data_type);
+    pub fn record_store(&self) {
+        self.metrics_tracker.record_store();
     }
 
     /// Create a merkle candidate quote for batch payment using ML-DSA-65.
@@ -429,9 +424,9 @@ mod tests {
         let metrics_tracker = QuotingMetricsTracker::new(0);
         let generator = QuoteGenerator::new(rewards_address, metrics_tracker);
 
-        generator.record_store(0);
-        generator.record_store(1);
-        generator.record_store(0);
+        generator.record_store();
+        generator.record_store();
+        generator.record_store();
 
         assert_eq!(generator.records_stored(), 3);
     }

--- a/src/storage/handler.rs
+++ b/src/storage/handler.rs
@@ -27,11 +27,12 @@
 //! └─────────────────────────────────────────────────────────┘
 //! ```
 
+#[cfg(test)]
+use crate::ant_protocol::DATA_TYPE_CHUNK;
 use crate::ant_protocol::{
     ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkMessageBody, ChunkPutRequest,
     ChunkPutResponse, ChunkQuoteRequest, ChunkQuoteResponse, MerkleCandidateQuoteRequest,
-    MerkleCandidateQuoteResponse, ProtocolError, CHUNK_PROTOCOL_ID, DATA_TYPE_CHUNK,
-    MAX_CHUNK_SIZE,
+    MerkleCandidateQuoteResponse, ProtocolError, CHUNK_PROTOCOL_ID, MAX_CHUNK_SIZE,
 };
 use crate::client::compute_address;
 use crate::error::{Error, Result};
@@ -256,9 +257,8 @@ impl AntProtocol {
             Ok(_) => {
                 let content_len = request.content.len();
                 info!("Stored chunk {addr_hex} ({content_len} bytes)");
-                // Record the store and payment in metrics
-                self.quote_generator.record_store(DATA_TYPE_CHUNK);
-                self.quote_generator.record_payment();
+                // Increment the close-records counter consumed by calculate_price.
+                self.quote_generator.record_store();
 
                 // 6. Notify replication engine for fresh fan-out.
                 //    Only emit when a real proof is present — cached-as-verified


### PR DESCRIPTION
## Summary

- Strip orphaned fields and helpers from `QuotingMetricsTracker` — the price formula reads exactly one input (`close_records_stored`), everything else was scaffolding without a consumer.
- Drop three unused direct dependencies (`aes-gcm-siv`, `hkdf`, `self_encryption`) and the dead `dev` Cargo feature flag.
- Re-word the pricing-module doc to remove the misleading "Phase 1 recalibration" framing.

Net: **+28 / -413 across 6 files** (Cargo.lock loses 76 lines on its own).

## What's actually dead

`QuotingMetricsTracker` shipped with seven fields, but only `close_records_stored` is read by `calculate_price` (which is the only consumer). The others were either ghost infrastructure (entire persistence layer: `with_persistence`, `PersistedMetrics`, `maybe_persist`, `Drop::persist`) or values that get bundled into a `QuotingMetrics` struct nobody calls — `received_payment_count`, `records_per_type`, `start_time`/`live_time`, `network_size`. Production constructs the tracker via `::new(_)`, never `::with_persistence(_)`, so the on-disk format and debounce machinery never fired anywhere.

Cargo deps `aes-gcm-siv`, `hkdf`, `self_encryption` were declared for a legacy data-migration feature that was never built — zero `use` statements across `src/`. Cargo feature `dev` had zero `#[cfg(feature = "dev")]` gates.

## What this PR doesn't touch

- The pricing formula itself is unchanged — only the unused metrics scaffolding around it goes.
- `record_payment` is removed (only fed the dropped counter); `record_store` loses its unused `data_type` parameter. The wire protocol still carries `data_type` through `ChunkQuoteRequest` and `MerkleCandidateQuoteRequest`, untouched.
- No external crate (`ant-client`, `ant-protocol`, `evmlib`, `saorsa-core`) imports the affected surface. Verified by grep across the workspace and `~/.cargo/registry/`.

## Verification

- 472 lib tests pass.
- `cargo clippy --all-features --all-targets -- -D warnings` clean.
- `cargo fmt --check` clean.
- `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS="--deny=warnings"` clean.

## Test plan

- [ ] CI green on ubuntu + windows
- [ ] Spot-check that downstream consumers (`ant-client`) build against this branch unchanged
- [ ] One reviewer sanity-checks the `record_store` signature change isn't load-bearing somewhere I missed
