### PR TITLE
fix(replication): add first_failed_key to audit-failure log

### DIFF
--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -2538,6 +2538,24 @@ async fn execute_single_fetch(
 // Audit result handler
 // ---------------------------------------------------------------------------
 
+/// Format the first confirmed-failed key as a 16-hex-char label.
+///
+/// Pairs with `challenged_peer` to form a stable cross-host correlation
+/// handle in the audit-failure log line, e.g.
+///
+/// ```text
+/// Audit failure for <peer>: …, `first_failed_key=0x18878f1d2d9e0612`
+/// ```
+///
+/// Falls back to `"0x"` when the list is empty so the log line never
+/// contains a misleading default.
+fn first_failed_key_label(confirmed_failed_keys: &[XorName]) -> String {
+    confirmed_failed_keys.first().map_or_else(
+        || "0x".to_string(),
+        |k| format!("0x{}", hex::encode(&k[..8])),
+    )
+}
+
 /// Handle audit result: log findings and emit trust events.
 async fn handle_audit_result(
     result: &AuditTickResult,
@@ -2573,8 +2591,9 @@ async fn handle_audit_result(
                 ..
             } = evidence
             {
+                let first_failed_key = first_failed_key_label(confirmed_failed_keys);
                 error!(
-                    "Audit failure for {challenged_peer}: reason={reason:?}, confirmed_failed_keys={}, challenged_keys={}, absent_keys={}, digest_mismatch_keys={}",
+                    "Audit failure for {challenged_peer}: reason={reason:?}, confirmed_failed_keys={}, challenged_keys={}, absent_keys={}, digest_mismatch_keys={}, first_failed_key={first_failed_key}",
                     confirmed_failed_keys.len(),
                     summary.challenged_keys,
                     summary.absent_keys,
@@ -2650,7 +2669,7 @@ fn audit_failure_clears_bootstrap_claim(reason: &AuditFailureReason) -> bool {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
-    use super::audit_failure_clears_bootstrap_claim;
+    use super::{audit_failure_clears_bootstrap_claim, first_failed_key_label};
     use crate::replication::types::AuditFailureReason;
 
     #[test]
@@ -2673,5 +2692,41 @@ mod tests {
                 "decoded non-bootstrap failure {reason:?} should clear active claim"
             );
         }
+    }
+
+    #[test]
+    fn first_failed_key_label_truncates_to_16_hex_chars() {
+        // The high-order 8 bytes of the XorName determine the label so an
+        // operator can group audit-failures on the same chunk prefix.
+        let mut key = [0u8; 32];
+        key[0] = 0x18;
+        key[7] = 0xff;
+        // Low-order bytes (positions 8..32) are deliberately set to 0xAA
+        // to verify they are NOT included in the label.
+        for byte in &mut key[8..] {
+            *byte = 0xAA;
+        }
+        let label = first_failed_key_label(&[key]);
+        // Only the first 8 bytes are encoded, low-order bytes are dropped.
+        assert_eq!(label, "0x18000000000000ff");
+        assert_eq!(label.len(), "0x".len() + 16);
+    }
+
+    #[test]
+    fn first_failed_key_label_falls_back_when_empty() {
+        // Should never happen in production (handle_audit_failure rejects
+        // empty sets), but the formatter must still produce a valid label
+        // so the log line doesn't contain a misleading default.
+        assert_eq!(first_failed_key_label(&[]), "0x");
+    }
+
+    #[test]
+    fn first_failed_key_label_uses_first_key_only() {
+        let first = [0x11u8; 32];
+        let second = [0x22u8; 32];
+        assert_eq!(
+            first_failed_key_label(&[first, second]),
+            format!("0x{}", hex::encode(&first[..8]))
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds a `first_failed_key=0x<16-hex>` field to the audit-failure ERROR line in `replication::handle_audit_result`. This is a follow-up to #129, which already gave us structured counts but no way to identify the specific chunk that was missing.

The line currently looks like:

```
Audit failure for <peer>: reason=KeyAbsent, confirmed_failed_keys=1, challenged_keys=1, absent_keys=1, digest_mismatch_keys=0
```

After this PR:

```
Audit failure for <peer>: reason=KeyAbsent, confirmed_failed_keys=1, challenged_keys=1, absent_keys=1, digest_mismatch_keys=0, first_failed_key=0x18878f1d2d9e0612
```

`first_failed_key` is the high-order 8 bytes of the first `confirmed_failed_keys` entry, hex-encoded with a `0x` prefix. 16 hex chars is short enough to keep the log volume low on the hot path but long enough to disambiguate distinct chunks inside the same close group.

## Why

- **Top-failing-key dashboard**: today, the only way to identify which chunk is missing on a peer is to regex-extract the `Audit failure for <hex>` prefix from the *target* peer (which is also its XorName, not the chunk XorName). Adding `first_failed_key` lets us group audit-failures by chunk *and* by peer without runtime regex.
- **Reproducible cross-host correlation**: `first_failed_key=0x18878f1d2d9e0612` + `challenged_peer=<peer-hex>` forms a stable `(chunk-prefix, target-peer)` pair that an operator can paste into a chat thread and anyone can grep for.
- **No behaviour change**: the only modification is the format string. Trust-event emission, responsibility confirmation, and bootstrap-claim handling are untouched.

## Test plan

Three new unit tests in `replication::tests` cover the helper:

- `first_failed_key_label_truncates_to_16_hex_chars` — sets the first 8 bytes to a known pattern and the rest to `0xAA`, asserts the label is exactly the 16-hex of the first 8 bytes and the lower bytes are dropped.
- `first_failed_key_label_falls_back_when_empty` — empty input produces `"0x"` (no misleading default).
- `first_failed_key_label_uses_first_key_only` — only the first entry of the list is used.

Verified locally:

```
$ cargo test --lib replication::
test result: ok. 228 passed; 0 failed; 0 ignored; 0 measured; 285 filtered out

$ cargo clippy --lib --all-features
    Finished `dev` profile [optimized + debuginfo] target(s) in 2.70s
# zero warnings
```

## Sample deployed log (before)

```
2026-06-07T12:17:37.515658Z  ERROR  ant_node::replication
  Audit failure for 18878f1d2d9e061239fe77159f783cff10af2745bddcd8d05dc3ef9522f8528a: reason=KeyAbsent, confirmed_failed_keys=1, challenged_keys=1, absent_keys=1, digest_mismatch_keys=0
```

## Sample deployed log (after, in 0.13.0)

```
2026-06-07T12:17:37.515658Z  ERROR  ant_node::replication
  Audit failure for 18878f1d2d9e061239fe77159f783cff10af2745bddcd8d05dc3ef9522f8528a: reason=KeyAbsent, confirmed_failed_keys=1, challenged_keys=1, absent_keys=1, digest_mismatch_keys=0, first_failed_key=0x18878f1d2d9e0612
```

## Out of scope (intentionally)

This PR does *not* address the underlying issue: a peer that passes responsibility confirmation but has *zero* of its assigned keys. That's a separate concern — the responsibility check in `handle_audit_failure` should only return `confirmed_failures` after a grace window has elapsed since the peer joined the close group, otherwise a fresh-joiner will fail every audit until its first sync completes. That fix needs its own PR; the new log line just makes the issue visible enough to measure and triage.
