### PR TITLE
feat(replication): prioritize new close peers in neighbor sync

### DIFF
--- a/docs/REPLICATION_DESIGN.md
+++ b/docs/REPLICATION_DESIGN.md
@@ -132,38 +132,40 @@ Rules:
 Triggers:
 
 - Periodic randomized timer (`NEIGHBOR_SYNC_INTERVAL`).
+- `KClosestPeersChanged(old, new)`: peers in `new - old` are queued for priority neighbor sync and the sync loop is triggered immediately.
 
 Rules:
 
-1. At the start of each round-robin cycle, node computes `CloseNeighbors(self)` as the `NEIGHBOR_SYNC_SCOPE` nearest peers to self in `LocalRT(self)`, then snapshots `NeighborSyncOrder(self)` as a deterministic ordering of those peers and resets `NeighborSyncCursor(self)` to `0`. The snapshot is fixed for the entire cycle; peers joining `CloseNeighbors(self)` mid-cycle are not added to the current snapshot (they enter the next cycle's snapshot).
-2. Node selects `NeighborSyncSet(self)` by scanning `NeighborSyncOrder(self)` forward from `NeighborSyncCursor(self)`:
+1. At the start of each round-robin cycle, node computes `CloseNeighbors(self)` as the `NEIGHBOR_SYNC_SCOPE` nearest peers to self in `LocalRT(self)`, then snapshots `NeighborSyncOrder(self)` as a deterministic ordering of those peers and resets `NeighborSyncCursor(self)` to `0`. The snapshot is fixed for the normal round-robin walk.
+2. When a `KClosestPeersChanged(old, new)` event reports peers that entered the close-neighbor set (`new - old`), node appends those peers to `PriorityNeighborSyncOrder(self)` unless already queued. Priority peers remain outside `NeighborSyncOrder(self)` but are selected before the normal cursor. If a priority peer is also present in the current snapshot, selecting it removes it from the snapshot so the same peer is not synced twice in one round.
+3. Node selects `NeighborSyncSet(self)` by first draining `PriorityNeighborSyncOrder(self)` and then scanning `NeighborSyncOrder(self)` forward from `NeighborSyncCursor(self)`:
    a. If a candidate peer is on per-peer cooldown (`NEIGHBOR_SYNC_COOLDOWN` not elapsed since last successful sync with that peer), remove the peer from `NeighborSyncOrder(self)` and continue scanning.
    b. Otherwise, add the peer to `NeighborSyncSet(self)`.
    c. Stop when `|NeighborSyncSet(self)| = NEIGHBOR_SYNC_PEER_COUNT` or no unscanned peers remain in the snapshot.
-3. Node initiates sync with each peer in `NeighborSyncSet(self)`. If a peer cannot be synced, remove it from `NeighborSyncOrder(self)` and attempt to fill the vacated slot by resuming the scan from where rule 2 left off. A peer cannot be synced if:
+4. Node initiates sync with each peer in `NeighborSyncSet(self)`. If a peer cannot be synced, remove it from `NeighborSyncOrder(self)` and `PriorityNeighborSyncOrder(self)`, then attempt to fill the vacated slot by resuming the scan from where rule 3 left off. A peer cannot be synced if:
    a. Unreachable (connection failure/timeout).
    b. Peer responds with a bootstrapping claim. On first observation, record `BootstrapClaimFirstSeen(self, peer)`. If `now - BootstrapClaimFirstSeen(self, peer) <= BOOTSTRAP_CLAIM_GRACE_PERIOD`, accept the claim and skip without penalty. If the grace period has elapsed, emit `BootstrapClaimAbuse` evidence to `TrustEngine` (via `report_trust_event` with `ApplicationFailure(weight)`) and skip. If the peer had previously stopped claiming bootstrap, emit `BootstrapClaimAbuse` immediately for the repeated claim and skip.
-4. On any sync session open (outbound or inbound), receiver validates peer authentication and checks current local route membership (`peer ∈ LocalRT(self)`).
-5. If `peer ∈ LocalRT(self)`, sync is bidirectional: both sides send and receive peer-targeted hint sets.
-6. If `peer ∉ LocalRT(self)`, sync is outbound-only from receiver perspective: receiver MAY send hints to that peer, but MUST NOT accept replica or paid-list hints from that peer.
-7. In each session, sender-side hint construction uses peer-targeted sets:
+5. On any sync session open (outbound or inbound), receiver validates peer authentication and checks current local route membership (`peer ∈ LocalRT(self)`).
+6. If `peer ∈ LocalRT(self)`, sync is bidirectional: both sides send and receive peer-targeted hint sets.
+7. If `peer ∉ LocalRT(self)`, sync is outbound-only from receiver perspective: receiver MAY send hints to that peer, but MUST NOT accept replica or paid-list hints from that peer.
+8. In each session, sender-side hint construction uses peer-targeted sets:
     - `ReplicaHintsForPeer`: keys the sender believes the receiver should hold (receiver is among the `CLOSE_GROUP_SIZE` nearest to `K` in sender's `SelfInclusiveRT`).
     - `PaidHintsForPeer`: keys the sender believes the receiver should track in `PaidForList` (receiver is among the `PAID_LIST_CLOSE_GROUP_SIZE` nearest to `K` in sender's `SelfInclusiveRT`).
-8. Transport-level chunking/fragmentation is implementation detail and out of scope for replication logic.
-9. Receiver treats hint sets as unordered collections and deduplicates repeated keys. If a key appears in both `ReplicaHintsForPeer` and `PaidHintsForPeer` in the same session, receiver MUST keep only the replica-hint entry and drop the paid-hint duplicate (single-pipeline processing).
-10. Receiver diffs replica hints against local store and pending sets, then runs per-key admission rules before quorum logic.
-11. Receiver launches quorum checks exactly once per admitted unknown replica key.
-12. Only admitted unknown replica keys that pass presence quorum or paid-list authorization are queued for fetch.
-13. Receiver processes unknown paid hints via Section 7.2 majority checks in a paid-list pipeline: successful checks may update `PaidForList(self)`. If the receiver is also storage-responsible for `K`, successful verification may queue record fetch using verified `Present` sources from the same round. If the same key is also present in replica hints, rule 9 drops the paid-hint duplicate and fetch behavior is governed by the replica-hint pipeline.
-14. Sync payloads MUST NOT include PoP material; PoP remains fresh-replication-only.
-15. Nodes SHOULD use ongoing neighbor sync rounds to re-announce paid hints for locally paid keys to improve paid-list convergence.
-16. After each round, node sets `NeighborSyncCursor(self)` to the position after the last scanned peer in the (possibly shrunk) snapshot. Peers removed during scanning (cooldown or unreachable) do not occupy cursor positions — the cursor reflects the snapshot's state after removals.
-17. When `NeighborSyncCursor(self) >= |NeighborSyncOrder(self)|`, the cycle is complete (`NeighborSyncCycleComplete(self)`). Node MUST execute post-cycle responsibility pruning (Section 11), then recompute `CloseNeighbors(self)` from current `LocalRT(self)`, take a fresh snapshot, and reset the cursor to `0` to begin the next cycle.
+9. Transport-level chunking/fragmentation is implementation detail and out of scope for replication logic.
+10. Receiver treats hint sets as unordered collections and deduplicates repeated keys. If a key appears in both `ReplicaHintsForPeer` and `PaidHintsForPeer` in the same session, receiver MUST keep only the replica-hint entry and drop the paid-hint duplicate (single-pipeline processing).
+11. Receiver diffs replica hints against local store and pending sets, then runs per-key admission rules before quorum logic.
+12. Receiver launches quorum checks exactly once per admitted unknown replica key.
+13. Only admitted unknown replica keys that pass presence quorum or paid-list authorization are queued for fetch.
+14. Receiver processes unknown paid hints via Section 7.2 majority checks in a paid-list pipeline: successful checks may update `PaidForList(self)`. If the receiver is also storage-responsible for `K`, successful verification may queue record fetch using verified `Present` sources from the same round. If the same key is also present in replica hints, rule 10 drops the paid-hint duplicate and fetch behavior is governed by the replica-hint pipeline.
+15. Sync payloads MUST NOT include PoP material; PoP remains fresh-replication-only.
+16. Nodes SHOULD use ongoing neighbor sync rounds to re-announce paid hints for locally paid keys to improve paid-list convergence.
+17. After each round, node sets `NeighborSyncCursor(self)` to the position after the last scanned peer in the (possibly shrunk) snapshot. Peers removed during scanning (cooldown or unreachable) do not occupy cursor positions — the cursor reflects the snapshot's state after removals. Priority syncs do not advance the cursor unless the peer was also removed from the snapshot.
+18. When `PriorityNeighborSyncOrder(self)` is empty and `NeighborSyncCursor(self) >= |NeighborSyncOrder(self)|`, the cycle is complete (`NeighborSyncCycleComplete(self)`). Node MUST execute post-cycle responsibility pruning (Section 11), then recompute `CloseNeighbors(self)` from current `LocalRT(self)`, take a fresh snapshot, and reset the cursor to `0` to begin the next cycle.
 
 Rate control:
 
 - `NEIGHBOR_SYNC_INTERVAL` governs the global sync timer cadence (how often batch selection runs).
-- `NEIGHBOR_SYNC_COOLDOWN` is per-peer: a peer is skipped and removed from the snapshot if it was last successfully synced within `NEIGHBOR_SYNC_COOLDOWN`.
+- `NEIGHBOR_SYNC_COOLDOWN` is per-peer: a peer is skipped and removed from priority and/or snapshot state if it was last successfully synced within `NEIGHBOR_SYNC_COOLDOWN`.
 
 ## 7. Authorization and Admission Rules
 
@@ -402,7 +404,8 @@ Capacity-managed mode (finite store):
 
 Maintain tracker for neighbor-sync eligibility/order and classify topology events:
 
-- `Trigger`: genuine change, run neighbor sync.
+- `Trigger`: genuine close-neighborhood change, run neighbor sync.
+- `Prioritize`: peers in `KClosestPeersChanged.new - KClosestPeersChanged.old` are queued ahead of the normal neighbor-sync cursor.
 - `Skip`: probable restart churn, suppress.
 - `Ignore`: far peers, no action.
 
@@ -414,7 +417,7 @@ Nodes MUST periodically perform self-lookups (network closest-peer lookup for th
 
 1. Self-lookup runs on a randomized timer (`SELF_LOOKUP_INTERVAL`).
 2. Discovered peers are added to `LocalRT(self)` through normal routing-table maintenance.
-3. `CloseNeighbors(self)` is recomputed from `LocalRT(self)` at the start of each neighbor-sync cycle (Section 6.2 rule 1).
+3. `KClosestPeersChanged(old, new)` queues newly-entered close peers for priority neighbor sync, and `CloseNeighbors(self)` is recomputed from `LocalRT(self)` at the start of each neighbor-sync cycle (Section 6.2 rules 1-2).
 4. Without regular self-lookups, a node's close neighborhood becomes stale under churn: new close peers go undetected and departed peers remain in `CloseNeighbors` until routing-table eviction. This delays repair and may cause responsibility misjudgments.
 
 ## 14. Failure Evidence and TrustEngine Integration
@@ -611,8 +614,8 @@ Each scenario should assert exact expected outcomes and state transitions.
 - When a full neighbor-sync round-robin cycle completes, node runs one prune pass using current `SelfInclusiveRT(self)` (`LocalRT(self) ∪ {self}`): stored keys with `IsResponsible(self, K)=false` have `RecordOutOfRangeFirstSeen` recorded (if not already set) but are deleted only when `now - RecordOutOfRangeFirstSeen >= PRUNE_HYSTERESIS_DURATION`, every current close-group peer has mature repair proof for the current close-group snapshot, and every current close-group peer returns a positive nonce-bound audit proof for the key. Missing or failed proofs defer pruning and emit trust penalties after fresh responsibility confirmation; first-time bootstrap claims are penalized only after the bootstrap grace period, while repeated bootstrap claims are penalized immediately. Prune-confirmation work is bounded per pass. Keys that are in range have their `RecordOutOfRangeFirstSeen` cleared. Same hysteresis timing applies independently to `PaidForList` entries where `self ∉ PaidCloseGroup(K)` using `PaidOutOfRangeFirstSeen`, but paid-list pruning does not require remote storage confirmation.
 37. Non-`LocalRT` inbound sync behavior:
 - If a peer opens sync while not in receiver `LocalRT(self)`, receiver may still send hints to that peer, but receiver drops all inbound replica/paid hints from that peer.
-38. Neighbor-sync snapshot stability under peer join:
-- Peer `P` joins `CloseNeighbors(self)` mid-cycle. `P` does not appear in the current `NeighborSyncOrder(self)` snapshot. After cycle completes and a new snapshot is taken from recomputed `CloseNeighbors(self)`, `P` is included in the next cycle's ordering.
+38. Neighbor-sync priority under peer join:
+- Peer `P` joins `CloseNeighbors(self)` mid-cycle. `P` does not appear in the current `NeighborSyncOrder(self)` snapshot, but `KClosestPeersChanged(old, new)` queues `P` in `PriorityNeighborSyncOrder(self)`. The next sync round selects `P` before the normal cursor, removes `P` from the snapshot if already present, and does not sync `P` twice in the same round.
 39. Neighbor-sync unreachable peer removal and slot fill:
 - Peer `P` is in the snapshot. Sync attempt with `P` fails (unreachable). `P` is removed from `NeighborSyncOrder(self)`. Node resumes scanning from where batch selection left off and picks the next available peer `Q` to fill the slot. `P` is not in the next cycle's snapshot (unless it has rejoined `CloseNeighbors`).
 40. Neighbor-sync per-peer cooldown skip:

--- a/docs/REPLICATION_DESIGN.md
+++ b/docs/REPLICATION_DESIGN.md
@@ -29,10 +29,11 @@ Primary goal: validate correctness, safety, and liveness of replication logic be
 - `LocalRT(N)`: node `N`'s current authenticated local routing-table peer set (does not include `N` itself).
 - `SelfInclusiveRT(N)`: derived local view `LocalRT(N) ∪ {N}` used for responsibility-range and local membership evaluations that must treat `N` as a candidate.
 - `CloseNeighbors(N)`: the `NEIGHBOR_SYNC_SCOPE` nearest peers to `N`'s own address in `LocalRT(N)`, ordered by distance to `N`. This is the set of peers eligible for neighbor-sync repair. Recomputed from `LocalRT(N)` at each cycle snapshot.
-- `NeighborSyncOrder(N)`: deterministic ordering of peers, snapshotted from `CloseNeighbors(N)` at the start of each round-robin cycle. Peers joining `CloseNeighbors(N)` mid-cycle are not added (they enter the next cycle's snapshot). Peers may be removed from the snapshot mid-cycle if they are on per-peer cooldown or unreachable during sync.
+- `NeighborSyncOrder(N)`: deterministic ordering of peers, snapshotted from `CloseNeighbors(N)` at the start of each round-robin cycle. Peers joining `CloseNeighbors(N)` mid-cycle are not inserted into this snapshot; they may be queued in `PriorityNeighborSyncOrder(N)` and appear in the next cycle's snapshot. Peers may be removed from the snapshot mid-cycle if they leave the scoped close-neighbor set, are on per-peer cooldown, are unreachable during sync, or are selected from the priority queue while also present in the snapshot.
+- `PriorityNeighborSyncOrder(N)`: FIFO queue of peers that newly entered `CloseNeighbors(N)` according to `KClosestPeersChanged(old, new)`. Priority peers are selected before the normal `NeighborSyncOrder(N)` cursor and are pruned if they leave the scoped close-neighbor set before being selected.
 - `NeighborSyncCursor(N)`: index into the current `NeighborSyncOrder(N)` snapshot indicating the next peer position to schedule. Valid for the lifetime of the snapshot.
-- `NeighborSyncSet(N)`: current round's up-to-`NEIGHBOR_SYNC_PEER_COUNT` peers selected from `NeighborSyncOrder(N)` starting at `NeighborSyncCursor(N)`; periodic repair sync partners for `N`.
-- `NeighborSyncCycleComplete(N)`: event that fires when node `N`'s cursor reaches or exceeds the end of the current `NeighborSyncOrder(N)` snapshot (all remaining peers synced, on cooldown, or unreachable). Triggers post-cycle pruning (Section 11) and a fresh snapshot from current `CloseNeighbors(N)` for the next cycle.
+- `NeighborSyncSet(N)`: current round's up-to-`NEIGHBOR_SYNC_PEER_COUNT` peers selected first from `PriorityNeighborSyncOrder(N)` and then from `NeighborSyncOrder(N)` starting at `NeighborSyncCursor(N)`; periodic repair sync partners for `N`.
+- `NeighborSyncCycleComplete(N)`: event that fires when `PriorityNeighborSyncOrder(N)` is empty and node `N`'s cursor reaches or exceeds the end of the current `NeighborSyncOrder(N)` snapshot (all pending peers synced, on cooldown, unreachable, or removed). Triggers post-cycle pruning (Section 11) and a fresh snapshot from current `CloseNeighbors(N)` for the next cycle.
 - `Record`: immutable, content-addressed data unit with key `K`.
 - `Distance(K, N)`: deterministic distance metric between key and node identity.
 - `CloseGroup(K)`: the `CLOSE_GROUP_SIZE` nearest nodes to key `K`.
@@ -298,7 +299,7 @@ For each unknown key:
 
 1. Deduplicate key in pending-verification table.
 2. Determine fetch eligibility from admission context:
-    - Apply cross-set precedence first (Section 6.2 rule 9): a key present in both hint sets is treated as replica-hint pipeline only.
+    - Apply cross-set precedence first (Section 6.2 rule 10): a key present in both hint sets is treated as replica-hint pipeline only.
     - `FetchEligible = true` if `K` is in the admitted replica-hint pipeline.
     - `FetchEligible = true` for a paid-hint-only key only if `IsResponsible(self, K)` is true.
     - `FetchEligible = false` for paid-hint-only keys where `IsResponsible(self, K)` is false.
@@ -452,7 +453,7 @@ Challenge-response for claimed holders:
 6. Challenger sends `challenged_peer_id` an ordered challenge key set equal to `PeerKeySet(challenged_peer_id)`.
 7. Target responds with either per-key `AuditKeyDigest` values or a bootstrapping claim:
     a. Per-key digests: for each challenged key `K_i` (in challenge order), target computes `AuditKeyDigest(K_i) = H(nonce || challenged_peer_id || K_i || record_bytes_i)`, where `record_bytes_i` is the full raw bytes of the record for `K_i`. Target returns the ordered list of per-key digests. If the target does not hold a challenged key, it MUST signal absence for that position (e.g., a sentinel/empty digest); it MUST NOT omit the position silently.
-    b. Bootstrapping claim: target asserts it is still bootstrapping. Challenger applies the bootstrap-claim grace logic (Section 6.2 rule 3b): record `BootstrapClaimFirstSeen` if first observation, accept without penalty within the one-time `BOOTSTRAP_CLAIM_GRACE_PERIOD`, emit `BootstrapClaimAbuse` evidence if past grace period or if this is a repeated claim after the peer previously stopped claiming bootstrap. Audit tick ends (no digest verification).
+    b. Bootstrapping claim: target asserts it is still bootstrapping. Challenger applies the bootstrap-claim grace logic (Section 6.2 rule 4b): record `BootstrapClaimFirstSeen` if first observation, accept without penalty within the one-time `BOOTSTRAP_CLAIM_GRACE_PERIOD`, emit `BootstrapClaimAbuse` evidence if past grace period or if this is a repeated claim after the peer previously stopped claiming bootstrap. Audit tick ends (no digest verification).
 8. On per-key digest response, challenger recomputes the expected `AuditKeyDigest(K_i)` for each challenged key from local copies and verifies equality per key before deadline. Each key is independently classified as passed (digest matches) or failed (mismatch, absent, or malformed).
 9. On any per-key audit failures (timeout, malformed response, or one or more `AuditKeyDigest` mismatches/absences), challenger MUST perform a responsibility confirmation for each failed key before emitting penalty evidence:
     a. For each failed key `K` in `PeerKeySet(challenged_peer_id)`, perform a fresh local RT closest-peer lookup for `K`.
@@ -621,7 +622,7 @@ Each scenario should assert exact expected outcomes and state transitions.
 40. Neighbor-sync per-peer cooldown skip:
 - Peer `P` was successfully synced in a prior round and is still within `NEIGHBOR_SYNC_COOLDOWN`. When batch selection reaches `P`, it is removed from `NeighborSyncOrder(self)` and scanning continues to the next peer. `P` does not consume a batch slot.
 41. Neighbor-sync cycle completion is guaranteed:
-- Under arbitrary churn, cooldowns, and unreachable peers, the cycle always terminates because the snapshot can only shrink (removals) and the cursor advances monotonically. Cycle completes when `NeighborSyncCursor >= |NeighborSyncOrder|`.
+- Under arbitrary churn, cooldowns, and unreachable peers, the cycle always terminates because the priority queue can only drain or be pruned, the snapshot can only shrink, and the cursor advances monotonically. Cycle completes when `PriorityNeighborSyncOrder` is empty and `NeighborSyncCursor >= |NeighborSyncOrder|`.
 42. Quorum-derived paid-list authorization:
 - Unknown key `K` passes presence quorum (`>= QuorumNeeded(K)` positives from `QuorumTargets`). Key is stored AND added to local `PaidForList(self)`. Node subsequently answers paid-list queries for `K` as "paid."
 43. Paid-list persistence across restart:

--- a/docs/REPLICATION_DESIGN.md
+++ b/docs/REPLICATION_DESIGN.md
@@ -132,12 +132,12 @@ Rules:
 Triggers:
 
 - Periodic randomized timer (`NEIGHBOR_SYNC_INTERVAL`).
-- `KClosestPeersChanged(old, new)`: peers in `new - old` are queued for priority neighbor sync and the sync loop is triggered immediately.
+- `KClosestPeersChanged(old, new)`: peers in `new - old` are queued for priority neighbor sync, peers no longer in `new` are removed from pending neighbor-sync state, and the sync loop is triggered immediately.
 
 Rules:
 
-1. At the start of each round-robin cycle, node computes `CloseNeighbors(self)` as the `NEIGHBOR_SYNC_SCOPE` nearest peers to self in `LocalRT(self)`, then snapshots `NeighborSyncOrder(self)` as a deterministic ordering of those peers and resets `NeighborSyncCursor(self)` to `0`. The snapshot is fixed for the normal round-robin walk.
-2. When a `KClosestPeersChanged(old, new)` event reports peers that entered the close-neighbor set (`new - old`), node appends those peers to `PriorityNeighborSyncOrder(self)` unless already queued. Priority peers remain outside `NeighborSyncOrder(self)` but are selected before the normal cursor. If a priority peer is also present in the current snapshot, selecting it removes it from the snapshot so the same peer is not synced twice in one round.
+1. At the start of each round-robin cycle, node computes `CloseNeighbors(self)` as the `NEIGHBOR_SYNC_SCOPE` nearest peers to self in `LocalRT(self)`, then snapshots `NeighborSyncOrder(self)` as a deterministic ordering of those peers and resets `NeighborSyncCursor(self)` to `0`. The snapshot preserves the normal round-robin walk for peers that remain close.
+2. When a `KClosestPeersChanged(old, new)` event reports close-neighborhood churn, node removes peers that are no longer in the scoped `new` set from both `PriorityNeighborSyncOrder(self)` and `NeighborSyncOrder(self)`, preserving the relative order and cursor position of peers that remain close. Peers that entered the close-neighbor set (`new - old`) are appended to `PriorityNeighborSyncOrder(self)` unless already queued. Priority peers remain outside `NeighborSyncOrder(self)` but are selected before the normal cursor. If a priority peer is also present in the current snapshot, selecting it removes it from the snapshot so the same peer is not synced twice in one round.
 3. Node selects `NeighborSyncSet(self)` by first draining `PriorityNeighborSyncOrder(self)` and then scanning `NeighborSyncOrder(self)` forward from `NeighborSyncCursor(self)`:
    a. If a candidate peer is on per-peer cooldown (`NEIGHBOR_SYNC_COOLDOWN` not elapsed since last successful sync with that peer), remove the peer from `NeighborSyncOrder(self)` and continue scanning.
    b. Otherwise, add the peer to `NeighborSyncSet(self)`.
@@ -615,7 +615,7 @@ Each scenario should assert exact expected outcomes and state transitions.
 37. Non-`LocalRT` inbound sync behavior:
 - If a peer opens sync while not in receiver `LocalRT(self)`, receiver may still send hints to that peer, but receiver drops all inbound replica/paid hints from that peer.
 38. Neighbor-sync priority under peer join:
-- Peer `P` joins `CloseNeighbors(self)` mid-cycle. `P` does not appear in the current `NeighborSyncOrder(self)` snapshot, but `KClosestPeersChanged(old, new)` queues `P` in `PriorityNeighborSyncOrder(self)`. The next sync round selects `P` before the normal cursor, removes `P` from the snapshot if already present, and does not sync `P` twice in the same round.
+- Peer `P` joins `CloseNeighbors(self)` mid-cycle. `P` does not appear in the current `NeighborSyncOrder(self)` snapshot, but `KClosestPeersChanged(old, new)` queues `P` in `PriorityNeighborSyncOrder(self)`. Peers that remain close keep their normal round-robin position, while peers no longer in `new` are removed from pending sync state. The next sync round selects `P` before the normal cursor, removes `P` from the snapshot if already present, and does not sync `P` twice in the same round.
 39. Neighbor-sync unreachable peer removal and slot fill:
 - Peer `P` is in the snapshot. Sync attempt with `P` fails (unreachable). `P` is removed from `NeighborSyncOrder(self)`. Node resumes scanning from where batch selection left off and picks the next available peer `Q` to fill the slot. `P` is not in the next cycle's snapshot (unless it has rejoined `CloseNeighbors`).
 40. Neighbor-sync per-peer cooldown skip:

--- a/src/replication/config.rs
+++ b/src/replication/config.rs
@@ -303,6 +303,12 @@ impl ReplicationConfig {
         if self.neighbor_sync_scope == 0 {
             return Err("neighbor_sync_scope must be >= 1".to_string());
         }
+        if self.neighbor_sync_scope > K_BUCKET_SIZE {
+            return Err(format!(
+                "neighbor_sync_scope ({}) must be <= K_BUCKET_SIZE ({})",
+                self.neighbor_sync_scope, K_BUCKET_SIZE,
+            ));
+        }
         Ok(())
     }
 
@@ -529,6 +535,15 @@ mod tests {
     fn neighbor_sync_peer_count_zero_rejected() {
         let config = ReplicationConfig {
             neighbor_sync_peer_count: 0,
+            ..ReplicationConfig::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn neighbor_sync_scope_exceeding_k_bucket_size_rejected() {
+        let config = ReplicationConfig {
+            neighbor_sync_scope: K_BUCKET_SIZE + 1,
             ..ReplicationConfig::default()
         };
         assert!(config.validate().is_err());

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -459,18 +459,19 @@ impl ReplicationEngine {
                                     .filter(|peer| !old_peers.contains(peer))
                                     .collect::<Vec<_>>();
                                 let entrant_count = entrants.len();
-                                let priority_insertions = {
+                                let (priority_insertions, sync_removals) = {
                                     let mut state = sync_state.write().await;
-                                    state.retain_priority_peers(&new_peers);
-                                    state.queue_priority_peers(entrants)
+                                    let sync_removals = state.retain_sync_peers(&new_peers);
+                                    let priority_insertions = state.queue_priority_peers(entrants);
+                                    (priority_insertions, sync_removals)
                                 };
                                 if priority_insertions > 0 {
                                     debug!(
-                                        "K-closest peers changed, queued {priority_insertions}/{entrant_count} new close peers for priority neighbor sync"
+                                        "K-closest peers changed, queued {priority_insertions}/{entrant_count} new close peers for priority neighbor sync and pruned {sync_removals} departed pending sync entries"
                                     );
                                 } else {
                                     debug!(
-                                        "K-closest peers changed, no additional close peers queued, triggering early neighbor sync"
+                                        "K-closest peers changed, no additional close peers queued, pruned {sync_removals} departed pending sync entries, triggering early neighbor sync"
                                     );
                                 }
                                 sync_trigger.notify_one();

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -375,6 +375,7 @@ impl ReplicationEngine {
         let sync_cycle_epoch = Arc::clone(&self.sync_cycle_epoch);
         let repair_proofs = Arc::clone(&self.repair_proofs);
         let sync_trigger = Arc::clone(&self.sync_trigger);
+        let sync_state = Arc::clone(&self.sync_state);
 
         let handle = tokio::spawn(async move {
             loop {
@@ -439,13 +440,43 @@ impl ReplicationEngine {
                     dht_event = dht_events.recv() => {
                         let Ok(dht_event) = dht_event else { continue };
                         match dht_event {
-                            DhtNetworkEvent::KClosestPeersChanged { .. } => {
-                                debug!(
-                                    "K-closest peers changed, triggering early neighbor sync"
-                                );
+                            DhtNetworkEvent::KClosestPeersChanged { old, new } => {
+                                let old_peers = old
+                                    .iter()
+                                    .take(config.neighbor_sync_scope)
+                                    .copied()
+                                    .collect::<HashSet<_>>();
+                                let new_scoped = new
+                                    .iter()
+                                    .take(config.neighbor_sync_scope)
+                                    .copied()
+                                    .collect::<Vec<_>>();
+                                let new_peers =
+                                    new_scoped.iter().copied().collect::<HashSet<_>>();
+                                let entrants = new_scoped
+                                    .iter()
+                                    .copied()
+                                    .filter(|peer| !old_peers.contains(peer))
+                                    .collect::<Vec<_>>();
+                                let entrant_count = entrants.len();
+                                let priority_insertions = {
+                                    let mut state = sync_state.write().await;
+                                    state.retain_priority_peers(&new_peers);
+                                    state.queue_priority_peers(entrants)
+                                };
+                                if priority_insertions > 0 {
+                                    debug!(
+                                        "K-closest peers changed, queued {priority_insertions}/{entrant_count} new close peers for priority neighbor sync"
+                                    );
+                                } else {
+                                    debug!(
+                                        "K-closest peers changed, no additional close peers queued, triggering early neighbor sync"
+                                    );
+                                }
                                 sync_trigger.notify_one();
                             }
                             DhtNetworkEvent::PeerRemoved { peer_id } => {
+                                sync_state.write().await.remove_peer(&peer_id);
                                 repair_proofs.write().await.remove_peer(&peer_id);
                             }
                             _ => {}

--- a/src/replication/neighbor_sync.rs
+++ b/src/replication/neighbor_sync.rs
@@ -140,8 +140,9 @@ pub async fn snapshot_close_neighbors(
 
 /// Select the next batch of peers for sync from the current cycle.
 ///
-/// Rules 2-3: Scan forward from cursor, skip peers still under cooldown,
-/// fill up to `peer_count` slots.
+/// Priority peers from routing-table churn are drained before the round-robin
+/// cursor. Rules 2-3 then scan forward from cursor, skip peers still under
+/// cooldown, and fill up to `peer_count` slots.
 pub fn select_sync_batch(
     state: &mut NeighborSyncState,
     peer_count: usize,
@@ -150,17 +151,29 @@ pub fn select_sync_batch(
     let mut batch = Vec::new();
     let now = Instant::now();
 
+    while batch.len() < peer_count {
+        let Some(peer) = state.priority_order.pop_front() else {
+            break;
+        };
+
+        if peer_on_cooldown(state, &peer, now, cooldown) {
+            state.remove_peer(&peer);
+            continue;
+        }
+
+        state.remove_peer(&peer);
+        batch.push(peer);
+    }
+
     while batch.len() < peer_count && state.cursor < state.order.len() {
         let peer = state.order[state.cursor];
 
         // Check cooldown (Rule 2a): if the peer was synced recently, remove
         // from the snapshot and continue without advancing the cursor (the
         // next element slides into the current cursor position).
-        if let Some(last_sync) = state.last_sync_times.get(&peer) {
-            if now.duration_since(*last_sync) < cooldown {
-                state.order.remove(state.cursor);
-                continue;
-            }
+        if peer_on_cooldown(state, &peer, now, cooldown) {
+            state.order.remove(state.cursor);
+            continue;
         }
 
         batch.push(peer);
@@ -168,6 +181,18 @@ pub fn select_sync_batch(
     }
 
     batch
+}
+
+fn peer_on_cooldown(
+    state: &NeighborSyncState,
+    peer: &PeerId,
+    now: Instant,
+    cooldown: Duration,
+) -> bool {
+    state
+        .last_sync_times
+        .get(peer)
+        .is_some_and(|last_sync| now.duration_since(*last_sync) < cooldown)
 }
 
 /// Execute a sync session with a single peer.
@@ -278,13 +303,7 @@ pub fn handle_sync_failure(
     cooldown: Duration,
 ) -> Option<PeerId> {
     // Find and remove the failed peer from the ordering.
-    if let Some(pos) = state.order.iter().position(|p| p == failed_peer) {
-        state.order.remove(pos);
-        // Adjust cursor if removal was before the current cursor position.
-        if pos < state.cursor {
-            state.cursor = state.cursor.saturating_sub(1);
-        }
-    }
+    state.remove_peer(failed_peer);
 
     // Try to fill the vacated slot, applying cooldown filtering (same as
     // select_sync_batch Rule 2a).
@@ -292,11 +311,9 @@ pub fn handle_sync_failure(
     while state.cursor < state.order.len() {
         let candidate = state.order[state.cursor];
 
-        if let Some(last_sync) = state.last_sync_times.get(&candidate) {
-            if now.duration_since(*last_sync) < cooldown {
-                state.order.remove(state.cursor);
-                continue;
-            }
+        if peer_on_cooldown(state, &candidate, now, cooldown) {
+            state.order.remove(state.cursor);
+            continue;
         }
 
         state.cursor += 1;
@@ -778,10 +795,9 @@ mod tests {
     }
 
     #[test]
-    fn scenario_38_mid_cycle_peer_join_excluded() {
-        // Peer D joins CloseNeighbors mid-cycle.
-        // D should NOT appear in the current NeighborSyncOrder snapshot.
-        // After cycle completes and a new snapshot is taken, D can be included.
+    fn scenario_38_mid_cycle_peer_join_prioritized() {
+        // Peer D joins CloseNeighbors mid-cycle. It is queued for priority
+        // sync without being inserted into the current round-robin snapshot.
         let peers = vec![
             peer_id_from_byte(0xA),
             peer_id_from_byte(0xB),
@@ -793,29 +809,18 @@ mod tests {
         let _ = select_sync_batch(&mut state, 1, Duration::from_secs(0));
         assert_eq!(state.cursor, 1);
 
-        // Peer D "joins" the network. It should NOT be in the current snapshot.
+        // Peer D "joins" the close-neighbor set. It remains outside the
+        // stable snapshot but is queued ahead of the cursor.
         let peer_d = peer_id_from_byte(0xD);
+        assert_eq!(state.queue_priority_peers([peer_d]), 1);
+        assert!(!state.order.contains(&peer_d));
         assert!(
-            !state.order.contains(&peer_d),
-            "mid-cycle joiner must not appear in the current snapshot"
+            !state.is_cycle_complete(),
+            "pending priority sync keeps the cycle active"
         );
 
-        // Complete the current cycle.
-        let _ = select_sync_batch(&mut state, 2, Duration::from_secs(0));
-        assert!(state.is_cycle_complete());
-
-        // New cycle: now D can be included in the fresh snapshot.
-        let new_peers = vec![
-            peer_id_from_byte(0xA),
-            peer_id_from_byte(0xB),
-            peer_id_from_byte(0xC),
-            peer_d,
-        ];
-        let new_state = NeighborSyncState::new_cycle(new_peers);
-        assert!(
-            new_state.order.contains(&peer_d),
-            "after new snapshot, joiner D should be present"
-        );
+        let batch = select_sync_batch(&mut state, 2, Duration::from_secs(0));
+        assert_eq!(batch, vec![peer_d, peer_id_from_byte(0xB)]);
     }
 
     #[test]
@@ -882,6 +887,42 @@ mod tests {
 
         // Cycle is complete since all remaining peers were selected.
         assert!(state.is_cycle_complete());
+    }
+
+    #[test]
+    fn priority_peer_in_snapshot_is_not_selected_twice() {
+        let peers = vec![
+            peer_id_from_byte(1),
+            peer_id_from_byte(2),
+            peer_id_from_byte(3),
+        ];
+        let mut state = NeighborSyncState::new_cycle(peers);
+        assert_eq!(state.queue_priority_peers([peer_id_from_byte(2)]), 1);
+
+        let batch = select_sync_batch(&mut state, 2, Duration::from_secs(0));
+
+        assert_eq!(batch, vec![peer_id_from_byte(2), peer_id_from_byte(1)]);
+        assert_eq!(
+            state.order,
+            vec![peer_id_from_byte(1), peer_id_from_byte(3)]
+        );
+        assert_eq!(state.cursor, 1);
+    }
+
+    #[test]
+    fn priority_peer_on_cooldown_is_skipped_and_removed_from_snapshot() {
+        let peers = vec![peer_id_from_byte(1), peer_id_from_byte(2)];
+        let mut state = NeighborSyncState::new_cycle(peers);
+        let cooldown = Duration::from_secs(1);
+        let priority_peer = peer_id_from_byte(2);
+        state.last_sync_times.insert(priority_peer, Instant::now());
+        assert_eq!(state.queue_priority_peers([priority_peer]), 1);
+
+        let batch = select_sync_batch(&mut state, 2, cooldown);
+
+        assert_eq!(batch, vec![peer_id_from_byte(1)]);
+        assert!(state.priority_order.is_empty());
+        assert!(!state.order.contains(&priority_peer));
     }
 
     #[test]

--- a/src/replication/neighbor_sync.rs
+++ b/src/replication/neighbor_sync.rs
@@ -152,20 +152,31 @@ pub fn select_sync_batch(
     let now = Instant::now();
 
     while batch.len() < peer_count {
-        let Some(peer) = state.priority_order.pop_front() else {
+        let Some(peer) = select_next_sync_peer(state, now, cooldown) else {
             break;
         };
+        batch.push(peer);
+    }
 
+    batch
+}
+
+fn select_next_sync_peer(
+    state: &mut NeighborSyncState,
+    now: Instant,
+    cooldown: Duration,
+) -> Option<PeerId> {
+    while let Some(peer) = state.priority_order.pop_front() {
         if peer_on_cooldown(state, &peer, now, cooldown) {
             state.remove_peer(&peer);
             continue;
         }
 
         state.remove_peer(&peer);
-        batch.push(peer);
+        return Some(peer);
     }
 
-    while batch.len() < peer_count && state.cursor < state.order.len() {
+    while state.cursor < state.order.len() {
         let peer = state.order[state.cursor];
 
         // Check cooldown (Rule 2a): if the peer was synced recently, remove
@@ -176,11 +187,11 @@ pub fn select_sync_batch(
             continue;
         }
 
-        batch.push(peer);
         state.cursor += 1;
+        return Some(peer);
     }
 
-    batch
+    None
 }
 
 fn peer_on_cooldown(
@@ -293,10 +304,9 @@ pub(crate) async fn sync_with_peer_with_outcome(
 /// Handle a failed sync attempt: remove peer from snapshot and try to fill
 /// the vacated slot.
 ///
-/// Rule 3: Remove unreachable peer from `NeighborSyncOrder`, attempt to fill
-/// by resuming scan from where rule 2 left off. Applies the same cooldown
-/// filtering as [`select_sync_batch`] to avoid selecting a peer that was
-/// recently synced.
+/// Rule 3: Remove unreachable peer from pending sync state, attempt to fill
+/// by using the same priority-first scan as [`select_sync_batch`]. Applies the
+/// same cooldown filtering to avoid selecting a peer that was recently synced.
 pub fn handle_sync_failure(
     state: &mut NeighborSyncState,
     failed_peer: &PeerId,
@@ -305,22 +315,10 @@ pub fn handle_sync_failure(
     // Find and remove the failed peer from the ordering.
     state.remove_peer(failed_peer);
 
-    // Try to fill the vacated slot, applying cooldown filtering (same as
-    // select_sync_batch Rule 2a).
+    // Try to fill the vacated slot, applying the same priority and cooldown
+    // filtering used by select_sync_batch.
     let now = Instant::now();
-    while state.cursor < state.order.len() {
-        let candidate = state.order[state.cursor];
-
-        if peer_on_cooldown(state, &candidate, now, cooldown) {
-            state.order.remove(state.cursor);
-            continue;
-        }
-
-        state.cursor += 1;
-        return Some(candidate);
-    }
-
-    None
+    select_next_sync_peer(state, now, cooldown)
 }
 
 /// Record a successful sync with a peer.
@@ -923,6 +921,28 @@ mod tests {
         assert_eq!(batch, vec![peer_id_from_byte(1)]);
         assert!(state.priority_order.is_empty());
         assert!(!state.order.contains(&priority_peer));
+    }
+
+    #[test]
+    fn failure_replacement_prefers_remaining_priority_peer() {
+        let peers = vec![peer_id_from_byte(1), peer_id_from_byte(2)];
+        let mut state = NeighborSyncState::new_cycle(peers);
+        let first_priority_peer = peer_id_from_byte(3);
+        let second_priority_peer = peer_id_from_byte(4);
+        assert_eq!(
+            state.queue_priority_peers([first_priority_peer, second_priority_peer]),
+            2
+        );
+
+        let batch = select_sync_batch(&mut state, 1, Duration::from_secs(0));
+        assert_eq!(batch, vec![first_priority_peer]);
+
+        let replacement =
+            handle_sync_failure(&mut state, &first_priority_peer, Duration::from_secs(0));
+
+        assert_eq!(replacement, Some(second_priority_peer));
+        assert!(state.priority_order.is_empty());
+        assert_eq!(state.cursor, 0);
     }
 
     #[test]

--- a/src/replication/types.rs
+++ b/src/replication/types.rs
@@ -578,10 +578,32 @@ impl NeighborSyncState {
         queued
     }
 
-    /// Drop queued priority peers that are no longer in the close-peer set.
-    pub fn retain_priority_peers(&mut self, close_peers: &HashSet<PeerId>) {
+    /// Drop pending sync peers that are no longer in the close-peer set.
+    ///
+    /// Peers still in `close_peers` keep their relative position. The cursor is
+    /// adjusted so already-scanned retained peers are not selected again.
+    pub fn retain_sync_peers(&mut self, close_peers: &HashSet<PeerId>) -> usize {
+        let old_priority_len = self.priority_order.len();
         self.priority_order
             .retain(|peer| close_peers.contains(peer));
+
+        let old_order_len = self.order.len();
+        let old_cursor = self.cursor;
+        let mut retained_before_cursor = 0;
+        let mut retained_order = Vec::with_capacity(old_order_len);
+        for (idx, peer) in self.order.drain(..).enumerate() {
+            if close_peers.contains(&peer) {
+                if idx < old_cursor {
+                    retained_before_cursor += 1;
+                }
+                retained_order.push(peer);
+            }
+        }
+
+        self.order = retained_order;
+        self.cursor = retained_before_cursor;
+
+        (old_priority_len - self.priority_order.len()) + (old_order_len - self.order.len())
     }
 
     /// Remove a peer from any pending neighbor-sync state.
@@ -1213,6 +1235,40 @@ mod tests {
         assert!(!state.priority_order.contains(&peer));
         assert_eq!(state.order, vec![retained]);
         assert_eq!(state.cursor, 0);
+    }
+
+    #[test]
+    fn neighbor_sync_retain_sync_peers_prunes_only_departed_peers() {
+        let already_scanned = peer_id_from_byte(1);
+        let stable_scanned = peer_id_from_byte(2);
+        let departed_priority = peer_id_from_byte(3);
+        let stable_unscanned = peer_id_from_byte(4);
+        let stable_priority = peer_id_from_byte(5);
+        let mut state = NeighborSyncState::new_cycle(vec![
+            already_scanned,
+            stable_scanned,
+            departed_priority,
+            stable_unscanned,
+        ]);
+        assert_eq!(
+            state.queue_priority_peers([departed_priority, stable_priority]),
+            2
+        );
+        state.cursor = 2;
+        let close_peers = HashSet::from([stable_scanned, stable_unscanned, stable_priority]);
+
+        let removed = state.retain_sync_peers(&close_peers);
+
+        assert_eq!(removed, 3);
+        assert_eq!(state.order, vec![stable_scanned, stable_unscanned]);
+        assert_eq!(
+            state.priority_order.iter().copied().collect::<Vec<_>>(),
+            vec![stable_priority]
+        );
+        assert_eq!(
+            state.cursor, 1,
+            "stable peer scanned before churn must not be selected again"
+        );
     }
 
     #[test]

--- a/src/replication/types.rs
+++ b/src/replication/types.rs
@@ -5,7 +5,7 @@
 //! `docs/REPLICATION_DESIGN.md`).
 
 use std::cmp::Ordering;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
@@ -479,6 +479,13 @@ pub enum BootstrapClaimObservation {
 /// used their one bootstrap-claim window.
 #[derive(Debug)]
 pub struct NeighborSyncState {
+    /// Newly-entered close peers to sync before the normal cycle cursor.
+    ///
+    /// This queue is populated from `KClosestPeersChanged` routing-table
+    /// events and is intentionally separate from `order`: priority syncs do
+    /// not restart the current round-robin cycle or discard already-scanned
+    /// peers.
+    pub priority_order: VecDeque<PeerId>,
     /// Deterministic ordering of peers for the current cycle (snapshot).
     pub order: Vec<PeerId>,
     /// Current cursor position into `order`.
@@ -509,6 +516,7 @@ impl NeighborSyncState {
     #[must_use]
     pub fn new_cycle(close_neighbors: Vec<PeerId>) -> Self {
         Self {
+            priority_order: VecDeque::new(),
             order: close_neighbors,
             cursor: 0,
             last_sync_times: HashMap::new(),
@@ -551,10 +559,51 @@ impl NeighborSyncState {
         self.bootstrap_claims.remove(peer).is_some()
     }
 
+    /// Queue newly-entered close peers for priority sync.
+    ///
+    /// Existing queued peers are retained in their original position and
+    /// duplicates from the same routing-table churn burst are ignored.
+    pub fn queue_priority_peers<I>(&mut self, peers: I) -> usize
+    where
+        I: IntoIterator<Item = PeerId>,
+    {
+        let mut queued = 0;
+        for peer in peers {
+            if self.priority_order.contains(&peer) {
+                continue;
+            }
+            self.priority_order.push_back(peer);
+            queued += 1;
+        }
+        queued
+    }
+
+    /// Drop queued priority peers that are no longer in the close-peer set.
+    pub fn retain_priority_peers(&mut self, close_peers: &HashSet<PeerId>) {
+        self.priority_order
+            .retain(|peer| close_peers.contains(peer));
+    }
+
+    /// Remove a peer from any pending neighbor-sync state.
+    pub fn remove_peer(&mut self, peer: &PeerId) -> bool {
+        let old_priority_len = self.priority_order.len();
+        self.priority_order.retain(|queued| queued != peer);
+
+        let old_order_len = self.order.len();
+        if let Some(pos) = self.order.iter().position(|queued| queued == peer) {
+            self.order.remove(pos);
+            if pos < self.cursor {
+                self.cursor = self.cursor.saturating_sub(1);
+            }
+        }
+
+        old_priority_len != self.priority_order.len() || old_order_len != self.order.len()
+    }
+
     /// Whether the current cycle is complete.
     #[must_use]
     pub fn is_cycle_complete(&self) -> bool {
-        self.cursor >= self.order.len()
+        self.priority_order.is_empty() && self.cursor >= self.order.len()
     }
 }
 
@@ -1126,6 +1175,44 @@ mod tests {
             state.is_cycle_complete(),
             "cursor past end should still report complete"
         );
+    }
+
+    #[test]
+    fn neighbor_sync_priority_queue_blocks_cycle_completion() {
+        let peer = peer_id_from_byte(2);
+        let mut state = NeighborSyncState::new_cycle(Vec::new());
+
+        assert!(state.is_cycle_complete());
+        assert_eq!(state.queue_priority_peers([peer]), 1);
+        assert!(
+            !state.is_cycle_complete(),
+            "pending priority peers must sync before the cycle completes"
+        );
+    }
+
+    #[test]
+    fn neighbor_sync_priority_queue_deduplicates_peers() {
+        let peer = peer_id_from_byte(3);
+        let mut state = NeighborSyncState::new_cycle(Vec::new());
+
+        assert_eq!(state.queue_priority_peers([peer, peer]), 1);
+        assert_eq!(state.priority_order.len(), 1);
+    }
+
+    #[test]
+    fn neighbor_sync_remove_peer_clears_order_and_priority_queue() {
+        let peer = peer_id_from_byte(4);
+        let retained = peer_id_from_byte(5);
+        let mut state = NeighborSyncState::new_cycle(vec![peer, retained]);
+        assert_eq!(state.queue_priority_peers([peer]), 1);
+        state.cursor = 1;
+
+        assert!(state.remove_peer(&peer));
+
+        assert!(!state.order.contains(&peer));
+        assert!(!state.priority_order.contains(&peer));
+        assert_eq!(state.order, vec![retained]);
+        assert_eq!(state.cursor, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This makes neighbour sync react more precisely to close-neighbour churn. When saorsa-core emits `KClosestPeersChanged { old, new }`, the replication engine now computes peers that entered the configured neighbour-sync scope and queues them for priority sync before continuing the normal round-robin cursor.

## Motivation

The previous implementation woke the neighbour-sync loop on `KClosestPeersChanged`, but it did not preserve which peers were new. That meant a peer that had just entered the close routing neighbourhood could still wait behind the existing cycle cursor before receiving targeted repair and paid-list hints.

Prioritising new close peers should improve convergence after joins, self-lookups, and routing-table repair without broadening sync to unrelated connection churn.

## Behaviour Changes

- Adds a small `PriorityNeighborSyncOrder` queue to `NeighborSyncState`.
- Queues only peers in `new - old`, scoped by `neighbor_sync_scope`.
- Drains priority peers before the regular `NeighborSyncOrder` cursor.
- Keeps the existing round-robin cycle intact rather than restarting it.
- Deduplicates queued priority peers.
- Removes a priority peer from the normal snapshot when selected, so it cannot be synced twice in one round.
- Applies the existing per-peer cooldown rules to priority peers.
- Removes peers from pending sync state when `PeerRemoved` arrives.
- Updates the replication design doc to match the new churn-handling contract.

## Notes For Review

The intent is to favour genuinely new close peers while preserving normal coverage and cycle completion semantics. Priority syncs do not advance the normal cursor unless the peer was also present in the snapshot and removed from it.

## Tests

- `cargo test -p ant-node replication::neighbor_sync`
- `cargo test -p ant-node replication::types`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
