### PR TITLE
chore: pin witnessed close-group dependency branches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,7 +862,7 @@ dependencies = [
 [[package]]
 name = "ant-protocol"
 version = "2.1.3"
-source = "git+https://github.com/WithAutonomi/ant-protocol?branch=snp-witnessed-close-group#0cb92b50d980cff3547ba49706a03ff2d3ac8217"
+source = "git+https://github.com/WithAutonomi/ant-protocol?branch=snp-witnessed-close-group#b1b0067946d304008113a30eec6d4021b88fb405"
 dependencies = [
  "blake3",
  "bytes",
@@ -4866,7 +4866,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.25.0"
-source = "git+https://github.com/mickvandijke/saorsa-core.git?branch=snp-witnessed-close-group#354a9d7d4d4f44edaa61a6fbf2393535df607019"
+source = "git+https://github.com/mickvandijke/saorsa-core.git?branch=snp-witnessed-close-group#348c47595fe5290db7b918a98470b268bfd7c071"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,8 +862,7 @@ dependencies = [
 [[package]]
 name = "ant-protocol"
 version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab11ef1ecd2d37433b010cfb711125bdee0c76d6df65cb1d4eee661a9559c37"
+source = "git+https://github.com/WithAutonomi/ant-protocol?branch=snp-witnessed-close-group#0cb92b50d980cff3547ba49706a03ff2d3ac8217"
 dependencies = [
  "blake3",
  "bytes",
@@ -4867,8 +4866,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b52b60284a36bd0e0f1311dd6f22465e3fd29b3a2f720fd563025cba7851293d"
+source = "git+https://github.com/mickvandijke/saorsa-core.git?branch=snp-witnessed-close-group#354a9d7d4d4f44edaa61a6fbf2393535df607019"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,7 +862,7 @@ dependencies = [
 [[package]]
 name = "ant-protocol"
 version = "2.1.3"
-source = "git+https://github.com/WithAutonomi/ant-protocol?branch=snp-witnessed-close-group#b1b0067946d304008113a30eec6d4021b88fb405"
+source = "git+https://github.com/WithAutonomi/ant-protocol?branch=snp-witnessed-close-group#a9c0255b1125a4d6abafe36f5e0d9a931429bc14"
 dependencies = [
  "blake3",
  "bytes",
@@ -4865,8 +4865,8 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.25.0"
-source = "git+https://github.com/mickvandijke/saorsa-core.git?branch=snp-witnessed-close-group#348c47595fe5290db7b918a98470b268bfd7c071"
+version = "0.25.1-rc.1"
+source = "git+https://github.com/mickvandijke/saorsa-core.git?branch=snp-witnessed-close-group#9344c3a5f95810ab2ac1ec64922ed902fb24f165"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,14 +35,13 @@ mimalloc = "0.1"
 # node-only DHT internals (DHTNode, TrustEvent, DhtNetworkEvent), which
 # Cargo unifies with ant-protocol's version constraint.
 #
-# TODO: swap to `ant-protocol = "2.0.0"` once 2.0.0 is on crates.io.
-# Until then, the git pin tracks the matching saorsa-core lineage
-# (the rc-2026.4.2 branch) so Cargo can unify the wire types here
-# with ant-protocol's re-exports.
-ant-protocol = "2.1.3"
+# The git pins below track the stacked witnessed-close-group dependency line so
+# Cargo can unify the wire types here with ant-protocol's re-exports while the
+# upstream PRs are open.
+ant-protocol = { git = "https://github.com/WithAutonomi/ant-protocol", branch = "snp-witnessed-close-group" }
 
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
-saorsa-core = "0.25.0"
+saorsa-core = { git = "https://github.com/mickvandijke/saorsa-core.git", branch = "snp-witnessed-close-group" }
 saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment


### PR DESCRIPTION
## Summary
- replace local/registry protocol and core pins with git branch dependencies for the witnessed close-group stack
- keep saorsa-node source behavior unchanged while ensuring it compiles against the updated saorsa-core API

## Depends on
- https://github.com/WithAutonomi/saorsa-core/pull/132
- https://github.com/WithAutonomi/ant-protocol/pull/13

## Tests
- cargo check --all-targets --all-features
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings