### PR TITLE
fix: disk-space pre-check before payment verification on full nodes

### DIFF
--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -1151,6 +1151,32 @@ async fn handle_fresh_offer(
         return Ok(());
     }
 
+    // Disk-space pre-check — mirror the PUT handler (V2-411). A full node can
+    // never store this record, so reject it before the expensive payment
+    // verification (EVM on-chain query / merkle pool work) rather than verifying
+    // and only then failing at `storage.put` below. Reuses the cached capacity
+    // check (passing results only, so freed space is detected promptly), and the
+    // store path keeps its own check as defence-in-depth.
+    if let Err(e) = storage.check_capacity() {
+        info!(
+            target: "ant_node::storage::disk_precheck",
+            key = %hex::encode(offer.key),
+            "Rejecting fresh replication offer before payment verification: {e}"
+        );
+        send_replication_response(
+            source,
+            p2p_node,
+            request_id,
+            ReplicationMessageBody::FreshReplicationResponse(FreshReplicationResponse::Rejected {
+                key: offer.key,
+                reason: format!("Storage error: {e}"),
+            }),
+            rr_message_id,
+        )
+        .await;
+        return Ok(());
+    }
+
     // Gap 1: Validate PoP via PaymentVerifier. This is an already-settled
     // receipt handed over by a neighbour, not a live sale — Replication
     // context skips the storer-being-paid-now checks (own-quote price

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -1169,7 +1169,7 @@ async fn handle_fresh_offer(
             request_id,
             ReplicationMessageBody::FreshReplicationResponse(FreshReplicationResponse::Rejected {
                 key: offer.key,
-                reason: format!("Storage error: {e}"),
+                reason: e.to_string(),
             }),
             rr_message_id,
         )
