### PR TITLE
chore(deps): track witnessed transcript dependency stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,7 +862,7 @@ dependencies = [
 [[package]]
 name = "ant-protocol"
 version = "2.1.4-rc.2"
-source = "git+https://github.com/WithAutonomi/ant-protocol?branch=rc-2026.6.2#af8fadc828266c52169bccd106f3ebfd9e409b36"
+source = "git+https://github.com/WithAutonomi/ant-protocol?branch=feat/witnessed-transcript-policy#d73d7656b4fcc7f96d06dfb98c7b9155edd50e08"
 dependencies = [
  "blake3",
  "bytes",
@@ -4866,7 +4866,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.25.1-rc.2"
-source = "git+https://github.com/saorsa-labs/saorsa-core?branch=rc-2026.6.2#f2dab914367b687342cc758b0cc8c2b10d824f31"
+source = "git+https://github.com/saorsa-labs/saorsa-core?branch=feat/witnessed-transcript-policy#d6877658b3b8248aeaeb7f422effd7d8b5499f98"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,13 +36,12 @@ mimalloc = "0.1"
 # Cargo unifies with ant-protocol's version constraint.
 #
 # TODO: swap to `ant-protocol = "2.0.0"` once 2.0.0 is on crates.io.
-# Until then, the git pin tracks the matching saorsa-core lineage
-# (the rc-2026.4.2 branch) so Cargo can unify the wire types here
-# with ant-protocol's re-exports.
-ant-protocol = { git = "https://github.com/WithAutonomi/ant-protocol", branch = "rc-2026.6.2" }
+# Until then, the git pin tracks the matching saorsa-core lineage so Cargo can
+# unify the wire types here with ant-protocol's re-exports.
+ant-protocol = { git = "https://github.com/WithAutonomi/ant-protocol", branch = "feat/witnessed-transcript-policy" }
 
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
-saorsa-core = { git = "https://github.com/saorsa-labs/saorsa-core", branch = "rc-2026.6.2" }
+saorsa-core = { git = "https://github.com/saorsa-labs/saorsa-core", branch = "feat/witnessed-transcript-policy" }
 saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment


### PR DESCRIPTION
## Summary
- update `ant-protocol` to the `feat/witnessed-transcript-policy` branch from WithAutonomi/ant-protocol#14
- update `saorsa-core` to the matching witnessed transcript branch from WithAutonomi/saorsa-core#133
- keep ant-node on a single coherent transport/core dependency graph for downstream clients

## SemVer
Dependency bridge only. This carries the breaking `saorsa-core` / `ant-protocol` API change downstream without adding node-side API changes.

## Dependency PRs
- Depends on WithAutonomi/saorsa-core#133
- Depends on WithAutonomi/ant-protocol#14

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`