### PR TITLE
fix(payment): widen paid-quote issuer admission to close group + margin

### DIFF
--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -11,6 +11,7 @@ use crate::payment::pricing::{calculate_price, derive_records_stored_from_price}
 use crate::payment::proof::{
     deserialize_merkle_proof, deserialize_proof, detect_proof_type, ProofType,
 };
+use crate::replication::config::storage_admission_width;
 use crate::storage::lmdb::LmdbStorage;
 use ant_protocol::payment::verify::{verify_quote_content, verify_quote_signature};
 use evmlib::common::{Amount, QuoteHash};
@@ -919,17 +920,27 @@ impl PaymentVerifier {
             }
         };
 
-        let close_group_size = self.config.close_group_size;
+        // Verify against the close group PLUS the storage-admission margin
+        // rather than the bare configured close-group width. The check compares
+        // the client's network-derived quote set against this node's *local*
+        // routing-table view, which on a real (young / large / NAT-heavy)
+        // network does not perfectly reflect the global K-closest: a peer the
+        // client legitimately quoted routinely ranks just outside this node's
+        // local close-group window. Bare `close_group_size` (no margin) falsely
+        // rejects those honest payments — the same divergence the sibling
+        // receiver admission check absorbs via `storage_admission_width`
+        // (PR #137); apply the same margin here for symmetry.
+        let admission_width = storage_admission_width(self.config.close_group_size);
         let closest = p2p_node
             .dht_manager()
-            .find_closest_nodes_local_with_self(xorname, close_group_size)
+            .find_closest_nodes_local_with_self(xorname, admission_width)
             .await;
         if closest.iter().any(|node| node.peer_id == *issuer_peer_id) {
             return Ok(());
         }
 
         Err(Error::Payment(format!(
-            "Paid quote issuer {} is not among this node's local {close_group_size} closest peers for {}",
+            "Paid quote issuer {} is not among this node's local {admission_width} closest peers for {}",
             issuer_peer_id.to_hex(),
             hex::encode(xorname)
         )))


### PR DESCRIPTION
## Problem

The paid-quote **issuer** close-group check in `PaymentVerifier::validate_paid_quote_issuer_close_group` compares the client's network-lookup-derived quote set against this node's **local routing-table** view (`find_closest_nodes_local_with_self`). On a young / large / NAT-heavy network the local routing table does not perfectly reflect the global K-closest, so a peer the client legitimately quoted routinely ranks just outside the bare `close_group_size` window. The honest payment is then rejected:

```
Paid quote issuer <peer> is not among this node's local 7 closest peers for <chunk>
```

Because one un-storable chunk fails the whole file, the upload failure rate scales **multiplicatively with file size**.

### Observed

Seen on a staging testnet (ant-node `0.12.1-rc.1`, 900 nodes, ~30% NAT-simulated). Failure rate by file size: ~1000 MB ≈ 100%, ~100 MB ≈ 55%, ~20 MB ≈ 10%; every failed upload reported `N-1/N chunks stored, 1 failed`, dominated by the "issuer is not among this node's local 7 closest peers" rejection.

## Cause

`fix(payment): enforce local admission before proof verification` narrowed the issuer check from the wide K-closest window down to the bare configured close group (`close_group_size`, 7). That is the same local-view divergence that `fix(replication): widen local storage admission range` addressed for the sibling **receiver** admission check by adding `STORAGE_ADMISSION_MARGIN` (→ `storage_admission_width`, 9). The issuer check never received that margin and so over-rejects.

## Fix

Apply the same margin to the issuer check: widen its window from `close_group_size` (7) to `storage_admission_width(close_group_size)` (9), mirroring the receiver admission check. Single-file change; no change to the receiver check or any other behaviour.

## Notes

- This keeps the design from `enforce local admission before proof verification` (issuer ∈ local close group) and simply reuses the tolerance margin already established for the receiver path — it does not revert either prior change.
- The margin size (+2 → width 9) is the conservative, symmetry-preserving choice. If real-world local-RT divergence proves larger than 2 ranks, the width may need to grow further; trying 9 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)