### PR TITLE
chore(replication): log audit challenge responses

### DIFF
--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -1642,6 +1642,13 @@ async fn handle_audit_challenge_msg(
 ) -> Result<()> {
     #[allow(clippy::cast_possible_truncation)]
     let stored_chunks = storage.current_chunks().map_or(0, |c| c as usize);
+    info!(
+        "Audit challenge received: kind=responsible keys={} bootstrapping={} request_response={}",
+        challenge.keys.len(),
+        is_bootstrapping,
+        rr_message_id.is_some(),
+    );
+
     let response = audit::handle_audit_challenge(
         challenge,
         storage,
@@ -1650,8 +1657,9 @@ async fn handle_audit_challenge_msg(
         stored_chunks,
     )
     .await;
+    let response_kind = audit_response_kind(&response);
 
-    send_replication_response(
+    let sent = send_replication_response_checked(
         source,
         p2p_node,
         request_id,
@@ -1659,8 +1667,31 @@ async fn handle_audit_challenge_msg(
         rr_message_id,
     )
     .await;
+    if sent {
+        info!(
+            "Audit challenge reply sent: kind=responsible response={} keys={} request_response={}",
+            response_kind,
+            challenge.keys.len(),
+            rr_message_id.is_some(),
+        );
+    } else {
+        warn!(
+            "Audit challenge reply not sent: kind=responsible response={} keys={} request_response={}",
+            response_kind,
+            challenge.keys.len(),
+            rr_message_id.is_some(),
+        );
+    }
 
     Ok(())
+}
+
+fn audit_response_kind(response: &protocol::AuditResponse) -> &'static str {
+    match response {
+        protocol::AuditResponse::Digests { .. } => "digests",
+        protocol::AuditResponse::Bootstrapping { .. } => "bootstrapping",
+        protocol::AuditResponse::Rejected { .. } => "rejected",
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Log each incoming responsible audit challenge at INFO level with a stable `Audit challenge received` phrase.
- Log whether the corresponding audit reply was accepted by the existing response send path, using `Audit challenge reply sent` / `Audit challenge reply not sent` phrases.
- Keep fields bounded and count-friendly: challenge kind, key count, bootstrapping state, response kind, and request-response path flag. No peer IDs or raw transport errors are added.

## Why
PROD logs currently show audit outcomes from the auditor side, but the responder path is silent on successful incoming audit challenges and replies. These two stable log lines let ES answer hourly averages for:

- incoming audit challenges received
- audit challenge replies sent

without changing protocol behaviour.

## Review team
- Multi-model review: initial review flagged that the direct use of `send_replication_response_checked` needed context and suggested lowering cardinality/clarifying field names.
- Applied follow-up: removed `stored_chunks` from the log message, renamed `rr` to `request_response`, and made failed sends WARN while successful sends remain INFO.
- Final multi-model review: Go. No blockers; noted the change is behaviour-identical because the old wrapper already called `send_replication_response_checked` and discarded its boolean.

## Verification
- `cargo fmt --all`
- `cargo check`
- `cargo test replication::audit::tests --lib` — 32 passed
- `git diff --check`
- `cargo clippy --all-features -- -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used`
