### PR TITLE
Revert #114 + #111; drop abandoned saorsa-core/ant-protocol rc pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, "rc-*"]
   pull_request:
-    branches: [main]
+    branches: [main, "rc-*"]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, "rc-*"]
+    branches: [main]
   pull_request:
-    branches: [main, "rc-*"]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,8 +861,9 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "2.1.2-rc.2"
-source = "git+https://github.com/WithAutonomi/ant-protocol?branch=rc-2026.5.4#114e67a19abc5470a56e516b92d9796c2ab2633f"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4d0ba3f671c08a1d52291b601ec35a7353f4f4e10f221b5f0ee372d154636dd"
 dependencies = [
  "blake3",
  "bytes",
@@ -1299,15 +1300,15 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.4"
+version = "0.1.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+checksum = "11301df0b06f22dea7bb1916403fdd88a371031e495c49b8f96931b28189e175"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.2"
+version = "0.14.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed83caece3afc59919481b33b472e1432d1abc4641ed9100be142ef5110b406"
+checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",
@@ -2163,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2960,9 +2961,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3478,9 +3479,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -3581,9 +3582,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memoffset"
@@ -4865,8 +4866,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.24.5-rc.2"
-source = "git+https://github.com/saorsa-labs/saorsa-core?branch=rc-2026.5.4#3de07d588cb06d752c6c30969e97aa71df201851"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1267928da1bcc91748c314f95f7952bc01c0359a4ac70a0b111b0386898934"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,10 +39,10 @@ mimalloc = "0.1"
 # Until then, the git pin tracks the matching saorsa-core lineage
 # (the rc-2026.4.2 branch) so Cargo can unify the wire types here
 # with ant-protocol's re-exports.
-ant-protocol = { git = "https://github.com/WithAutonomi/ant-protocol", branch = "rc-2026.5.4" }
+ant-protocol = "2.1.1"
 
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
-saorsa-core = { git = "https://github.com/saorsa-labs/saorsa-core", branch = "rc-2026.5.4" }
+saorsa-core = "0.24.4"
 saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment

--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -990,12 +990,6 @@ impl PaymentVerifier {
     /// the dominant cost is still Sybil-grinding midpoint addresses or
     /// running real nodes near the target — same security floor.
     /// `CANDIDATE_CLOSENESS_REQUIRED` (13/16) is unchanged.
-    ///
-    /// Also doubles as the sparse-table gate in
-    /// [`verify_merkle_candidate_closeness_inner`]: the storer answers from its
-    /// local routing table and only falls back to the iterative network lookup
-    /// when the local table returns fewer than this many peers near the
-    /// midpoint (i.e. it genuinely cannot answer authoritatively).
     const CLOSENESS_LOOKUP_WIDTH: usize = 2 * evmlib::merkle_payments::CANDIDATES_PER_POOL;
 
     /// Maximum waiter → leader retries when the leader's future was cancelled
@@ -1028,21 +1022,6 @@ impl PaymentVerifier {
         } else {
             pool_len
         }
-    }
-
-    /// Whether the storer must fall back from the local routing table to the
-    /// iterative network lookup for the Merkle closeness check.
-    ///
-    /// The local k-buckets can answer authoritatively only when they hold at
-    /// least `CLOSENESS_LOOKUP_WIDTH` peers near the midpoint; below that the
-    /// table is genuinely too sparse and we pay for the network lookup. The
-    /// gate is local table size — NOT match outcome — so a forged pool cannot
-    /// force the expensive 240s path (an attacker cannot make a victim's local
-    /// routing table sparse). Extracted from
-    /// [`verify_merkle_candidate_closeness_inner`] so the boundary can be unit
-    /// tested without a `P2PNode`.
-    const fn closeness_should_fall_back_to_network(local_peer_count: usize) -> bool {
-        local_peer_count < Self::CLOSENESS_LOOKUP_WIDTH
     }
 
     /// Verify that the candidate pool's `pub_keys` correspond to peers that
@@ -1361,76 +1340,39 @@ impl PaymentVerifier {
         // the pool rather than truncating, which would otherwise re-open the
         // K-too-small failure mode.
         let lookup_count = Self::closeness_lookup_count(pool.candidate_nodes.len());
-
-        // Fast path: answer from the local routing table. This is a pure
-        // in-memory k-bucket read (`find_closest_nodes_local_by_distance`
-        // returns `Vec<DHTNode>` with no network I/O and no `Result`), so it is
-        // safe to call from this PUT-handling request handler — unlike
-        // `find_closest_nodes_network`, which runs an iterative Kademlia lookup
-        // (up to MAX_ITERATIONS rounds, bounded by CLOSENESS_LOOKUP_TIMEOUT) and
-        // is the dominant term in slow per-chunk store times.
-        //
-        // We use the XOR-only `_by_distance` variant deliberately, NOT the
-        // reachability-reranked `find_closest_nodes_local`: this is a closeness
-        // *verification*, so it must mirror the uploader's pure XOR-distance
-        // view. The reachability re-rank (which the close-group *selection* path
-        // uses) could demote an XOR-close relay-only peer out of the compared
-        // window and falsely reject an honest candidate pool that legitimately
-        // contains that peer. See saorsa-labs/saorsa-core#121.
-        let mut closeness_peers = p2p_node
+        let network_lookup = p2p_node
             .dht_manager()
-            .find_closest_nodes_local_by_distance(&pool_address.0, lookup_count)
-            .await;
-
-        // Sparse-table fallback: only when the local table genuinely cannot
-        // answer authoritatively (fewer than CLOSENESS_LOOKUP_WIDTH peers near
-        // the midpoint) do we pay for the iterative network lookup. The gate is
-        // local table size, NOT match outcome — an attacker cannot make a
-        // victim's local routing table sparse, so a forged pool cannot force the
-        // expensive 240s network path (DoS-safe). On a well-connected production
-        // node the local table is dense near any key, so this path is rare.
-        if Self::closeness_should_fall_back_to_network(closeness_peers.len()) {
-            debug!(
-                "Merkle closeness: local table returned only {} peers (< {}) for \
-                 pool midpoint {}; falling back to network lookup",
-                closeness_peers.len(),
-                Self::CLOSENESS_LOOKUP_WIDTH,
-                hex::encode(pool_address.0),
-            );
-            let network_lookup = p2p_node
-                .dht_manager()
-                .find_closest_nodes_network(&pool_address.0, lookup_count);
-            closeness_peers =
-                match tokio::time::timeout(Self::CLOSENESS_LOOKUP_TIMEOUT, network_lookup).await {
-                    Ok(Ok(peers)) => peers,
-                    Ok(Err(e)) => {
-                        debug!(
-                            "Merkle closeness network-lookup failed for pool midpoint {}: {e}",
-                            hex::encode(pool_address.0),
-                        );
-                        return Err(Error::Payment(
-                            "Merkle candidate pool rejected: could not verify candidate \
+            .find_closest_nodes_network(&pool_address.0, lookup_count);
+        let network_peers =
+            match tokio::time::timeout(Self::CLOSENESS_LOOKUP_TIMEOUT, network_lookup).await {
+                Ok(Ok(peers)) => peers,
+                Ok(Err(e)) => {
+                    debug!(
+                        "Merkle closeness network-lookup failed for pool midpoint {}: {e}",
+                        hex::encode(pool_address.0),
+                    );
+                    return Err(Error::Payment(
+                        "Merkle candidate pool rejected: could not verify candidate \
                      closeness against the authoritative network view."
-                                .into(),
-                        ));
-                    }
-                    Err(_) => {
-                        debug!(
-                            "Merkle closeness network-lookup timeout ({:?}) for pool midpoint {}",
-                            Self::CLOSENESS_LOOKUP_TIMEOUT,
-                            hex::encode(pool_address.0),
-                        );
-                        return Err(Error::Payment(
-                            "Merkle candidate pool rejected: authoritative network lookup \
+                            .into(),
+                    ));
+                }
+                Err(_) => {
+                    debug!(
+                        "Merkle closeness network-lookup timeout ({:?}) for pool midpoint {}",
+                        Self::CLOSENESS_LOOKUP_TIMEOUT,
+                        hex::encode(pool_address.0),
+                    );
+                    return Err(Error::Payment(
+                        "Merkle candidate pool rejected: authoritative network lookup \
                      timed out. Retry once the network lookup completes."
-                                .into(),
-                        ));
-                    }
-                };
-        }
+                            .into(),
+                    ));
+                }
+            };
 
-        let closeness_peer_ids: Vec<PeerId> = closeness_peers.iter().map(|n| n.peer_id).collect();
-        Self::check_closeness_match(&candidate_peer_ids, &closeness_peer_ids, &pool_address.0)
+        let network_peer_ids: Vec<PeerId> = network_peers.iter().map(|n| n.peer_id).collect();
+        Self::check_closeness_match(&candidate_peer_ids, &network_peer_ids, &pool_address.0)
     }
 
     /// Verify a merkle batch payment proof.
@@ -3408,39 +3350,6 @@ mod tests {
             PaymentVerifier::closeness_lookup_count(1),
             PaymentVerifier::CLOSENESS_LOOKUP_WIDTH,
             "lookup_count must never drop below CLOSENESS_LOOKUP_WIDTH"
-        );
-    }
-
-    #[test]
-    fn closeness_falls_back_to_network_only_below_lookup_width() {
-        // Fix B: the storer answers the Merkle closeness check from its local
-        // routing table and falls back to the iterative network lookup ONLY
-        // when the local table is genuinely too sparse to be authoritative —
-        // i.e. it returns fewer than CLOSENESS_LOOKUP_WIDTH peers near the
-        // midpoint. The gate is local table size, not match outcome, so a
-        // forged pool cannot force the expensive 240s network path.
-        let width = PaymentVerifier::CLOSENESS_LOOKUP_WIDTH;
-
-        // Below the boundary: local table too sparse → must fall back.
-        assert!(
-            PaymentVerifier::closeness_should_fall_back_to_network(0),
-            "an empty local table must fall back to the network lookup"
-        );
-        assert!(
-            PaymentVerifier::closeness_should_fall_back_to_network(width - 1),
-            "WIDTH-1 local peers is still too sparse — must fall back"
-        );
-
-        // At/above the boundary: local table is authoritative → no fallback.
-        // This is the common production path: a forged pool reaching a
-        // well-connected node must NOT be able to trigger the network lookup.
-        assert!(
-            !PaymentVerifier::closeness_should_fall_back_to_network(width),
-            "exactly WIDTH local peers is authoritative — must not fall back"
-        );
-        assert!(
-            !PaymentVerifier::closeness_should_fall_back_to_network(width + 1),
-            "more than WIDTH local peers is authoritative — must not fall back"
         );
     }
 

