### PR TITLE
fix(replication): handle inbound audit challenges concurrently

### DIFF
--- a/src/replication/config.rs
+++ b/src/replication/config.rs
@@ -103,17 +103,18 @@ pub const MAX_CONCURRENT_REPLICATION_SENDS: usize = 3;
 
 /// Maximum number of concurrent in-flight audit-responder tasks.
 ///
-/// Subtree (round 1) and byte (round 2) challenge handlers are spawned off the
-/// serial replication message loop so their disk reads don't stall replication.
-/// This caps how many run at once across the engine, restoring backpressure: a
-/// peer flooding audit challenges cannot fan out unbounded `get_raw` reads or
-/// multi-MiB byte serves. When the cap is hit, the challenge is dropped — the
-/// auditor graces a non-response as a timeout, so honest auditors are
-/// unaffected and only a flooder is throttled. Sized to cover a handful of
-/// concurrent honest auditors (the per-peer gossip-audit cooldown is 30 min, so
-/// genuine concurrent audits are few) while bounding the byte round's worst-case
-/// resident bytes (`N × MAX_BYTE_CHALLENGE_KEYS × MAX_CHUNK_SIZE`).
-pub const MAX_CONCURRENT_AUDIT_RESPONSES: usize = 8;
+/// The responsible-chunk (audit #2), subtree (round 1), and byte (round 2)
+/// challenge handlers are all spawned off the serial replication message loop so
+/// their disk reads don't stall replication. This caps how many run at once
+/// across the engine, restoring backpressure: a peer flooding audit challenges
+/// cannot fan out unbounded `get_raw` reads or multi-MiB byte serves. When the
+/// cap is hit, the challenge is dropped — the auditor graces a non-response as a
+/// timeout, so honest auditors are unaffected and only a flooder is throttled.
+/// Sized to cover a handful of concurrent honest auditors (the per-peer
+/// gossip-audit cooldown is 30 min, so genuine concurrent audits are few) while
+/// bounding the byte round's worst-case resident bytes
+/// (`N × MAX_BYTE_CHALLENGE_KEYS × MAX_CHUNK_SIZE`).
+pub const MAX_CONCURRENT_AUDIT_RESPONSES: usize = 16;
 
 /// Maximum concurrent in-flight audit-responder tasks from any SINGLE peer.
 ///

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -1691,22 +1691,53 @@ async fn handle_replication_message(
             )
             .await
         }
