### PR TITLE
perf(replication): reduce neighbor sync CPU spikes

### DIFF
--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -559,8 +559,14 @@ impl PaymentVerifier {
                     "Payment verification: context={context:?}, proof_type={proof_type}, proof_bytes={proof_bytes}, status={status:?}, elapsed_ms={elapsed_ms}",
                 );
             }
-            Err(e) => {
+            Err(e) if elapsed_ms >= PAYMENT_VERIFY_SLOW_LOG_MS => {
                 warn!(
+                    target: "ant_node::payment::verify",
+                    "Slow payment verification failed: context={context:?}, proof_type={proof_type}, proof_bytes={proof_bytes}, elapsed_ms={elapsed_ms}: {e}",
+                );
+            }
+            Err(e) => {
+                debug!(
                     target: "ant_node::payment::verify",
                     "Payment verification failed: context={context:?}, proof_type={proof_type}, proof_bytes={proof_bytes}, elapsed_ms={elapsed_ms}: {e}",
                 );

--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -30,6 +30,7 @@ use saorsa_core::P2PNode;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
+use std::time::Instant;
 
 /// Minimum allowed size for a payment proof in bytes.
 ///
@@ -60,6 +61,7 @@ const PAID_QUOTE_PRICE_FLOOR_TOLERANCE_PCT: u64 = 20;
 
 const PERCENT_DENOMINATOR: u64 = 100;
 const PAID_QUOTE_PAYMENT_MULTIPLIER: u64 = 3;
+const PAYMENT_VERIFY_SLOW_LOG_MS: u128 = 500;
 
 /// Number of nearest DHT peers accepted for paid-quote issuer locality.
 ///
@@ -81,6 +83,16 @@ fn price_floor(current_price: Amount, tolerance_pct: u64) -> Amount {
 
 fn median_quote_index(quote_count: usize) -> usize {
     quote_count / 2
+}
+
+fn payment_proof_type_label(payment_proof: Option<&[u8]>) -> &'static str {
+    match payment_proof.and_then(detect_proof_type) {
+        Some(ProofType::Merkle) => "merkle",
+        Some(ProofType::SingleNode) => "single_node",
+        Some(_) => "unsupported",
+        None if payment_proof.is_some() => "unknown",
+        None => "none",
+    }
 }
 
 /// Configuration for EVM payment verification.
@@ -521,6 +533,44 @@ impl PaymentVerifier {
     ///
     /// Returns an error if payment is required but not provided, or if payment is invalid.
     pub async fn verify_payment(
+        &self,
+        xorname: &XorName,
+        payment_proof: Option<&[u8]>,
+        context: VerificationContext,
+    ) -> Result<PaymentStatus> {
+        let started = Instant::now();
+        let proof_type = payment_proof_type_label(payment_proof);
+        let proof_bytes = payment_proof.map_or(0, <[u8]>::len);
+        let result = self
+            .verify_payment_inner(xorname, payment_proof, context)
+            .await;
+        let elapsed_ms = started.elapsed().as_millis();
+
+        match &result {
+            Ok(status) if elapsed_ms >= PAYMENT_VERIFY_SLOW_LOG_MS => {
+                info!(
+                    target: "ant_node::payment::verify",
+                    "Slow payment verification: context={context:?}, proof_type={proof_type}, proof_bytes={proof_bytes}, status={status:?}, elapsed_ms={elapsed_ms}",
+                );
+            }
+            Ok(status) => {
+                debug!(
+                    target: "ant_node::payment::verify",
+                    "Payment verification: context={context:?}, proof_type={proof_type}, proof_bytes={proof_bytes}, status={status:?}, elapsed_ms={elapsed_ms}",
+                );
+            }
+            Err(e) => {
+                warn!(
+                    target: "ant_node::payment::verify",
+                    "Payment verification failed: context={context:?}, proof_type={proof_type}, proof_bytes={proof_bytes}, elapsed_ms={elapsed_ms}: {e}",
+                );
+            }
+        }
+
+        result
+    }
+
+    async fn verify_payment_inner(
         &self,
         xorname: &XorName,
         payment_proof: Option<&[u8]>,

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -101,6 +101,9 @@ const FETCH_WORKER_POLL_MS: u64 = 100;
 /// Verification worker polling interval in milliseconds.
 const VERIFICATION_WORKER_POLL_MS: u64 = 250;
 
+/// Verification cycle duration that is worth surfacing at info level.
+const VERIFICATION_CYCLE_SLOW_LOG_MS: u128 = 500;
+
 /// Bootstrap drain check interval in seconds.
 const BOOTSTRAP_DRAIN_CHECK_SECS: u64 = 5;
 
@@ -905,6 +908,16 @@ impl ReplicationEngine {
                     break;
                 }
 
+                let mut hints_by_peer = neighbor_sync::build_sync_hints_for_peers(
+                    batch,
+                    &storage,
+                    &paid_list,
+                    &p2p,
+                    config.close_group_size,
+                    config.paid_list_close_group_size,
+                )
+                .await;
+
                 for peer in batch {
                     if shutdown.is_cancelled() {
                         break;
@@ -915,13 +928,13 @@ impl ReplicationEngine {
 
                     bootstrap::increment_pending_requests(&bootstrap_state, 1).await;
 
-                    let outcome = neighbor_sync::sync_with_peer_with_outcome(
+                    let hints = hints_by_peer.remove(peer).unwrap_or_default();
+                    let outcome = neighbor_sync::sync_with_peer_with_hints(
                         peer,
                         &p2p,
-                        &storage,
-                        &paid_list,
                         &config,
                         bootstrapping,
+                        hints,
                     )
                     .await;
 
@@ -1832,17 +1845,22 @@ async fn run_neighbor_sync_round(
 
     debug!("Neighbor sync: syncing with {} peers", batch.len());
 
+    let mut hints_by_peer = neighbor_sync::build_sync_hints_for_peers(
+        &batch,
+        storage,
+        paid_list,
+        p2p_node,
+        config.close_group_size,
+        config.paid_list_close_group_size,
+    )
+    .await;
+
     // Sync with each peer in the batch.
     for peer in &batch {
-        let outcome = neighbor_sync::sync_with_peer_with_outcome(
-            peer,
-            p2p_node,
-            storage,
-            paid_list,
-            config,
-            bootstrapping,
-        )
-        .await;
+        let hints = hints_by_peer.remove(peer).unwrap_or_default();
+        let outcome =
+            neighbor_sync::sync_with_peer_with_hints(peer, p2p_node, config, bootstrapping, hints)
+                .await;
 
         if let Some(outcome) = outcome {
             handle_sync_response(
@@ -1872,13 +1890,24 @@ async fn run_neighbor_sync_round(
 
             // Attempt sync with the replacement peer (if one was found).
             if let Some(replacement_peer) = replacement {
-                let replacement_outcome = neighbor_sync::sync_with_peer_with_outcome(
-                    &replacement_peer,
-                    p2p_node,
+                let mut replacement_hints = neighbor_sync::build_sync_hints_for_peers(
+                    std::slice::from_ref(&replacement_peer),
                     storage,
                     paid_list,
+                    p2p_node,
+                    config.close_group_size,
+                    config.paid_list_close_group_size,
+                )
+                .await;
+                let hints = replacement_hints
+                    .remove(&replacement_peer)
+                    .unwrap_or_default();
+                let replacement_outcome = neighbor_sync::sync_with_peer_with_hints(
+                    &replacement_peer,
+                    p2p_node,
                     config,
                     bootstrapping,
+                    hints,
                 )
                 .await;
 
@@ -2136,6 +2165,7 @@ async fn admit_and_queue_hints(
 /// Run one verification cycle: process pending keys through quorum checks.
 #[allow(clippy::too_many_lines)]
 async fn run_verification_cycle(ctx: VerificationCycleContext<'_>) {
+    let cycle_started = Instant::now();
     let VerificationCycleContext {
         p2p_node,
         paid_list,
@@ -2162,6 +2192,7 @@ async fn run_verification_cycle(ctx: VerificationCycleContext<'_>) {
     if pending_keys.is_empty() {
         return;
     }
+    let initial_pending_count = pending_keys.len();
 
     let self_id = *p2p_node.peer_id();
 
@@ -2228,6 +2259,9 @@ async fn run_verification_cycle(ctx: VerificationCycleContext<'_>) {
             }
         }
     }
+
+    let local_paid_probe_count = local_paid_presence_probe_keys.len();
+    let keys_needing_network_count = keys_needing_network.len();
 
     // Step 1b: Local paid-list hit for fetch-eligible keys. Per Section 9
     // step 4, authorization succeeds immediately; run a presence-only probe
@@ -2393,6 +2427,29 @@ async fn run_verification_cycle(ctx: VerificationCycleContext<'_>) {
         bootstrap_complete_notify,
     )
     .await;
+
+    let (pending_after, fetch_after, in_flight_after) = {
+        let q = queues.read().await;
+        (
+            q.pending_count(),
+            q.fetch_queue_count(),
+            q.in_flight_count(),
+        )
+    };
+    let terminal_key_count = terminal_keys.len();
+    let elapsed_ms = cycle_started.elapsed().as_millis();
+
+    if elapsed_ms >= VERIFICATION_CYCLE_SLOW_LOG_MS {
+        info!(
+            target: "ant_node::replication::verification",
+            "Slow replication verification cycle: pending_start={initial_pending_count}, local_paid_probe={local_paid_probe_count}, network_verify={keys_needing_network_count}, terminal={terminal_key_count}, pending_after={pending_after}, fetch_after={fetch_after}, in_flight_after={in_flight_after}, elapsed_ms={elapsed_ms}",
+        );
+    } else {
+        debug!(
+            target: "ant_node::replication::verification",
+            "Replication verification cycle: pending_start={initial_pending_count}, local_paid_probe={local_paid_probe_count}, network_verify={keys_needing_network_count}, terminal={terminal_key_count}, pending_after={pending_after}, fetch_after={fetch_after}, in_flight_after={in_flight_after}, elapsed_ms={elapsed_ms}",
+        );
+    }
 }
 
 /// Post-verification bootstrap bookkeeping: remove terminal keys from the

--- a/src/replication/neighbor_sync.rs
+++ b/src/replication/neighbor_sync.rs
@@ -3,11 +3,11 @@
 //! Round-robin cycle management: snapshot close neighbors, iterate through
 //! them in batches of `NEIGHBOR_SYNC_PEER_COUNT`, exchanging hint sets.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use crate::logging::{debug, warn};
+use crate::logging::{debug, info, warn};
 use rand::Rng;
 use saorsa_core::identity::PeerId;
 use saorsa_core::P2PNode;
@@ -20,6 +20,9 @@ use crate::replication::protocol::{
 };
 use crate::replication::types::NeighborSyncState;
 use crate::storage::LmdbStorage;
+
+/// Hint-build duration that is worth surfacing at info level.
+const HINT_BUILD_SLOW_LOG_MS: u128 = 250;
 
 /// Replica hint sent to a peer, with the close-group snapshot used to decide
 /// that hint.
@@ -38,6 +41,16 @@ pub(crate) struct NeighborSyncOutcome {
     pub(crate) response: NeighborSyncResponse,
     /// Replica hints sent to the peer in our request.
     pub(crate) sent_replica_hints: Vec<SentReplicaHint>,
+}
+
+/// Prebuilt hint sets for one outbound neighbor-sync exchange.
+#[derive(Debug, Default)]
+pub(crate) struct PeerSyncHints {
+    /// Replica hints, including the close-group snapshot needed for repair
+    /// proof recording after the request is successfully sent.
+    pub(crate) sent_replica_hints: Vec<SentReplicaHint>,
+    /// Paid-list-only hints for this peer.
+    paid_hints: Vec<XorName>,
 }
 
 /// Build replica hints for a specific peer.
@@ -88,6 +101,110 @@ pub(crate) async fn build_replica_hints_for_peer_with_close_groups(
         }
     }
     hints
+}
+
+/// Build outbound hint sets for a batch of peers with one scan over local
+/// storage and one scan over the paid list.
+pub(crate) async fn build_sync_hints_for_peers(
+    peers: &[PeerId],
+    storage: &Arc<LmdbStorage>,
+    paid_list: &Arc<PaidList>,
+    p2p_node: &Arc<P2PNode>,
+    close_group_size: usize,
+    paid_list_close_group_size: usize,
+) -> HashMap<PeerId, PeerSyncHints> {
+    let started = Instant::now();
+    let target_peers = peers.iter().copied().collect::<HashSet<_>>();
+    let mut hints_by_peer = peers
+        .iter()
+        .copied()
+        .map(|peer| (peer, PeerSyncHints::default()))
+        .collect::<HashMap<_, _>>();
+
+    if peers.is_empty() {
+        return hints_by_peer;
+    }
+
+    let all_keys = match storage.all_keys().await {
+        Ok(keys) => keys,
+        Err(e) => {
+            warn!("Failed to read stored keys for batch hint construction: {e}");
+            Vec::new()
+        }
+    };
+    let stored_key_count = all_keys.len();
+
+    let dht = p2p_node.dht_manager();
+    for key in all_keys {
+        let closest = dht
+            .find_closest_nodes_local_with_self(&key, close_group_size)
+            .await;
+        let close_peers = closest.iter().map(|n| n.peer_id).collect::<HashSet<_>>();
+        for peer in close_peers.intersection(&target_peers) {
+            if let Some(peer_hints) = hints_by_peer.get_mut(peer) {
+                peer_hints.sent_replica_hints.push(SentReplicaHint {
+                    key,
+                    close_peers: close_peers.clone(),
+                });
+            }
+        }
+    }
+
+    let all_paid_keys = match paid_list.all_keys() {
+        Ok(keys) => keys,
+        Err(e) => {
+            warn!("Failed to read PaidForList for batch hint construction: {e}");
+            Vec::new()
+        }
+    };
+    let paid_key_count = all_paid_keys.len();
+
+    for key in all_paid_keys {
+        let closest = dht
+            .find_closest_nodes_local_with_self(&key, paid_list_close_group_size)
+            .await;
+        for node in closest {
+            if target_peers.contains(&node.peer_id) {
+                if let Some(peer_hints) = hints_by_peer.get_mut(&node.peer_id) {
+                    peer_hints.paid_hints.push(key);
+                }
+            }
+        }
+    }
+
+    let replica_hint_count = hints_by_peer
+        .values()
+        .map(|hints| hints.sent_replica_hints.len())
+        .sum::<usize>();
+    let paid_hint_count = hints_by_peer
+        .values()
+        .map(|hints| hints.paid_hints.len())
+        .sum::<usize>();
+    let elapsed_ms = started.elapsed().as_millis();
+
+    if elapsed_ms >= HINT_BUILD_SLOW_LOG_MS {
+        info!(
+            target: "ant_node::replication::neighbor_sync",
+            "Slow neighbor-sync hint build: peers={}, stored_keys={}, paid_keys={}, replica_hints={}, paid_hints={}, elapsed_ms={elapsed_ms}",
+            peers.len(),
+            stored_key_count,
+            paid_key_count,
+            replica_hint_count,
+            paid_hint_count,
+        );
+    } else {
+        debug!(
+            target: "ant_node::replication::neighbor_sync",
+            "Neighbor-sync hint build: peers={}, stored_keys={}, paid_keys={}, replica_hints={}, paid_hints={}, elapsed_ms={elapsed_ms}",
+            peers.len(),
+            stored_key_count,
+            paid_key_count,
+            replica_hint_count,
+            paid_hint_count,
+        );
+    }
+
+    hints_by_peer
 }
 
 /// Build paid hints for a specific peer.
@@ -232,24 +349,36 @@ pub(crate) async fn sync_with_peer_with_outcome(
     is_bootstrapping: bool,
 ) -> Option<NeighborSyncOutcome> {
     // Build peer-targeted hint sets (Rule 7).
-    let sent_replica_hints = build_replica_hints_for_peer_with_close_groups(
-        peer,
+    let mut hints_by_peer = build_sync_hints_for_peers(
+        std::slice::from_ref(peer),
         storage,
+        paid_list,
         p2p_node,
         config.close_group_size,
+        config.paid_list_close_group_size,
     )
     .await;
-    let replica_hints = sent_replica_hints
+    let hints = hints_by_peer.remove(peer).unwrap_or_default();
+    sync_with_peer_with_hints(peer, p2p_node, config, is_bootstrapping, hints).await
+}
+
+pub(crate) async fn sync_with_peer_with_hints(
+    peer: &PeerId,
+    p2p_node: &Arc<P2PNode>,
+    config: &ReplicationConfig,
+    is_bootstrapping: bool,
+    hints: PeerSyncHints,
+) -> Option<NeighborSyncOutcome> {
+    let replica_hints = hints
+        .sent_replica_hints
         .iter()
         .map(|hint| hint.key)
         .collect::<Vec<_>>();
-    let paid_hints =
-        build_paid_hints_for_peer(peer, paid_list, p2p_node, config.paid_list_close_group_size)
-            .await;
+    let sent_replica_hints = hints.sent_replica_hints;
 
     let request = NeighborSyncRequest {
         replica_hints,
-        paid_hints,
+        paid_hints: hints.paid_hints,
         bootstrapping: is_bootstrapping,
     };
     let request_id = rand::thread_rng().gen::<u64>();

--- a/src/replication/quorum.rs
+++ b/src/replication/quorum.rs
@@ -5,8 +5,9 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Instant;
 
-use crate::logging::{debug, warn};
+use crate::logging::{debug, info, warn};
 use saorsa_core::identity::PeerId;
 use saorsa_core::P2PNode;
 
@@ -16,6 +17,9 @@ use crate::replication::protocol::{
     ReplicationMessage, ReplicationMessageBody, VerificationRequest, VerificationResponse,
 };
 use crate::replication::types::{KeyVerificationEvidence, PaidListEvidence, PresenceEvidence};
+
+/// Verification round duration that is worth surfacing at info level.
+const VERIFICATION_ROUND_SLOW_LOG_MS: u128 = 500;
 
 // ---------------------------------------------------------------------------
 // Verification targets
@@ -328,6 +332,10 @@ pub async fn run_verification_round(
     p2p_node: &Arc<P2PNode>,
     config: &ReplicationConfig,
 ) -> HashMap<XorName, KeyVerificationEvidence> {
+    let started = Instant::now();
+    let peer_count = targets.peer_to_keys.len();
+    let requested_key_refs = targets.peer_to_keys.values().map(Vec::len).sum::<usize>();
+
     // Initialize empty evidence for all keys.
     let mut evidence: HashMap<XorName, KeyVerificationEvidence> = keys
         .iter()
@@ -422,6 +430,21 @@ pub async fn run_verification_round(
         if let ReplicationMessageBody::VerificationResponse(resp) = msg.body {
             process_verification_response(&peer, &resp, targets, &mut evidence);
         }
+    }
+
+    let elapsed_ms = started.elapsed().as_millis();
+    if elapsed_ms >= VERIFICATION_ROUND_SLOW_LOG_MS {
+        info!(
+            target: "ant_node::replication::verification",
+            "Slow quorum verification round: keys={}, peers={peer_count}, requested_key_refs={requested_key_refs}, elapsed_ms={elapsed_ms}",
+            keys.len(),
+        );
+    } else {
+        debug!(
+            target: "ant_node::replication::verification",
+            "Quorum verification round: keys={}, peers={peer_count}, requested_key_refs={requested_key_refs}, elapsed_ms={elapsed_ms}",
+            keys.len(),
+        );
     }
 
     evidence


### PR DESCRIPTION
## Summary

Reduces the CPU amplification in outbound replication neighbor sync by batching hint construction per sync batch, and adds targeted timing logs around the hot paths identified during the `0.12.0` CPU spike investigation.

Semver: patch

## Background

The investigation pointed at two related changes in runtime behavior since `0.12.0`:

- replication receipts now reach the more expensive payment verification path instead of being rejected earlier
- successful verification grows local stored-key and paid-list datasets, making periodic neighbor sync scans more expensive over time

Before this change, outbound neighbor sync built hints independently for each peer. Each peer sync scanned all local stored keys and all paid-list keys, then ran DHT close-group checks for each key. For a batch of peers this made the cost scale as roughly `stored_keys * peers` plus `paid_keys * peers`, which can become visible as periodic CPU spikes on nodes with larger datasets.

## Changes

- Add `build_sync_hints_for_peers` to construct outbound sync hints for a whole peer batch with one storage scan and one paid-list scan.
- Wire bootstrap neighbor sync, scheduled neighbor sync, and replacement-peer sync through the prebuilt hint path.
- Keep the existing single-peer sync API by delegating it through the new batch builder for compatibility with current call sites.
- Add neighbor-sync hint build logs with peer count, stored-key count, paid-key count, emitted hint counts, and elapsed time.
- Add payment verification timing logs including context, detected proof type, proof byte length, result status, and elapsed time.
- Add quorum verification round timing logs with key count, peer count, requested key refs, and elapsed time.
- Add full replication verification cycle timing logs with pending/fetch/in-flight queue counts and terminal key count.

## Expected Impact

The sync-side work should now scale by scanning the local datasets once per selected peer batch, then distributing matching hints to the peers in that batch. This should reduce periodic CPU spikes from neighbor sync without changing replication protocol semantics.

The added logs should make any remaining spikes attributable to one of the following areas:

- neighbor-sync hint construction
- payment proof verification
- quorum verification requests
- full verification-cycle queue processing

## Validation

Ran successfully:

```text
cargo test --lib neighbor_sync
cargo test --lib quorum
cargo test --lib payment::verifier
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
```
