### PR TITLE
fix(payment): verify closeness against pure-XOR view; escalate Merkle on mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, "rc-*"]
   pull_request:
-    branches: [main]
+    branches: [main, "rc-*"]
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4846,7 +4846,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.24.5-rc.1"
-source = "git+https://github.com/saorsa-labs/saorsa-core?branch=rc-2026.5.4#1be73520bb8939d651f6d55ef1b2308810995052"
+source = "git+https://github.com/saorsa-labs/saorsa-core?branch=rc-2026.5.4#82bb541237b66f4e0976ca7124f990bce2811a35"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -163,6 +163,14 @@ pub struct PaymentVerifier {
     /// amplification to one lookup per unique `pool_hash` regardless of
     /// concurrency.
     inflight_closeness: Mutex<LruCache<PoolHash, Arc<ClosenessSlot>>>,
+    /// Bounds the number of concurrent authoritative *network* closeness
+    /// lookups. The local routing-table fast path serves healthy traffic, so
+    /// honest uploads rarely fall back to the network; this caps the cost when
+    /// they (or a flood of forged pools that each fail the local check) do.
+    /// `inflight_closeness` already collapses same-pool concurrency — this
+    /// bounds the distinct-`pool_hash` case so a forged-pool storm cannot spawn
+    /// unbounded `CLOSENESS_LOOKUP_TIMEOUT`-long Kademlia walks.
+    closeness_fallback_permits: Arc<tokio::sync::Semaphore>,
     /// P2P node handle, attached post-construction so merkle verification can
     /// check that candidate `pub_keys` map to peers actually close to the pool
     /// midpoint in the live DHT. `None` in unit tests that don't exercise
@@ -262,6 +270,9 @@ impl PaymentVerifier {
         let pool_cache = Mutex::new(LruCache::new(pool_cache_size));
         let closeness_pass_cache = Mutex::new(LruCache::new(pool_cache_size));
         let inflight_closeness = Mutex::new(LruCache::new(pool_cache_size));
+        let closeness_fallback_permits = Arc::new(tokio::sync::Semaphore::new(
+            Self::CLOSENESS_NETWORK_FALLBACK_CONCURRENCY,
+        ));
 
         let cache_capacity = config.cache_capacity;
         info!("Payment verifier initialized (cache_capacity={cache_capacity}, evm=always-on, pool_cache={DEFAULT_POOL_CACHE_CAPACITY})");
@@ -283,6 +294,7 @@ impl PaymentVerifier {
             pool_cache,
             closeness_pass_cache,
             inflight_closeness,
+            closeness_fallback_permits,
             p2p_node: RwLock::new(None),
             config,
         }
@@ -664,9 +676,20 @@ impl PaymentVerifier {
             &self.config.local_rewards_address,
         )?;
 
+        // Use the XOR-only `_by_distance` variant, NOT the reachability-reranked
+        // `find_closest_nodes_local_with_self`: this is a quote-closeness
+        // *verification*, so it must mirror the uploader's pure XOR-distance
+        // close-group selection (`get_store_quotes` keeps the XOR-closest
+        // CLOSE_GROUP_SIZE responders). The reachability re-rank that
+        // saorsa-labs/saorsa-core#121 added to `_with_self` demotes XOR-close
+        // relay-only / NAT'd peers out of the local top-CLOSE_GROUP_SIZE, so on a
+        // network with a meaningful NAT fraction the storer's view drops 2-3 of
+        // the uploader's quoted peers and falsely rejects honest single-node
+        // payments. This mirrors the same fix already applied to the Merkle
+        // closeness check below (verify_merkle_candidate_closeness_inner).
         let close_group = p2p_node
             .dht_manager()
-            .find_closest_nodes_local_with_self(xorname, CLOSE_GROUP_SIZE)
+            .find_closest_nodes_local_by_distance_with_self(xorname, CLOSE_GROUP_SIZE)
             .await;
         let close_group_peer_ids: Vec<PeerId> =
             close_group.iter().map(|node| node.peer_id).collect();
@@ -1013,6 +1036,20 @@ impl PaymentVerifier {
     /// at the previous value of 4).
     const MAX_LEADER_RETRIES: usize = 1;
 
+    /// Maximum number of authoritative *network* closeness lookups allowed to
+    /// run concurrently across all pools (see [`closeness_fallback_permits`]).
+    ///
+    /// The local routing-table fast path resolves honest traffic on a healthy,
+    /// converged network, so this cap is rarely approached in normal operation.
+    /// Its job is to bound the worst case: a flood of distinct forged pools that
+    /// each pass pool-signature verification but fail the local closeness check
+    /// would otherwise each spawn a `CLOSENESS_LOOKUP_TIMEOUT`-bounded Kademlia
+    /// walk. Beyond this many in-flight walks, further PUTs are rejected fast
+    /// with a retryable error rather than queueing. Sized generously enough to
+    /// absorb several legitimate concurrent batch uploads (each batch collapses
+    /// to a single lookup via [`inflight_closeness`]).
+    const CLOSENESS_NETWORK_FALLBACK_CONCURRENCY: usize = 16;
+
     /// Compute the storer's authoritative-lookup width for a candidate pool.
     ///
     /// Returns `max(CLOSENESS_LOOKUP_WIDTH, pool_len)`: matches the client's
@@ -1030,17 +1067,22 @@ impl PaymentVerifier {
         }
     }
 
-    /// Whether the storer must fall back from the local routing table to the
-    /// iterative network lookup for the Merkle closeness check.
+    /// Whether the storer's local routing table is too sparse to answer the
+    /// Merkle closeness check authoritatively on its own.
     ///
     /// The local k-buckets can answer authoritatively only when they hold at
     /// least `CLOSENESS_LOOKUP_WIDTH` peers near the midpoint; below that the
-    /// table is genuinely too sparse and we pay for the network lookup. The
-    /// gate is local table size — NOT match outcome — so a forged pool cannot
-    /// force the expensive 240s path (an attacker cannot make a victim's local
-    /// routing table sparse). Extracted from
-    /// [`verify_merkle_candidate_closeness_inner`] so the boundary can be unit
-    /// tested without a `P2PNode`.
+    /// table is genuinely too sparse and the network lookup is mandatory.
+    ///
+    /// Note this is no longer the *only* trigger for the network lookup: a
+    /// dense-but-disagreeing local view also escalates to the network (see
+    /// [`verify_merkle_candidate_closeness_inner`]), because on a real network
+    /// the local k-bucket sample legitimately diverges from the uploader's
+    /// network-walked candidate set. The `DoS` concern that motivated the
+    /// size-only gate — a forged pool forcing the expensive path — is instead
+    /// bounded by [`closeness_fallback_permits`]
+    /// (`CLOSENESS_NETWORK_FALLBACK_CONCURRENCY`). Extracted so the boundary can
+    /// be unit tested without a `P2PNode`.
     const fn closeness_should_fall_back_to_network(local_peer_count: usize) -> bool {
         local_peer_count < Self::CLOSENESS_LOOKUP_WIDTH
     }
@@ -1377,60 +1419,113 @@ impl PaymentVerifier {
         // uses) could demote an XOR-close relay-only peer out of the compared
         // window and falsely reject an honest candidate pool that legitimately
         // contains that peer. See saorsa-labs/saorsa-core#121.
-        let mut closeness_peers = p2p_node
+        let local_peers = p2p_node
             .dht_manager()
             .find_closest_nodes_local_by_distance(&pool_address.0, lookup_count)
             .await;
 
-        // Sparse-table fallback: only when the local table genuinely cannot
-        // answer authoritatively (fewer than CLOSENESS_LOOKUP_WIDTH peers near
-        // the midpoint) do we pay for the iterative network lookup. The gate is
-        // local table size, NOT match outcome — an attacker cannot make a
-        // victim's local routing table sparse, so a forged pool cannot force the
-        // expensive 240s network path (DoS-safe). On a well-connected production
-        // node the local table is dense near any key, so this path is rare.
-        if Self::closeness_should_fall_back_to_network(closeness_peers.len()) {
+        // When the local table is dense enough to be authoritative AND the pool
+        // already matches it, accept without paying for a network lookup — the
+        // common case on a healthy, converged network, and the #111 performance
+        // win we want to keep.
+        if Self::closeness_should_fall_back_to_network(local_peers.len()) {
             debug!(
                 "Merkle closeness: local table returned only {} peers (< {}) for \
                  pool midpoint {}; falling back to network lookup",
-                closeness_peers.len(),
+                local_peers.len(),
                 Self::CLOSENESS_LOOKUP_WIDTH,
                 hex::encode(pool_address.0),
             );
-            let network_lookup = p2p_node
-                .dht_manager()
-                .find_closest_nodes_network(&pool_address.0, lookup_count);
-            closeness_peers =
-                match tokio::time::timeout(Self::CLOSENESS_LOOKUP_TIMEOUT, network_lookup).await {
-                    Ok(Ok(peers)) => peers,
-                    Ok(Err(e)) => {
-                        debug!(
-                            "Merkle closeness network-lookup failed for pool midpoint {}: {e}",
-                            hex::encode(pool_address.0),
-                        );
-                        return Err(Error::Payment(
-                            "Merkle candidate pool rejected: could not verify candidate \
-                     closeness against the authoritative network view."
-                                .into(),
-                        ));
-                    }
-                    Err(_) => {
-                        debug!(
-                            "Merkle closeness network-lookup timeout ({:?}) for pool midpoint {}",
-                            Self::CLOSENESS_LOOKUP_TIMEOUT,
-                            hex::encode(pool_address.0),
-                        );
-                        return Err(Error::Payment(
-                            "Merkle candidate pool rejected: authoritative network lookup \
-                     timed out. Retry once the network lookup completes."
-                                .into(),
-                        ));
-                    }
-                };
+        } else {
+            let local_peer_ids: Vec<PeerId> = local_peers.iter().map(|n| n.peer_id).collect();
+            if Self::check_closeness_match(&candidate_peer_ids, &local_peer_ids, &pool_address.0)
+                .is_ok()
+            {
+                return Ok(());
+            }
+            // Local view disagrees. The storer's local k-bucket sample
+            // legitimately diverges from the uploader's *network-walked*
+            // candidate set: the uploader collected reachable responders (per
+            // CLOSENESS_LOOKUP_WIDTH, often from positions 17–32) that the
+            // storer's local closest-`lookup_count` need not rank the same way.
+            // Escalate to the authoritative network lookup before rejecting an
+            // honest pool — this restores the pre-#111 correctness, but only on
+            // the (rare on a healthy net) match-failure path rather than for
+            // every chunk. The DoS exposure this reopens is bounded by
+            // `merkle_closeness_network_peer_ids`' concurrency permit.
+            debug!(
+                "Merkle closeness: local view ({} peers) disagreed for pool \
+                 midpoint {}; escalating to authoritative network lookup",
+                local_peers.len(),
+                hex::encode(pool_address.0),
+            );
         }
 
-        let closeness_peer_ids: Vec<PeerId> = closeness_peers.iter().map(|n| n.peer_id).collect();
-        Self::check_closeness_match(&candidate_peer_ids, &closeness_peer_ids, &pool_address.0)
+        // Authoritative network lookup (bounded; see
+        // `merkle_closeness_network_peer_ids`). This is the final verdict —
+        // there is no further escalation, so its result is returned directly.
+        let network_peer_ids = self
+            .merkle_closeness_network_peer_ids(&p2p_node, &pool_address.0, lookup_count)
+            .await?;
+        Self::check_closeness_match(&candidate_peer_ids, &network_peer_ids, &pool_address.0)
+    }
+
+    /// Run the authoritative iterative-Kademlia closeness lookup for a pool
+    /// midpoint, bounded both in time (`CLOSENESS_LOOKUP_TIMEOUT`) and in
+    /// concurrency ([`closeness_fallback_permits`]).
+    ///
+    /// Returns the network's closest-`lookup_count` peer IDs to the midpoint.
+    /// All error paths are retryable (the uploader can re-PUT): the verifier is
+    /// at fallback capacity, the lookup failed, or it timed out.
+    async fn merkle_closeness_network_peer_ids(
+        &self,
+        p2p_node: &Arc<P2PNode>,
+        pool_address: &[u8; 32],
+        lookup_count: usize,
+    ) -> Result<Vec<PeerId>> {
+        // Bound concurrent network walks. The local fast path handles healthy
+        // traffic, so honest uploads rarely reach here; a forged-pool flood
+        // (distinct pool_hashes that each fail the local check) could otherwise
+        // spawn unbounded CLOSENESS_LOOKUP_TIMEOUT-long walks. `inflight_closeness`
+        // already collapses same-pool concurrency; this caps the distinct-pool
+        // case. Excess PUTs are rejected fast (retryable) rather than queued.
+        let Ok(_permit) = Arc::clone(&self.closeness_fallback_permits).try_acquire_owned() else {
+            return Err(Error::Payment(
+                "Merkle candidate pool rejected: authoritative closeness lookups \
+                 are at capacity; retry shortly."
+                    .into(),
+            ));
+        };
+
+        let network_lookup = p2p_node
+            .dht_manager()
+            .find_closest_nodes_network(pool_address, lookup_count);
+        match tokio::time::timeout(Self::CLOSENESS_LOOKUP_TIMEOUT, network_lookup).await {
+            Ok(Ok(peers)) => Ok(peers.iter().map(|n| n.peer_id).collect()),
+            Ok(Err(e)) => {
+                debug!(
+                    "Merkle closeness network-lookup failed for pool midpoint {}: {e}",
+                    hex::encode(pool_address),
+                );
+                Err(Error::Payment(
+                    "Merkle candidate pool rejected: could not verify candidate \
+                     closeness against the authoritative network view."
+                        .into(),
+                ))
+            }
+            Err(_) => {
+                debug!(
+                    "Merkle closeness network-lookup timeout ({:?}) for pool midpoint {}",
+                    Self::CLOSENESS_LOOKUP_TIMEOUT,
+                    hex::encode(pool_address),
+                );
+                Err(Error::Payment(
+                    "Merkle candidate pool rejected: authoritative network lookup \
+                     timed out. Retry once the network lookup completes."
+                        .into(),
+                ))
+            }
+        }
     }
 
     /// Verify a merkle batch payment proof.


### PR DESCRIPTION
## Summary

Fixes two upload-breaking regressions seen on testnets with a meaningful NAT fraction (e.g. STG-01: ~900 nodes, 30% NAT-simulated — **every** upload failed). Both stem from the same root cause: storer-side closeness verification compares the uploader's **network-walk-derived** peer set against the storer's **local routing-table** view, and those views diverge on a real network.

### 1. Single-node payment close-group check (regressed by saorsa-core #121)

The check (introduced in #107) calls `find_closest_nodes_local_with_self`. When saorsa-core #121 re-ranked that lookup `(reachability_tier, xor_distance)` — correct for storage *selection* — the verifier silently inherited it. The re-rank demotes XOR-close relay-only / NAT'd peers out of the local top-`CLOSE_GROUP_SIZE`, while the uploader's quoted set (`get_store_quotes`, pure XOR) still contains them. Result: only 3–4 of 7 quoted peers match, breaching the `>=5` threshold → every single-node payment rejected.

**Fix:** switch to the XOR-only `find_closest_nodes_local_by_distance_with_self` (saorsa-labs/saorsa-core#122), exactly mirroring the Merkle closeness path. Still a pure local lookup → **no added network cost**.

### 2. Merkle candidate-pool closeness check (regressed by #111)

#111 moved this check off the authoritative iterative-Kademlia network lookup onto the local routing table (a real per-chunk latency win), with the network fallback gated on **local-table size, not match outcome**. The DoS argument was sound — an attacker can't make a victim's table sparse — but it also means that when the local k-bucket sample *legitimately* disagrees with the uploader's network-walked candidates (which include reachable responders from positions 17–32), honest pools are hard-rejected with no escalation. On STG-01 this was 100% of Merkle uploads (`candidate pub_keys do not match`; node logs: all match-failures, zero sparse-defers, zero timeouts).

**Fix:** keep #111's local fast path — accept immediately on a local match (the common case on a healthy, converged network) — but escalate to the authoritative network lookup on match **failure** as well as sparsity. This restores the pre-#111 correctness only on the (rare, on a healthy net) mismatch path, not per chunk.

**DoS bound:** the reopened network-fallback path is capped by a new `closeness_fallback_permits` semaphore (`CLOSENESS_NETWORK_FALLBACK_CONCURRENCY = 16`). `inflight_closeness` already collapses same-pool concurrency; this caps the distinct-`pool_hash` case so a forged-pool flood cannot spawn unbounded `CLOSENESS_LOOKUP_TIMEOUT`-long walks. Excess concurrent walks get a fast, retryable rejection rather than queueing — addressing the exact DoS rationale #111 gave for the size-only gate.

## Dependency / merge order

⚠️ Requires **saorsa-labs/saorsa-core#122** (`find_closest_nodes_local_by_distance_with_self`) to land on `rc-2026.5.4` first. The `saorsa-core` git pin then resolves it via `cargo update -p saorsa-core`; until then CI here will not compile. (Verified locally against #122 via a path patch.)

## Test plan

- [x] `cargo check --lib` — clean (against saorsa-core#122)
- [x] `cargo test --lib payment::verifier` — 67 passed, 0 failed
- [x] `cargo clippy --lib --all-features -- -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Follow-up (not in this PR): testnet upload run on a NAT-simulated network confirming single-node + Merkle uploads succeed, plus per-chunk `store_durations_ms` p50/p99 vs baseline to confirm the fast path is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)