-        ReplicationMessageBody::AuditChallenge(ref challenge) => {
+        ReplicationMessageBody::AuditChallenge(challenge) => {
             // Responsible-chunk audit (audit #2) responder: answer with per-key
             // possession digests. This same handler also answers the
             // prune-confirmation audit, which sends the same `AuditChallenge`
             // wire message.
+            //
+            // Answering digests the stored bytes of every challenged key, so —
+            // like the subtree/byte audits below — run it on a detached task off
+            // this serial message loop. Handling it inline lets one challenge
+            // block all other replication traffic until its digests complete
+            // (head-of-line blocking). The same flood-fair admission applies: a
+            // global ceiling AND a per-peer cap, dropping the challenge if either
+            // is hit (an honest auditor graces a non-response as a timeout, while
+            // a flooder is held to its per-peer share and cannot starve others).
+            let Some(guard) =
+                admit_audit_responder(audit_responder_semaphore, audit_responder_inflight, source)
+                    .await
+            else {
+                warn!(
+                    "Audit challenge reply not sent: kind=responsible response=dropped \
+                     source={source} (audit-responder capacity reached)"
+                );
+                return Ok(());
+            };
             let bootstrapping = *is_bootstrapping.read().await;
-            handle_audit_challenge_msg(
-                source,
-                challenge,
-                storage,
-                p2p_node,
-                bootstrapping,
-                msg.request_id,
-                rr_message_id,
-            )
-            .await
+            let storage = Arc::clone(storage);
+            let p2p_node = Arc::clone(p2p_node);
+            let source = *source;
+            let request_id = msg.request_id;
+            let rr_message_id = rr_message_id.map(ToOwned::to_owned);
+            tokio::spawn(async move {
+                let _guard = guard; // global permit + per-peer slot, held until done
+                if let Err(e) = handle_audit_challenge_msg(
+                    &source,
+                    &challenge,
+                    &storage,
+                    &p2p_node,
+                    bootstrapping,
+                    request_id,
+                    rr_message_id.as_deref(),
+                )
+                .await
+                {
+                    debug!("Audit challenge from {source} error: {e}");
+                }
+            });
+            Ok(())
         }
         ReplicationMessageBody::SubtreeAuditChallenge(challenge) => {
             // Gossip-triggered storage-bound subtree audit (ADR-0002). The


### PR DESCRIPTION
## Summary

Rebased onto `main` after #128 (`audit-on-gossip`) landed. #128 already moved the
**new** storage-bound audits (`SubtreeAuditChallenge`, `SubtreeByteChallenge`) off
the serial replication receive loop via a bounded, flood-fair admission
(`admit_audit_responder`: a global cap **and** a per-peer cap, dropping on
overload). But it left the **old responsible-chunk `AuditChallenge`** — the
per-key possession-digest responder, also reused by prune-confirmation audits —
handled **inline**, so a single such challenge still blocks all other replication
traffic until its digests complete (head-of-line blocking).

This PR closes that one remaining serial path.

## What it does

- Route the responsible-chunk `AuditChallenge` responder through `main`'s existing
  `admit_audit_responder` admission + a detached `tokio::spawn`, exactly like the
  subtree/byte handlers. Answering digests the stored bytes of every challenged
  key, so it belongs off the serial loop for the same reason.
- On admission failure the challenge is **dropped** (the auditor graces a
  non-response as a timeout); the per-peer cap (`MAX_AUDIT_RESPONSES_PER_PEER = 2`)
  guarantees no single flooder can occupy more than its share or starve other
  peers.
- The audit-responder pool is now a **single shared ceiling** across all three
  responder types (responsible-chunk + subtree + byte). Raise that global cap
  `MAX_CONCURRENT_AUDIT_RESPONSES` from **8 → 16** for combined headroom now that a
  third type shares it. (Per-peer cap unchanged.)

## Relationship to the earlier version of this PR

The first version of this branch (pre-#128) introduced its **own** parallel
admission system — a `JoinSet` with `MAX_CONCURRENT_INBOUND_AUDIT_CHALLENGES`, an
overload **reply** (`AuditResponse::Rejected`) instead of a drop, and an
auditor-side `OverloadClaimTracker`. Once #128 merged its own
`admit_audit_responder`, keeping a second parallel system (two global semaphores,
two per-peer maps, two overload policies) was redundant. This PR now **reuses
#128's mechanism** for the responsible-chunk path, so the codebase has one
audit-admission system — far smaller and consistent with the subtree/byte
handlers.

Trade-off adopted from #128: drop-on-overload rather than reply-with-reason. A
busy-but-honest responder whose challenge is dropped can be charged a `Timeout`
audit failure (after the auditor's responsibility re-confirmation). In practice
this is bounded by the per-peer cap of 2 and the 30-min gossip-audit cooldown
(honest auditors challenge one-at-a-time), and it is the same trade-off `main`
already accepts for the subtree audits.

## Why only audit challenges (and not all inbound handlers)

Unchanged rationale: only audit-challenge handling is offloaded; **every other
inbound request type stays inline**. The e2e harness runs on a single-threaded
Tokio runtime, so spawning the convergence-critical handlers (fresh-offer /
neighbor-sync / verification / fetch) delays their responses past the
request-response timeouts and regresses
`test_late_joiner_replicates_responsible_chunks`. Keeping them inline preserves
their original latency.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --lib replication::` — 375 passed
- e2e `replication::test_audit_challenge_returns_correct_digest` — pass (the
  responsible-chunk responder path, now spawned off the loop)
- e2e `replication::test_late_joiner_replicates_responsible_chunks` — **pass** (~71s), no convergence regression

## Diff size

Two commits on top of `main`:
- `fix(replication): offload responsible-chunk audit challenges off the receive loop` — +42 / −11, one file
- `perf(replication): raise concurrent audit-responder cap to 16` — +12 / −11, one file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