--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -163,14 +163,6 @@ pub struct PaymentVerifier {
     /// amplification to one lookup per unique `pool_hash` regardless of
     /// concurrency.
     inflight_closeness: Mutex<LruCache<PoolHash, Arc<ClosenessSlot>>>,
-    /// Bounds the number of concurrent authoritative *network* closeness
-    /// lookups. The local routing-table fast path serves healthy traffic, so
-    /// honest uploads rarely fall back to the network; this caps the cost when
-    /// they (or a flood of forged pools that each fail the local check) do.
-    /// `inflight_closeness` already collapses same-pool concurrency — this
-    /// bounds the distinct-`pool_hash` case so a forged-pool storm cannot spawn
-    /// unbounded `CLOSENESS_LOOKUP_TIMEOUT`-long Kademlia walks.
-    closeness_fallback_permits: Arc<tokio::sync::Semaphore>,
     /// P2P node handle, attached post-construction so merkle verification can
     /// check that candidate `pub_keys` map to peers actually close to the pool
     /// midpoint in the live DHT. `None` in unit tests that don't exercise
@@ -270,9 +262,6 @@ impl PaymentVerifier {
         let pool_cache = Mutex::new(LruCache::new(pool_cache_size));
         let closeness_pass_cache = Mutex::new(LruCache::new(pool_cache_size));
         let inflight_closeness = Mutex::new(LruCache::new(pool_cache_size));
-        let closeness_fallback_permits = Arc::new(tokio::sync::Semaphore::new(
-            Self::CLOSENESS_NETWORK_FALLBACK_CONCURRENCY,
-        ));
 
         let cache_capacity = config.cache_capacity;
         info!("Payment verifier initialized (cache_capacity={cache_capacity}, evm=always-on, pool_cache={DEFAULT_POOL_CACHE_CAPACITY})");
@@ -294,7 +283,6 @@ impl PaymentVerifier {
             pool_cache,
             closeness_pass_cache,
             inflight_closeness,
-            closeness_fallback_permits,
             p2p_node: RwLock::new(None),
             config,
         }
@@ -676,20 +664,9 @@ impl PaymentVerifier {
             &self.config.local_rewards_address,
         )?;
 
-        // Use the XOR-only `_by_distance` variant, NOT the reachability-reranked
-        // `find_closest_nodes_local_with_self`: this is a quote-closeness
-        // *verification*, so it must mirror the uploader's pure XOR-distance
-        // close-group selection (`get_store_quotes` keeps the XOR-closest
-        // CLOSE_GROUP_SIZE responders). The reachability re-rank that
-        // saorsa-labs/saorsa-core#121 added to `_with_self` demotes XOR-close
-        // relay-only / NAT'd peers out of the local top-CLOSE_GROUP_SIZE, so on a
-        // network with a meaningful NAT fraction the storer's view drops 2-3 of
-        // the uploader's quoted peers and falsely rejects honest single-node
-        // payments. This mirrors the same fix already applied to the Merkle
-        // closeness check below (verify_merkle_candidate_closeness_inner).
         let close_group = p2p_node
             .dht_manager()
-            .find_closest_nodes_local_by_distance_with_self(xorname, CLOSE_GROUP_SIZE)
+            .find_closest_nodes_local_with_self(xorname, CLOSE_GROUP_SIZE)
             .await;
         let close_group_peer_ids: Vec<PeerId> =
             close_group.iter().map(|node| node.peer_id).collect();
@@ -1036,20 +1013,6 @@ impl PaymentVerifier {
     /// at the previous value of 4).
     const MAX_LEADER_RETRIES: usize = 1;
 
-    /// Maximum number of authoritative *network* closeness lookups allowed to
-    /// run concurrently across all pools (see [`closeness_fallback_permits`]).
-    ///
-    /// The local routing-table fast path resolves honest traffic on a healthy,
-    /// converged network, so this cap is rarely approached in normal operation.
-    /// Its job is to bound the worst case: a flood of distinct forged pools that
-    /// each pass pool-signature verification but fail the local closeness check
-    /// would otherwise each spawn a `CLOSENESS_LOOKUP_TIMEOUT`-bounded Kademlia
-    /// walk. Beyond this many in-flight walks, further PUTs are rejected fast
-    /// with a retryable error rather than queueing. Sized generously enough to
-    /// absorb several legitimate concurrent batch uploads (each batch collapses
-    /// to a single lookup via [`inflight_closeness`]).
-    const CLOSENESS_NETWORK_FALLBACK_CONCURRENCY: usize = 16;
-
     /// Compute the storer's authoritative-lookup width for a candidate pool.
     ///
     /// Returns `max(CLOSENESS_LOOKUP_WIDTH, pool_len)`: matches the client's
@@ -1067,22 +1030,17 @@ impl PaymentVerifier {
         }
     }
 
-    /// Whether the storer's local routing table is too sparse to answer the
-    /// Merkle closeness check authoritatively on its own.
+    /// Whether the storer must fall back from the local routing table to the
+    /// iterative network lookup for the Merkle closeness check.
     ///
     /// The local k-buckets can answer authoritatively only when they hold at
     /// least `CLOSENESS_LOOKUP_WIDTH` peers near the midpoint; below that the
-    /// table is genuinely too sparse and the network lookup is mandatory.
-    ///
-    /// Note this is no longer the *only* trigger for the network lookup: a
-    /// dense-but-disagreeing local view also escalates to the network (see
-    /// [`verify_merkle_candidate_closeness_inner`]), because on a real network
-    /// the local k-bucket sample legitimately diverges from the uploader's
-    /// network-walked candidate set. The `DoS` concern that motivated the
-    /// size-only gate — a forged pool forcing the expensive path — is instead
-    /// bounded by [`closeness_fallback_permits`]
-    /// (`CLOSENESS_NETWORK_FALLBACK_CONCURRENCY`). Extracted so the boundary can
-    /// be unit tested without a `P2PNode`.
+    /// table is genuinely too sparse and we pay for the network lookup. The
+    /// gate is local table size — NOT match outcome — so a forged pool cannot
+    /// force the expensive 240s path (an attacker cannot make a victim's local
+    /// routing table sparse). Extracted from
+    /// [`verify_merkle_candidate_closeness_inner`] so the boundary can be unit
+    /// tested without a `P2PNode`.
     const fn closeness_should_fall_back_to_network(local_peer_count: usize) -> bool {
         local_peer_count < Self::CLOSENESS_LOOKUP_WIDTH
     }
@@ -1419,113 +1377,60 @@ impl PaymentVerifier {
         // uses) could demote an XOR-close relay-only peer out of the compared
         // window and falsely reject an honest candidate pool that legitimately
         // contains that peer. See saorsa-labs/saorsa-core#121.
-        let local_peers = p2p_node
+        let mut closeness_peers = p2p_node
             .dht_manager()
             .find_closest_nodes_local_by_distance(&pool_address.0, lookup_count)
             .await;
 
-        // When the local table is dense enough to be authoritative AND the pool
-        // already matches it, accept without paying for a network lookup — the
-        // common case on a healthy, converged network, and the #111 performance
-        // win we want to keep.
-        if Self::closeness_should_fall_back_to_network(local_peers.len()) {
+        // Sparse-table fallback: only when the local table genuinely cannot
+        // answer authoritatively (fewer than CLOSENESS_LOOKUP_WIDTH peers near
+        // the midpoint) do we pay for the iterative network lookup. The gate is
+        // local table size, NOT match outcome — an attacker cannot make a
+        // victim's local routing table sparse, so a forged pool cannot force the
+        // expensive 240s network path (DoS-safe). On a well-connected production
+        // node the local table is dense near any key, so this path is rare.
+        if Self::closeness_should_fall_back_to_network(closeness_peers.len()) {
             debug!(
                 "Merkle closeness: local table returned only {} peers (< {}) for \
                  pool midpoint {}; falling back to network lookup",
-                local_peers.len(),
+                closeness_peers.len(),
                 Self::CLOSENESS_LOOKUP_WIDTH,
                 hex::encode(pool_address.0),
             );
-        } else {
-            let local_peer_ids: Vec<PeerId> = local_peers.iter().map(|n| n.peer_id).collect();
-            if Self::check_closeness_match(&candidate_peer_ids, &local_peer_ids, &pool_address.0)
-                .is_ok()
-            {
-                return Ok(());
-            }
-            // Local view disagrees. The storer's local k-bucket sample
-            // legitimately diverges from the uploader's *network-walked*
-            // candidate set: the uploader collected reachable responders (per
-            // CLOSENESS_LOOKUP_WIDTH, often from positions 17–32) that the
-            // storer's local closest-`lookup_count` need not rank the same way.
-            // Escalate to the authoritative network lookup before rejecting an
-            // honest pool — this restores the pre-#111 correctness, but only on
-            // the (rare on a healthy net) match-failure path rather than for
-            // every chunk. The DoS exposure this reopens is bounded by
-            // `merkle_closeness_network_peer_ids`' concurrency permit.
-            debug!(
-                "Merkle closeness: local view ({} peers) disagreed for pool \
-                 midpoint {}; escalating to authoritative network lookup",
-                local_peers.len(),
-                hex::encode(pool_address.0),
-            );
-        }
-
-        // Authoritative network lookup (bounded; see
-        // `merkle_closeness_network_peer_ids`). This is the final verdict —
-        // there is no further escalation, so its result is returned directly.
-        let network_peer_ids = self
-            .merkle_closeness_network_peer_ids(&p2p_node, &pool_address.0, lookup_count)
-            .await?;
-        Self::check_closeness_match(&candidate_peer_ids, &network_peer_ids, &pool_address.0)
-    }
-
-    /// Run the authoritative iterative-Kademlia closeness lookup for a pool
-    /// midpoint, bounded both in time (`CLOSENESS_LOOKUP_TIMEOUT`) and in
-    /// concurrency ([`closeness_fallback_permits`]).
-    ///
-    /// Returns the network's closest-`lookup_count` peer IDs to the midpoint.
-    /// All error paths are retryable (the uploader can re-PUT): the verifier is
-    /// at fallback capacity, the lookup failed, or it timed out.
-    async fn merkle_closeness_network_peer_ids(
-        &self,
-        p2p_node: &Arc<P2PNode>,
-        pool_address: &[u8; 32],
-        lookup_count: usize,
-    ) -> Result<Vec<PeerId>> {
-        // Bound concurrent network walks. The local fast path handles healthy
-        // traffic, so honest uploads rarely reach here; a forged-pool flood
-        // (distinct pool_hashes that each fail the local check) could otherwise
-        // spawn unbounded CLOSENESS_LOOKUP_TIMEOUT-long walks. `inflight_closeness`
-        // already collapses same-pool concurrency; this caps the distinct-pool
-        // case. Excess PUTs are rejected fast (retryable) rather than queued.
-        let Ok(_permit) = Arc::clone(&self.closeness_fallback_permits).try_acquire_owned() else {
-            return Err(Error::Payment(
-                "Merkle candidate pool rejected: authoritative closeness lookups \
-                 are at capacity; retry shortly."
-                    .into(),
-            ));
-        };
-
-        let network_lookup = p2p_node
-            .dht_manager()
-            .find_closest_nodes_network(pool_address, lookup_count);
-        match tokio::time::timeout(Self::CLOSENESS_LOOKUP_TIMEOUT, network_lookup).await {
-            Ok(Ok(peers)) => Ok(peers.iter().map(|n| n.peer_id).collect()),
-            Ok(Err(e)) => {
-                debug!(
-                    "Merkle closeness network-lookup failed for pool midpoint {}: {e}",
-                    hex::encode(pool_address),
-                );
-                Err(Error::Payment(
-                    "Merkle candidate pool rejected: could not verify candidate \
+            let network_lookup = p2p_node
+                .dht_manager()
+                .find_closest_nodes_network(&pool_address.0, lookup_count);
+            closeness_peers =
+                match tokio::time::timeout(Self::CLOSENESS_LOOKUP_TIMEOUT, network_lookup).await {
+                    Ok(Ok(peers)) => peers,
+                    Ok(Err(e)) => {
+                        debug!(
+                            "Merkle closeness network-lookup failed for pool midpoint {}: {e}",
+                            hex::encode(pool_address.0),
+                        );
+                        return Err(Error::Payment(
+                            "Merkle candidate pool rejected: could not verify candidate \
                      closeness against the authoritative network view."
-                        .into(),
-                ))
-            }
-            Err(_) => {
-                debug!(
-                    "Merkle closeness network-lookup timeout ({:?}) for pool midpoint {}",
-                    Self::CLOSENESS_LOOKUP_TIMEOUT,
-                    hex::encode(pool_address),
-                );
-                Err(Error::Payment(
-                    "Merkle candidate pool rejected: authoritative network lookup \
+                                .into(),
+                        ));
+                    }
+                    Err(_) => {
+                        debug!(
+                            "Merkle closeness network-lookup timeout ({:?}) for pool midpoint {}",
+                            Self::CLOSENESS_LOOKUP_TIMEOUT,
+                            hex::encode(pool_address.0),
+                        );
+                        return Err(Error::Payment(
+                            "Merkle candidate pool rejected: authoritative network lookup \
                      timed out. Retry once the network lookup completes."
-                        .into(),
-                ))
-            }
+                                .into(),
+                        ));
+                    }
+                };
         }
+
+        let closeness_peer_ids: Vec<PeerId> = closeness_peers.iter().map(|n| n.peer_id).collect();
+        Self::check_closeness_match(&candidate_peer_ids, &closeness_peer_ids, &pool_address.0)
     }
 
     /// Verify a merkle batch payment proof.

--- a/src/upgrade/binary_cache.rs
+++ b/src/upgrade/binary_cache.rs
@@ -901,7 +901,7 @@ mod tests {
 
     /// A cache-dir attacker who replaces the cached archive with a FIFO
     /// must not be able to hang `get_verified_archive` waiting for a
-    /// writer to connect. The pre-check + O_NONBLOCK belt-and-braces
+    /// writer to connect. The pre-check + `O_NONBLOCK` belt-and-braces
     /// returns immediately with an error, the cache hit is abandoned, and
     /// the caller falls back to a fresh verified download.
     #[cfg(unix)]


### PR DESCRIPTION
## Why

PRs #114 (`single-node-and-merkle-closeness-verification`) and #111
(`merkle-closeness-local-lookup`) turned out not to be feasible and are being
walked back from the `rc-2026.5.4` release candidate.

Their companion `saorsa-core` changes (#121, #122) are also being abandoned, so
the `saorsa-core` and `ant-protocol` `rc-2026.5.4` branches are going away. This
PR therefore also points both deps back at their crates.io releases.

## Changes

- Revert #114 (`59da17b`).
- Revert #111 (`5ac1f76`).
- Repoint `saorsa-core` → `0.24.4` and `ant-protocol` → `2.1.1` (crates.io),
  refresh `Cargo.lock` (now has zero `branch=rc-2026.5.4` git refs).

## Kept

The other rc-2026.5.4 ant-node changes are untouched: #107, #106, #110, #109, #112.

## Notes

- `cargo check` passes against the crates.io deps.
- A matching ant-client repoint + deletion of the saorsa-core/ant-protocol rc
  branches follow once this merges (ant-client pulls those crates transitively
  via its `ant-node@rc` dep).