### PR TITLE
ci: run CI on rc-* release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, "rc-*"]
   pull_request:
-    branches: [main]
+    branches: [main, "rc-*"]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

CI (`.github/workflows/ci.yml`) only triggered on `push`/`pull_request` against `main`, so PRs targeting release branches (e.g. `rc-2026.5.4`) ran **no checks** — including #114. This adds `rc-*` to both branch filters.

```yaml
on:
  push:
    branches: [main, "rc-*"]
  pull_request:
    branches: [main, "rc-*"]
```

## Why this PR targets `rc-2026.5.4` (and must be merged there)

For `pull_request` events the `branches` filter is matched against the PR's **base** branch, and GitHub reads the trigger config from the base branch. So the fix only takes effect once it's on `rc-2026.5.4` — bundling it into a feature-branch PR wouldn't make that PR's own checks fire. Hence a standalone PR straight to the release branch.

Once merged, re-running (or pushing a new commit to) existing rc-targeted PRs like #114 will trigger their checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)