@@ -1262,7 +1262,7 @@ async fn handle_fresh_offer(
                 ReplicationMessageBody::FreshReplicationResponse(
                     FreshReplicationResponse::Rejected {
                         key: offer.key,
-                        reason: format!("Storage error: {e}"),
+                        reason: e.to_string(),
                     },
                 ),
                 rr_message_id,

--- a/src/storage/handler.rs
+++ b/src/storage/handler.rs
@@ -248,9 +248,11 @@ impl AntProtocol {
         //    lookup, and an on-chain Arbitrum RPC). A disk-full node can never
         //    satisfy this PUT, so reject it here rather than burning that work
         //    only to fail the reserve check inside `storage.put` (V2-411). The
-        //    check is cached (passing results only), so this is effectively
-        //    free per-PUT and still detects freed space promptly. The store
-        //    path keeps its own check as defence-in-depth.
+        //    check caches passing results, so it is free per-PUT on a healthy
+        //    node; a disk-full node re-runs a cheap `available_space` syscall
+        //    each PUT (still negligible next to the verification it avoids) and
+        //    so detects freed space promptly. The store path keeps its own
+        //    check as defence-in-depth.
         if let Err(e) = self.storage.check_capacity() {
             info!(
                 target: "ant_node::storage::disk_precheck",

--- a/src/storage/handler.rs
+++ b/src/storage/handler.rs
@@ -243,7 +243,24 @@ impl AntProtocol {
             Ok(false) => {}
         }
 
-        // 4. Verify payment. This node is the storer being paid right now, so
+        // 4. Cheap disk-space pre-check — runs BEFORE the expensive payment
+        //    verification path (ML-DSA pool checks, a Kademlia closeness
+        //    lookup, and an on-chain Arbitrum RPC). A disk-full node can never
+        //    satisfy this PUT, so reject it here rather than burning that work
+        //    only to fail the reserve check inside `storage.put` (V2-411). The
+        //    check is cached (passing results only), so this is effectively
+        //    free per-PUT and still detects freed space promptly. The store
+        //    path keeps its own check as defence-in-depth.
+        if let Err(e) = self.storage.check_capacity() {
+            info!(
+                target: "ant_node::storage::disk_precheck",
+                addr = %addr_hex,
+                "Rejecting PUT before payment verification: {e}"
+            );
+            return ChunkPutResponse::Error(ProtocolError::StorageFailed(e.to_string()));
+        }
+
+        // 5. Verify payment. This node is the storer being paid right now, so
         // the full ClientPut check set applies (own-quote price freshness,
         // local recipient, merkle candidate closeness).
         let payment_result = self
@@ -269,7 +286,7 @@ impl AntProtocol {
             }
         }
 
-        // 5. Store chunk
+        // 6. Store chunk
         match self.storage.put(&address, &request.content).await {
             Ok(_) => {
                 let content_len = request.content.len();
@@ -281,7 +298,7 @@ impl AntProtocol {
                 // fallback path stays roughly accurate.
                 self.quote_generator.record_store();
 
-                // 6. Notify replication engine for fresh fan-out.
+                // 7. Notify replication engine for fresh fan-out.
                 //    Only emit when a real proof is present — cached-as-verified
                 //    PUTs have no proof to forward, and the chunk would have
                 //    already replicated on the original write that carried one.
@@ -528,10 +545,22 @@ mod tests {
     use tempfile::TempDir;
 
     async fn create_test_protocol() -> (AntProtocol, TempDir) {
+        // `test_default()` sets `disk_reserve: 0`, so the disk pre-check always
+        // passes for the regular tests.
+        create_test_protocol_with_reserve(0).await
+    }
+
+    /// Build a test protocol whose storage enforces the given disk reserve.
+    ///
+    /// A very large reserve (e.g. `u64::MAX`) makes `available < reserve`
+    /// always true, so the disk-space pre-check in `handle_put_inner` fails —
+    /// used to exercise the V2-411 early-return path.
+    async fn create_test_protocol_with_reserve(disk_reserve: u64) -> (AntProtocol, TempDir) {
         let temp_dir = TempDir::new().expect("create temp dir");
 
         let storage_config = LmdbStorageConfig {
             root_dir: temp_dir.path().to_path_buf(),
+            disk_reserve,
             ..LmdbStorageConfig::test_default()
         };
         let storage = Arc::new(
@@ -725,6 +754,56 @@ mod tests {
         } else {
             panic!("expected ChunkTooLarge error");
         }
+    }
+
+    /// V2-411: a disk-full node must reject a PUT with the disk-space error
+    /// *before* running payment verification.
+    ///
+    /// The chunk is intentionally **not** cache-inserted, so if the handler
+    /// reached `verify_payment` it would return `PaymentRequired`/`PaymentFailed`
+    /// (an uncached chunk with no proof). Observing the `StorageFailed` disk
+    /// error instead proves the disk pre-check short-circuited ahead of
+    /// verification — there is no on-chain path to reach.
+    #[tokio::test]
+    async fn test_put_rejected_on_insufficient_disk_before_verification() {
+        // u64::MAX reserve guarantees `available < reserve`, so the cached
+        // disk-space check always fails.
+        let (protocol, _temp) = create_test_protocol_with_reserve(u64::MAX).await;
+
+        let content = b"chunk for a disk-full node";
+        let address = LmdbStorage::compute_address(content);
+
+        let put_request = ChunkPutRequest::new(address, Bytes::copy_from_slice(content));
+        let put_msg = ChunkMessage {
+            request_id: 41,
+            body: ChunkMessageBody::PutRequest(put_request),
+        };
+        let put_bytes = put_msg.encode().expect("encode put");
+
+        let response_bytes = protocol
+            .try_handle_request(&put_bytes)
+            .await
+            .expect("handle put")
+            .expect("expected response");
+        let response = ChunkMessage::decode(&response_bytes).expect("decode response");
+
+        assert_eq!(response.request_id, 41);
+        match response.body {
+            ChunkMessageBody::PutResponse(ChunkPutResponse::Error(
+                ProtocolError::StorageFailed(msg),
+            )) => {
+                assert!(
+                    msg.contains("Insufficient disk space"),
+                    "expected disk-space error, got: {msg}"
+                );
+            }
+            other => {
+                panic!("expected StorageFailed disk error before verification, got: {other:?}")
+            }
+        }
+
+        // And nothing was stored.
+        assert!(!protocol.exists(&address).expect("exists check"));
     }
 
     #[tokio::test]

--- a/src/storage/lmdb.rs
+++ b/src/storage/lmdb.rs
@@ -587,7 +587,7 @@ impl LmdbStorage {
     /// doing expensive setup (e.g. the PUT handler skipping payment
     /// verification on a disk-full node — see `V2-411`).
     ///
-    /// Delegates to [`Self::check_disk_space_cached`], so it shares the same
+    /// Delegates to the private `check_disk_space_cached`, so it shares the same
     /// TTL cache and only ever performs an `fs2::available_space` syscall on a
     /// cache miss. Returns the same `Insufficient disk space …` error the
     /// store path raises, keeping caller behaviour identical.

--- a/src/storage/lmdb.rs
+++ b/src/storage/lmdb.rs
@@ -583,6 +583,23 @@ impl LmdbStorage {
         value
     }
 
+    /// Cheap capacity pre-check for callers that want to reject work *before*
+    /// doing expensive setup (e.g. the PUT handler skipping payment
+    /// verification on a disk-full node — see `V2-411`).
+    ///
+    /// Delegates to [`Self::check_disk_space_cached`], so it shares the same
+    /// TTL cache and only ever performs an `fs2::available_space` syscall on a
+    /// cache miss. Returns the same `Insufficient disk space …` error the
+    /// store path raises, keeping caller behaviour identical.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Storage`] when available space is below the configured
+    /// reserve, or when the disk-space query itself fails.
+    pub fn check_capacity(&self) -> Result<()> {
+        self.check_disk_space_cached()
+    }
+
     /// Check available disk space, skipping the syscall if a recent check passed.
     ///
     /// Only caches *passing* results — a low-space condition is always

--- a/src/storage/lmdb.rs
+++ b/src/storage/lmdb.rs
@@ -596,7 +596,7 @@ impl LmdbStorage {
     ///
     /// Returns [`Error::Storage`] when available space is below the configured
     /// reserve, or when the disk-space query itself fails.
-    pub fn check_capacity(&self) -> Result<()> {
+    pub(crate) fn check_capacity(&self) -> Result<()> {
         self.check_disk_space_cached()
     }
 


### PR DESCRIPTION
Resolves V2-411.

## Why

Investigation of the PROD-UL-01 merkle upload failures found that a large fraction of the node
fleet sits below the 0.49 GiB disk reserve. A full node that receives a PUT it can never satisfy
still ran the **expensive** payment verification first — ML-DSA pool checks, a synchronous
Kademlia closeness lookup, and an on-chain Arbitrum RPC (the call that intermittently failed
against `arb1.arbitrum.io` during the incident) — and only discovered the disk problem afterwards
at `storage.put`. At fleet scale that is wasted RPC/network load and it delays the client's
fallback to another peer, contributing to the slow uploads observed.

The node is not taking money here — merkle/EVM payment is already settled on-chain before the
PUT; verification only validates a pre-paid proof. The issue is wasted work + latency, not lost
funds.

## What

Add a cheap disk-space pre-check ahead of payment verification on the two paths where a full node
would otherwise verify-then-fail:

- **PUT handler** (`handle_put_inner`): call a new `LmdbStorage::check_capacity()` immediately
  after the already-exists check and before `verify_payment`; on insufficient space, return the
  existing `ProtocolError::StorageFailed` early.
- **Replication fresh-offer path** (`handle_fresh_offer`): the same guard before `verify_payment`,
  returning a `Rejected` response. (Found via the testnet verification below — the PUT-handler fix
  alone left this path still doing wasted verification.)

Both emit an info-level reject log under target `ant_node::storage::disk_precheck` for log-based
verification. `check_capacity()` wraps the existing cached check (passing results only, so freed
space is still detected promptly; effectively free per-PUT). The store-path check inside
`LmdbStorage::put()` is kept as defence-in-depth.

Scope notes:
- Backwards compatible — no wire/response-variant change. The client already falls back to the
  next peer on any `Err`. A dedicated `OutOfCapacity`/`TryElsewhere` response is left to V2-469.
- `handle_paid_notify` (the third `verify_payment` caller) is intentionally **not** guarded: it
  stores no chunk data, so there is no doomed store to skip.
- The pull/fetch store path does no payment verification, so it is unchanged.

## Commits

- `fix(storage): disk-space pre-check before payment verification in PUT`
- `fix(replication): disk-space pre-check before payment verification on fresh offers`

## Test plan

Local gates (all green):
- `cargo fmt --all`
- `cargo clippy --all-features -- -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used`
- `cargo test` — storage handler 15/15 (incl. a new regression test asserting a disk-full PUT of
  an uncached chunk returns the disk error before verification), replication 233/233.

Testnet verification (DEV-02, 40 nodes, 8 full @ 20%, this build), via Elasticsearch log queries
scoped to the known full hosts:

**Run 1 (PUT-handler fix):**
- `disk_precheck` reject log fired **only** on the full hosts; zero on healthy hosts.
- On full hosts `put_rpc` count == `disk_precheck` count (115 == 115) — 100% of client PUT RPCs
  rejected at the pre-check; `put_rpc` with `duration_ms >= 30` = 0; `Stored chunk` = 0.
- PUT latency collapsed: full hosts p50 1 ms / p99 8 ms / max 10 ms vs healthy p50 152 ms /
  p99 937 ms / max 2148 ms (~100x), exactly the skipped verification work.
- Revealed the replication push path still verified-then-failed (~491 `EVM payment verified`
  followed by `Failed to store fetched record ...: Insufficient disk`), motivating the second commit.

**Run 2 (both fixes):**
- `disk_precheck` rejects only on full hosts; breakdown PUT-path 70, **replication-path 313**
  (`Rejecting fresh replication offer before payment verification: ... Insufficient disk space`).
- PUT latency still collapsed: full hosts p50 0 ms / p99 2 ms vs healthy p50 146 ms / p99 534 ms;
  `Stored chunk` on full hosts = 0.
- Residual `EVM payment verified` on full hosts traced structurally to `handle_paid_notify`
  (no store) — i.e. no wasted store-path verification remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)