### PR TITLE
fix(ci): pin Foundry version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
+  FOUNDRY_VERSION: v1.7.1
 
 jobs:
   fmt:
@@ -46,7 +47,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: ${{ env.FOUNDRY_VERSION }}
       - name: Run unit tests
         run: cargo test --lib --features test-utils
       - name: Run e2e tests
@@ -88,7 +89,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: ${{ env.FOUNDRY_VERSION }}
       - name: Run unit tests without logging
         run: cargo test --lib --no-default-features
 


### PR DESCRIPTION
## Summary
- Pin Foundry CI installs to v1.7.1 via a shared workflow env var
- Avoid the unauthenticated nightly release tag lookup that failed with GitHub API 403s on the macOS job

## Testing
- git diff --check -- .github/workflows/ci.yml