### PR TITLE
chore(release): bump ant-node to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "alloy",
  "ant-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"


### PR DESCRIPTION
Promotes `main` to release version `0.14.0` (minor bump from `0.13.1`).

**Minor (not patch)** because the headline change carries breaking changes:

- **#128** Gossip-triggered subtree audit + responsible-chunk audit (ADR-0002) — breaking, +10,963/−116

Also included since the `v0.13.0` release:
- #154 fix(replication): log audit send failures
- #157 log audit challenge responses
- #124 ci: ADR governance compliance

This PR:
- bumps `[package].version` `0.13.1` → `0.14.0`
- refreshes `Cargo.lock` (ant-node entry only; no transitive drift)

Internal deps are already crates.io version pins (`ant-protocol = 2.2.0`, `saorsa-core = 0.26.0`, `evmlib = 0.8.1`) — no rewrites needed.

Note: the earlier `v0.13.1` bump (#155) was merged but never published (crates.io is still at 0.13.0); this `0.14.0` supersedes it.

Once merged, the `v0.14.0` tag will be pushed to fire the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)