### PR TITLE
chore(release): bump ant-node to 0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "alloy",
  "ant-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"


### PR DESCRIPTION
Promotes `main` to release version `0.13.1` (patch bump from `0.13.0`).

The only change on `main` since the `v0.13.0` release is **#154** _fix(replication): log audit send failures_ — extended audit-timeout diagnostics logging (`src/replication/audit.rs`, +105/−3).

This PR:
- bumps `[package].version` `0.13.0` → `0.13.1`
- refreshes `Cargo.lock` (ant-node entry only; no transitive drift)

Internal deps are already crates.io version pins (`ant-protocol = 2.2.0`, `saorsa-core = 0.26.0`, `evmlib = 0.8.1`) — no rewrites needed.

Once merged, the `v0.13.1` tag will be pushed to fire the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)