### PR TITLE
feat(ant-devnet): opt-in LAN / external-devnet mode (--host / --evm-network / --serve-port)

### DIFF
--- a/src/bin/ant-devnet/cli.rs
+++ b/src/bin/ant-devnet/cli.rs
@@ -80,8 +80,9 @@ pub struct Cli {
     /// Serve the manifest over a read-only HTTP API on this port (binds
     /// 0.0.0.0). Any LAN device can then GET
     /// `http://<host>:<port>/api/devnet-manifest.json` (and `/api/info`) —
-    /// no file copying. Open CORS. Suggested: 8088.
-    #[arg(long)]
+    /// no file copying. Open CORS. Suggested: 8088. Requires `--host` (the API
+    /// advertises a LAN URL, so a loopback-only devnet would be misleading).
+    #[arg(long, requires = "host", value_parser = clap::value_parser!(u16).range(1..))]
     pub serve_port: Option<u16>,
 }
 
@@ -121,5 +122,20 @@ mod tests {
     #[test]
     fn host_rejects_non_ipv4() {
         assert!(Cli::try_parse_from(["ant-devnet", "--host", "not-an-ip"]).is_err());
+    }
+
+    /// `--serve-port` requires `--host` (it advertises a LAN URL).
+    #[test]
+    fn serve_port_requires_host() {
+        assert!(Cli::try_parse_from(["ant-devnet", "--serve-port", "8088"]).is_err());
+    }
+
+    /// `--serve-port 0` is rejected (an ephemeral port would be advertised as `:0`).
+    #[test]
+    fn serve_port_rejects_zero() {
+        assert!(
+            Cli::try_parse_from(["ant-devnet", "--host", "192.168.1.5", "--serve-port", "0"])
+                .is_err()
+        );
     }
 }

--- a/src/bin/ant-devnet/cli.rs
+++ b/src/bin/ant-devnet/cli.rs
@@ -62,4 +62,64 @@ pub struct Cli {
     /// payments against the local chain.
     #[arg(long)]
     pub enable_evm: bool,
+
+    /// Advertise this IPv4 to peers/clients and bind 0.0.0.0, so the devnet is
+    /// reachable from other devices on the LAN. When omitted, nodes bind
+    /// loopback (127.0.0.1) as before (single-machine only).
+    #[arg(long)]
+    pub host: Option<std::net::Ipv4Addr>,
+
+    /// EVM network for node payment verification. `arbitrum-sepolia` makes
+    /// nodes verify against the real deployed Arbitrum Sepolia contracts —
+    /// no local Anvil and no embedded wallet key (bring your own funded
+    /// wallet via an external signer). Omit for the local-Anvil devnet
+    /// (`--enable-evm`).
+    #[arg(long)]
+    pub evm_network: Option<String>,
+
+    /// Serve the manifest over a read-only HTTP API on this port (binds
+    /// 0.0.0.0). Any LAN device can then GET
+    /// `http://<host>:<port>/api/devnet-manifest.json` (and `/api/info`) —
+    /// no file copying. Open CORS. Suggested: 8088.
+    #[arg(long)]
+    pub serve_port: Option<u16>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    /// Backward-compatibility contract: with none of the LAN flags, the new
+    /// options parse to `None`, so behavior is identical to before.
+    #[test]
+    fn lan_flags_default_off() {
+        let cli = Cli::parse_from(["ant-devnet", "--preset", "small"]);
+        assert!(cli.host.is_none());
+        assert!(cli.evm_network.is_none());
+        assert!(cli.serve_port.is_none());
+    }
+
+    /// The LAN flags parse into the expected typed values.
+    #[test]
+    fn lan_flags_parse() {
+        let cli = Cli::parse_from([
+            "ant-devnet",
+            "--host",
+            "192.168.1.100",
+            "--evm-network",
+            "arbitrum-sepolia",
+            "--serve-port",
+            "8088",
+        ]);
+        assert_eq!(cli.host, Some(Ipv4Addr::new(192, 168, 1, 100)));
+        assert_eq!(cli.evm_network.as_deref(), Some("arbitrum-sepolia"));
+        assert_eq!(cli.serve_port, Some(8088));
+    }
+
+    /// A non-IPv4 `--host` is rejected by clap's value parser.
+    #[test]
+    fn host_rejects_non_ipv4() {
+        assert!(Cli::try_parse_from(["ant-devnet", "--host", "not-an-ip"]).is_err());
+    }
 }

--- a/src/bin/ant-devnet/cli.rs
+++ b/src/bin/ant-devnet/cli.rs
@@ -73,8 +73,8 @@ pub struct Cli {
     /// nodes verify against the real deployed Arbitrum Sepolia contracts —
     /// no local Anvil and no embedded wallet key (bring your own funded
     /// wallet via an external signer). Omit for the local-Anvil devnet
-    /// (`--enable-evm`).
-    #[arg(long)]
+    /// (`--enable-evm`). Mutually exclusive with `--enable-evm`.
+    #[arg(long, conflicts_with = "enable_evm")]
     pub evm_network: Option<String>,
 
     /// Serve the manifest over a read-only HTTP API on this port (binds

--- a/src/bin/ant-devnet/main.rs
+++ b/src/bin/ant-devnet/main.rs
@@ -86,12 +86,15 @@ async fn main() -> color_eyre::Result<()> {
         config.stabilization_timeout = std::time::Duration::from_secs(timeout_secs);
     }
 
-    // A loopback/unspecified --host would stamp unreachable bootstrap addresses
-    // into the manifest (LAN mode would fail non-obviously), so reject it early.
-    if let Some(host) = cli.host.filter(|h| h.is_loopback() || h.is_unspecified()) {
+    // A non-unicast --host would stamp unreachable bootstrap addresses into the
+    // manifest (LAN mode would fail non-obviously), so reject it early.
+    if let Some(host) = cli
+        .host
+        .filter(|h| h.is_loopback() || h.is_unspecified() || h.is_multicast() || h.is_broadcast())
+    {
         return Err(color_eyre::eyre::eyre!(
-            "--host must be a routable LAN IPv4 (got {host}); loopback/0.0.0.0 would \
-             advertise unreachable bootstrap addresses"
+            "--host must be a routable unicast LAN IPv4 (got {host}); \
+             loopback/unspecified/multicast/broadcast are not reachable bootstrap addresses"
         ));
     }
     config.advertise_ip = cli.host;
@@ -232,15 +235,25 @@ fn serve_manifest_api(
             },
         })
     });
+    let bootstrap = serde_json::to_value(&manifest.bootstrap)?;
     let info = serde_json::json!({
         "host_ip": host_ip,
         "manifest_url": format!("http://{host_ip}:{port}/api/devnet-manifest.json"),
         "node_count": manifest.node_count as u64,
-        "bootstrap": serde_json::to_value(&manifest.bootstrap).unwrap_or(serde_json::Value::Null),
+        "bootstrap": bootstrap,
         "evm": evm_block,
     });
     let info_json = serde_json::to_string_pretty(&info)?;
-    spawn_manifest_server(port, manifest_json, info_json);
+    // Bind synchronously so a failure (e.g. the port is already in use)
+    // propagates to the caller instead of the devnet silently coming up
+    // without its manifest API.
+    let listener = std::net::TcpListener::bind(("0.0.0.0", port)).map_err(|e| {
+        color_eyre::eyre::eyre!("failed to bind manifest API on 0.0.0.0:{port}: {e}")
+    })?;
+    ant_node::logging::info!(
+        "manifest API on http://0.0.0.0:{port}/api/devnet-manifest.json (+ /api/info)"
+    );
+    spawn_manifest_server(listener, manifest_json, info_json);
     Ok(())
 }
 
@@ -254,64 +267,55 @@ fn local_ip_guess() -> String {
         .unwrap_or_else(|_| "127.0.0.1".to_string())
 }
 
-/// Spawn a tiny read-only HTTP server (its own thread) exposing the manifest
-/// over the LAN. GET-only, open CORS; hand-rolled HTTP/1.1 so there's no new
-/// dependency. Threads are detached and die when the process exits on Ctrl+C.
-fn spawn_manifest_server(port: u16, manifest_json: String, info_json: String) {
-    let listener = match std::net::TcpListener::bind(("0.0.0.0", port)) {
-        Ok(l) => l,
-        Err(e) => {
-            ant_node::logging::warn!("manifest API: failed to bind 0.0.0.0:{port}: {e}");
-            return;
-        }
-    };
-    ant_node::logging::info!(
-        "manifest API on http://0.0.0.0:{port}/api/devnet-manifest.json (+ /api/info)"
-    );
+/// Run a tiny read-only HTTP server on `listener` (its own thread) exposing the
+/// manifest over the LAN. GET-only, open CORS; hand-rolled HTTP/1.1 so there's
+/// no new dependency. Connections are handled **inline, one at a time** — the
+/// payloads are tiny and a devnet serves a handful of LAN devices, so a single
+/// thread bounds resource use (no per-connection thread to exhaust). Each
+/// connection gets a read timeout so a slow/idle client can't stall the loop.
+/// The thread is detached and dies when the process exits on Ctrl+C.
+fn spawn_manifest_server(
+    listener: std::net::TcpListener,
+    manifest_json: String,
+    info_json: String,
+) {
     std::thread::spawn(move || {
         use std::io::{Read, Write};
         for stream in listener.incoming() {
             let Ok(mut stream) = stream else { continue };
-            // Cap how long a slow/idle client can hold a handler thread — the
-            // listener binds 0.0.0.0, so an unbounded blocking read is a trivial
-            // resource-exhaustion vector.
             let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(5)));
-            let manifest = manifest_json.clone();
-            let info = info_json.clone();
-            std::thread::spawn(move || {
-                let mut buf = [0u8; 2048];
-                let n = stream.read(&mut buf).unwrap_or(0);
-                let req = String::from_utf8_lossy(&buf[..n]);
-                let mut tokens = req.split_whitespace();
-                let method = tokens.next().unwrap_or("");
-                let raw = tokens.next().unwrap_or("/");
-                let path = raw.split('?').next().unwrap_or("/").trim_end_matches('/');
-                // Read-only API — only GET is allowed; anything else is 405.
-                let (status, body) = if method == "GET" {
-                    match path {
-                        "/api/devnet-manifest.json" => ("200 OK", manifest.as_str()),
-                        "/api/info" => ("200 OK", info.as_str()),
-                        "" | "/api" => (
-                            "200 OK",
-                            "{\"service\":\"ant-devnet manifest API\",\
-                             \"endpoints\":[\"/api/devnet-manifest.json\",\"/api/info\"]}",
-                        ),
-                        _ => ("404 Not Found", "{\"error\":\"not found\"}"),
-                    }
-                } else {
-                    (
-                        "405 Method Not Allowed",
-                        "{\"error\":\"method not allowed\"}",
-                    )
-                };
-                let resp = format!(
-                    "HTTP/1.1 {status}\r\nContent-Type: application/json\r\n\
-                     Access-Control-Allow-Origin: *\r\nCache-Control: no-store\r\n\
-                     Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
-                    body.len()
-                );
-                let _ = stream.write_all(resp.as_bytes());
-            });
+            let mut buf = [0u8; 2048];
+            let n = stream.read(&mut buf).unwrap_or(0);
+            let req = String::from_utf8_lossy(&buf[..n]);
+            let mut tokens = req.split_whitespace();
+            let method = tokens.next().unwrap_or("");
+            let raw = tokens.next().unwrap_or("/");
+            let path = raw.split('?').next().unwrap_or("/").trim_end_matches('/');
+            // Read-only API — only GET is allowed; anything else is 405.
+            let (status, body) = if method == "GET" {
+                match path {
+                    "/api/devnet-manifest.json" => ("200 OK", manifest_json.as_str()),
+                    "/api/info" => ("200 OK", info_json.as_str()),
+                    "" | "/api" => (
+                        "200 OK",
+                        "{\"service\":\"ant-devnet manifest API\",\
+                         \"endpoints\":[\"/api/devnet-manifest.json\",\"/api/info\"]}",
+                    ),
+                    _ => ("404 Not Found", "{\"error\":\"not found\"}"),
+                }
+            } else {
+                (
+                    "405 Method Not Allowed",
+                    "{\"error\":\"method not allowed\"}",
+                )
+            };
+            let resp = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\n\
+                 Access-Control-Allow-Origin: *\r\nCache-Control: no-store\r\n\
+                 Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = stream.write_all(resp.as_bytes());
         }
     });
 }

--- a/src/bin/ant-devnet/main.rs
+++ b/src/bin/ant-devnet/main.rs
@@ -86,6 +86,14 @@ async fn main() -> color_eyre::Result<()> {
         config.stabilization_timeout = std::time::Duration::from_secs(timeout_secs);
     }
 
+    // A loopback/unspecified --host would stamp unreachable bootstrap addresses
+    // into the manifest (LAN mode would fail non-obviously), so reject it early.
+    if let Some(host) = cli.host.filter(|h| h.is_loopback() || h.is_unspecified()) {
+        return Err(color_eyre::eyre::eyre!(
+            "--host must be a routable LAN IPv4 (got {host}); loopback/0.0.0.0 would \
+             advertise unreachable bootstrap addresses"
+        ));
+    }
     config.advertise_ip = cli.host;
     let evm_info =
         resolve_evm_info(cli.evm_network.as_deref(), cli.enable_evm, &mut config).await?;
@@ -264,23 +272,37 @@ fn spawn_manifest_server(port: u16, manifest_json: String, info_json: String) {
         use std::io::{Read, Write};
         for stream in listener.incoming() {
             let Ok(mut stream) = stream else { continue };
+            // Cap how long a slow/idle client can hold a handler thread — the
+            // listener binds 0.0.0.0, so an unbounded blocking read is a trivial
+            // resource-exhaustion vector.
+            let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(5)));
             let manifest = manifest_json.clone();
             let info = info_json.clone();
             std::thread::spawn(move || {
                 let mut buf = [0u8; 2048];
                 let n = stream.read(&mut buf).unwrap_or(0);
                 let req = String::from_utf8_lossy(&buf[..n]);
-                let raw = req.split_whitespace().nth(1).unwrap_or("/");
+                let mut tokens = req.split_whitespace();
+                let method = tokens.next().unwrap_or("");
+                let raw = tokens.next().unwrap_or("/");
                 let path = raw.split('?').next().unwrap_or("/").trim_end_matches('/');
-                let (status, body) = match path {
-                    "/api/devnet-manifest.json" => ("200 OK", manifest.as_str()),
-                    "/api/info" => ("200 OK", info.as_str()),
-                    "" | "/api" => (
-                        "200 OK",
-                        "{\"service\":\"ant-devnet manifest API\",\
-                         \"endpoints\":[\"/api/devnet-manifest.json\",\"/api/info\"]}",
-                    ),
-                    _ => ("404 Not Found", "{\"error\":\"not found\"}"),
+                // Read-only API — only GET is allowed; anything else is 405.
+                let (status, body) = if method == "GET" {
+                    match path {
+                        "/api/devnet-manifest.json" => ("200 OK", manifest.as_str()),
+                        "/api/info" => ("200 OK", info.as_str()),
+                        "" | "/api" => (
+                            "200 OK",
+                            "{\"service\":\"ant-devnet manifest API\",\
+                             \"endpoints\":[\"/api/devnet-manifest.json\",\"/api/info\"]}",
+                        ),
+                        _ => ("404 Not Found", "{\"error\":\"not found\"}"),
+                    }
+                } else {
+                    (
+                        "405 Method Not Allowed",
+                        "{\"error\":\"method not allowed\"}",
+                    )
                 };
                 let resp = format!(
                     "HTTP/1.1 {status}\r\nContent-Type: application/json\r\n\

--- a/src/bin/ant-devnet/main.rs
+++ b/src/bin/ant-devnet/main.rs
@@ -87,74 +87,8 @@ async fn main() -> color_eyre::Result<()> {
     }
 
     config.advertise_ip = cli.host;
-
-    // External EVM network (e.g. Arbitrum Sepolia): nodes verify payments
-    // against the real deployed contracts — no Anvil, and no embedded wallet
-    // key (bring your own funded wallet via an external signer). Falls through
-    // to the local-Anvil path (`--enable-evm`) when unset.
-    let evm_info = if let Some(net_name) = cli.evm_network.as_deref() {
-        let network = match net_name {
-            "arbitrum-sepolia" => evmlib::Network::ArbitrumSepoliaTest,
-            other => {
-                return Err(color_eyre::eyre::eyre!(
-                    "Unsupported --evm-network {other} (supported: arbitrum-sepolia)"
-                ))
-            }
-        };
-        let rpc_url = network.rpc_url().to_string();
-        let token_addr = format!("{:?}", network.payment_token_address());
-        let vault_addr = format!("{:?}", network.payment_vault_address());
-        ant_node::logging::info!(
-            "Using external EVM network {net_name}: rpc={rpc_url} token={token_addr} vault={vault_addr}"
-        );
-        config.evm_network = Some(network);
-        Some(DevnetEvmInfo {
-            rpc_url,
-            wallet_private_key: String::new(),
-            payment_token_address: token_addr,
-            payment_vault_address: vault_addr,
-        })
-    } else if cli.enable_evm {
-        ant_node::logging::info!("Starting local Anvil blockchain for EVM payment enforcement...");
-        let testnet = evmlib::testnet::Testnet::new()
-            .await
-            .map_err(|e| color_eyre::eyre::eyre!("Failed to start Anvil testnet: {e}"))?;
-        let network = testnet.to_network();
-        let wallet_key = testnet
-            .default_wallet_private_key()
-            .map_err(|e| color_eyre::eyre::eyre!("Failed to get wallet key: {e}"))?;
-
-        let (rpc_url, token_addr, vault_addr) = match &network {
-            evmlib::Network::Custom(custom) => (
-                custom.rpc_url_http.to_string(),
-                format!("{:?}", custom.payment_token_address),
-                format!("{:?}", custom.payment_vault_address),
-            ),
-            _ => {
-                return Err(color_eyre::eyre::eyre!(
-                    "Anvil testnet returned non-Custom network"
-                ))
-            }
-        };
-
-        config.evm_network = Some(network);
-
-        ant_node::logging::info!("Anvil blockchain running at {rpc_url}");
-        ant_node::logging::info!("Funded wallet private key: {wallet_key}");
-
-        // Keep testnet alive by leaking it (it will be cleaned up on process exit)
-        // This is necessary because AnvilInstance stops Anvil when dropped
-        std::mem::forget(testnet);
-
-        Some(DevnetEvmInfo {
-            rpc_url,
-            wallet_private_key: wallet_key,
-            payment_token_address: token_addr,
-            payment_vault_address: vault_addr,
-        })
-    } else {
-        None
-    };
+    let evm_info =
+        resolve_evm_info(cli.evm_network.as_deref(), cli.enable_evm, &mut config).await?;
 
     let mut devnet = Devnet::new(config).await?;
     devnet.start().await?;
@@ -187,6 +121,80 @@ async fn main() -> color_eyre::Result<()> {
 
     devnet.shutdown().await?;
     Ok(())
+}
+
+/// Resolve which EVM backing the devnet uses, updating `config` accordingly:
+/// an **external** network (`--evm-network`, e.g. Arbitrum Sepolia verified
+/// against the real deployed contracts, no embedded wallet key); a **local
+/// Anvil** chain (`--enable-evm`); or **none**. External takes precedence.
+async fn resolve_evm_info(
+    evm_network: Option<&str>,
+    enable_evm: bool,
+    config: &mut DevnetConfig,
+) -> color_eyre::Result<Option<DevnetEvmInfo>> {
+    if let Some(net_name) = evm_network {
+        let network = match net_name {
+            "arbitrum-sepolia" => evmlib::Network::ArbitrumSepoliaTest,
+            other => {
+                return Err(color_eyre::eyre::eyre!(
+                    "Unsupported --evm-network {other} (supported: arbitrum-sepolia)"
+                ))
+            }
+        };
+        let rpc_url = network.rpc_url().to_string();
+        let token_addr = format!("{:?}", network.payment_token_address());
+        let vault_addr = format!("{:?}", network.payment_vault_address());
+        ant_node::logging::info!(
+            "Using external EVM network {net_name}: rpc={rpc_url} token={token_addr} vault={vault_addr}"
+        );
+        config.evm_network = Some(network);
+        Ok(Some(DevnetEvmInfo {
+            rpc_url,
+            wallet_private_key: String::new(),
+            payment_token_address: token_addr,
+            payment_vault_address: vault_addr,
+        }))
+    } else if enable_evm {
+        ant_node::logging::info!("Starting local Anvil blockchain for EVM payment enforcement...");
+        let testnet = evmlib::testnet::Testnet::new()
+            .await
+            .map_err(|e| color_eyre::eyre::eyre!("Failed to start Anvil testnet: {e}"))?;
+        let network = testnet.to_network();
+        let wallet_key = testnet
+            .default_wallet_private_key()
+            .map_err(|e| color_eyre::eyre::eyre!("Failed to get wallet key: {e}"))?;
+
+        let (rpc_url, token_addr, vault_addr) = match &network {
+            evmlib::Network::Custom(custom) => (
+                custom.rpc_url_http.to_string(),
+                format!("{:?}", custom.payment_token_address),
+                format!("{:?}", custom.payment_vault_address),
+            ),
+            _ => {
+                return Err(color_eyre::eyre::eyre!(
+                    "Anvil testnet returned non-Custom network"
+                ))
+            }
+        };
+
+        config.evm_network = Some(network);
+
+        ant_node::logging::info!("Anvil blockchain running at {rpc_url}");
+        ant_node::logging::info!("Funded wallet private key: {wallet_key}");
+
+        // Keep testnet alive by leaking it (it will be cleaned up on process exit)
+        // This is necessary because AnvilInstance stops Anvil when dropped
+        std::mem::forget(testnet);
+
+        Ok(Some(DevnetEvmInfo {
+            rpc_url,
+            wallet_private_key: wallet_key,
+            payment_token_address: token_addr,
+            payment_vault_address: vault_addr,
+        }))
+    } else {
+        Ok(None)
+    }
 }
 
 /// Build the `/api/info` payload for `manifest` and start the read-only HTTP

--- a/src/bin/ant-devnet/main.rs
+++ b/src/bin/ant-devnet/main.rs
@@ -1,4 +1,29 @@
 //! ant-devnet CLI entry point.
+//!
+//! Runs a local devnet for testing. By default all nodes bind loopback
+//! (`127.0.0.1`), so only the host machine can reach them.
+//!
+//! Three opt-in flags extend this to a **LAN / external-devnet** scenario for
+//! testing from another device (a phone, a simulator, a second machine). All
+//! default off — omitting them reproduces the original loopback behavior:
+//!
+//! - `--host <ipv4>`: bind `0.0.0.0` and advertise this LAN IP in the manifest's
+//!   bootstrap addresses, so other devices on the LAN can connect.
+//! - `--evm-network arbitrum-sepolia`: verify payments against the real deployed
+//!   Arbitrum Sepolia contracts (no local Anvil, empty wallet key) — exercises
+//!   the external-signer payment flow.
+//! - `--serve-port <port>`: expose the manifest over a small read-only HTTP API
+//!   (`GET /api/devnet-manifest.json` + `/api/info`) so devices fetch it instead
+//!   of copying files.
+//!
+//! ```text
+//! # single-machine, local Anvil (unchanged default behavior)
+//! ant-devnet --preset small --enable-evm
+//!
+//! # LAN devnet backed by Arbitrum Sepolia, manifest served over HTTP
+//! ant-devnet --preset small --host 192.168.1.100 \
+//!     --evm-network arbitrum-sepolia --serve-port 8088
+//! ```
 
 #![cfg_attr(not(feature = "logging"), allow(unused_variables))]
 
@@ -61,8 +86,35 @@ async fn main() -> color_eyre::Result<()> {
         config.stabilization_timeout = std::time::Duration::from_secs(timeout_secs);
     }
 
-    // Start Anvil and deploy contracts if EVM is enabled
-    let evm_info = if cli.enable_evm {
+    config.advertise_ip = cli.host;
+
+    // External EVM network (e.g. Arbitrum Sepolia): nodes verify payments
+    // against the real deployed contracts — no Anvil, and no embedded wallet
+    // key (bring your own funded wallet via an external signer). Falls through
+    // to the local-Anvil path (`--enable-evm`) when unset.
+    let evm_info = if let Some(net_name) = cli.evm_network.as_deref() {
+        let network = match net_name {
+            "arbitrum-sepolia" => evmlib::Network::ArbitrumSepoliaTest,
+            other => {
+                return Err(color_eyre::eyre::eyre!(
+                    "Unsupported --evm-network {other} (supported: arbitrum-sepolia)"
+                ))
+            }
+        };
+        let rpc_url = network.rpc_url().to_string();
+        let token_addr = format!("{:?}", network.payment_token_address());
+        let vault_addr = format!("{:?}", network.payment_vault_address());
+        ant_node::logging::info!(
+            "Using external EVM network {net_name}: rpc={rpc_url} token={token_addr} vault={vault_addr}"
+        );
+        config.evm_network = Some(network);
+        Some(DevnetEvmInfo {
+            rpc_url,
+            wallet_private_key: String::new(),
+            payment_token_address: token_addr,
+            payment_vault_address: vault_addr,
+        })
+    } else if cli.enable_evm {
         ant_node::logging::info!("Starting local Anvil blockchain for EVM payment enforcement...");
         let testnet = evmlib::testnet::Testnet::new()
             .await
@@ -124,9 +176,112 @@ async fn main() -> color_eyre::Result<()> {
         println!("{json}");
     }
 
+    // Optional read-only HTTP API so LAN devices fetch the manifest instead of
+    // copying files (GET /api/devnet-manifest.json + /api/info).
+    if let Some(port) = cli.serve_port {
+        serve_manifest_api(port, cli.host, &manifest, json.clone())?;
+    }
+
     ant_node::logging::info!("Devnet running. Press Ctrl+C to stop.");
     tokio::signal::ctrl_c().await?;
 
     devnet.shutdown().await?;
     Ok(())
+}
+
+/// Build the `/api/info` payload for `manifest` and start the read-only HTTP
+/// server on `port`. `host` is the advertised LAN IP when set, otherwise a
+/// best-effort local-IP guess is used for the URLs it reports.
+fn serve_manifest_api(
+    port: u16,
+    host: Option<std::net::Ipv4Addr>,
+    manifest: &DevnetManifest,
+    manifest_json: String,
+) -> color_eyre::Result<()> {
+    let host_ip = host.map_or_else(local_ip_guess, |i| i.to_string());
+    let evm_block = manifest.evm.as_ref().map_or(serde_json::Value::Null, |e| {
+        let loopback = e.rpc_url.contains("127.0.0.1") || e.rpc_url.contains("localhost");
+        serde_json::json!({
+            "rpc_url": e.rpc_url,
+            "network": if loopback { "local-anvil" } else { "external" },
+            "reachable_from_lan": !loopback,
+            "note": if loopback {
+                format!(
+                    "Anvil binds loopback on the host — bridge it (socat \
+                     TCP-LISTEN:8545,fork,bind=0.0.0.0 TCP:127.0.0.1:<anvil-port>) \
+                     and use http://{host_ip}:8545/."
+                )
+            } else {
+                "Public RPC — reachable directly from any device.".to_string()
+            },
+        })
+    });
+    let info = serde_json::json!({
+        "host_ip": host_ip,
+        "manifest_url": format!("http://{host_ip}:{port}/api/devnet-manifest.json"),
+        "node_count": manifest.node_count as u64,
+        "bootstrap": serde_json::to_value(&manifest.bootstrap).unwrap_or(serde_json::Value::Null),
+        "evm": evm_block,
+    });
+    let info_json = serde_json::to_string_pretty(&info)?;
+    spawn_manifest_server(port, manifest_json, info_json);
+    Ok(())
+}
+
+/// Best-effort primary LAN IP (src of the default route) for the info endpoint.
+fn local_ip_guess() -> String {
+    std::net::UdpSocket::bind("0.0.0.0:0")
+        .and_then(|s| {
+            s.connect("1.1.1.1:80")?;
+            Ok(s.local_addr()?.ip().to_string())
+        })
+        .unwrap_or_else(|_| "127.0.0.1".to_string())
+}
+
+/// Spawn a tiny read-only HTTP server (its own thread) exposing the manifest
+/// over the LAN. GET-only, open CORS; hand-rolled HTTP/1.1 so there's no new
+/// dependency. Threads are detached and die when the process exits on Ctrl+C.
+fn spawn_manifest_server(port: u16, manifest_json: String, info_json: String) {
+    let listener = match std::net::TcpListener::bind(("0.0.0.0", port)) {
+        Ok(l) => l,
+        Err(e) => {
+            ant_node::logging::warn!("manifest API: failed to bind 0.0.0.0:{port}: {e}");
+            return;
+        }
+    };
+    ant_node::logging::info!(
+        "manifest API on http://0.0.0.0:{port}/api/devnet-manifest.json (+ /api/info)"
+    );
+    std::thread::spawn(move || {
+        use std::io::{Read, Write};
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            let manifest = manifest_json.clone();
+            let info = info_json.clone();
+            std::thread::spawn(move || {
+                let mut buf = [0u8; 2048];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                let req = String::from_utf8_lossy(&buf[..n]);
+                let raw = req.split_whitespace().nth(1).unwrap_or("/");
+                let path = raw.split('?').next().unwrap_or("/").trim_end_matches('/');
+                let (status, body) = match path {
+                    "/api/devnet-manifest.json" => ("200 OK", manifest.as_str()),
+                    "/api/info" => ("200 OK", info.as_str()),
+                    "" | "/api" => (
+                        "200 OK",
+                        "{\"service\":\"ant-devnet manifest API\",\
+                         \"endpoints\":[\"/api/devnet-manifest.json\",\"/api/info\"]}",
+                    ),
+                    _ => ("404 Not Found", "{\"error\":\"not found\"}"),
+                };
+                let resp = format!(
+                    "HTTP/1.1 {status}\r\nContent-Type: application/json\r\n\
+                     Access-Control-Allow-Origin: *\r\nCache-Control: no-store\r\n\
+                     Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(resp.as_bytes());
+            });
+        }
+    });
 }

--- a/src/devnet.rs
+++ b/src/devnet.rs
@@ -165,6 +165,10 @@ pub struct DevnetConfig {
     /// When `Some`, nodes will use this network (e.g. Anvil testnet) for
     /// on-chain verification. Defaults to Arbitrum One when `None`.
     pub evm_network: Option<EvmNetwork>,
+
+    /// Optional IPv4 to advertise to peers/clients (LAN devnet). When `Some`,
+    /// nodes bind 0.0.0.0 and advertise this IP instead of 127.0.0.1.
+    pub advertise_ip: Option<Ipv4Addr>,
 }
 
 impl Default for DevnetConfig {
@@ -186,6 +190,7 @@ impl Default for DevnetConfig {
             enable_node_logging: false,
             cleanup_data_dir: true,
             evm_network: None,
+            advertise_ip: None,
         }
     }
 }
@@ -436,7 +441,12 @@ impl Devnet {
         self.nodes
             .iter()
             .take(self.config.bootstrap_count)
-            .map(|n| MultiAddr::quic(SocketAddr::from((Ipv4Addr::LOCALHOST, n.port))))
+            .map(|n| {
+                MultiAddr::quic(SocketAddr::from((
+                    self.config.advertise_ip.unwrap_or(Ipv4Addr::LOCALHOST),
+                    n.port,
+                )))
+            })
             .collect()
     }
 
@@ -471,7 +481,12 @@ impl Devnet {
                 ))
             })?
             .iter()
-            .map(|n| MultiAddr::quic(SocketAddr::from((Ipv4Addr::LOCALHOST, n.port))))
+            .map(|n| {
+                MultiAddr::quic(SocketAddr::from((
+                    self.config.advertise_ip.unwrap_or(Ipv4Addr::LOCALHOST),
+                    n.port,
+                )))
+            })
             .collect();
 
         for i in self.config.bootstrap_count..self.config.node_count {
@@ -582,7 +597,7 @@ impl Devnet {
 
         let mut core_config = CoreNodeConfig::builder()
             .port(node.port)
-            .local(true)
+            .local(self.config.advertise_ip.is_none())
             .max_message_size(crate::ant_protocol::MAX_WIRE_MESSAGE_SIZE)
             .build()
             .map_err(|e| DevnetError::Core(format!("Failed to create core config: {e}")))?;
@@ -772,5 +787,19 @@ impl Drop for Devnet {
         if let Some(handle) = self.health_monitor.take() {
             handle.abort();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Backward-compatibility contract: a default config advertises no LAN IP,
+    /// so nodes bind loopback (`.local(advertise_ip.is_none())` → `.local(true)`)
+    /// and stamp `127.0.0.1` into the manifest bootstrap addresses — exactly as
+    /// before the `--host` flag existed.
+    #[test]
+    fn default_config_has_no_advertise_ip() {
+        assert!(DevnetConfig::default().advertise_ip.is_none());
     }
 }


### PR DESCRIPTION
## What

Adds a **LAN / external-devnet scenario** to the existing `ant-devnet` harness so a devnet can be tested from another device — a phone, an iOS simulator, or a second machine — rather than only from the host box. Three opt-in flags, all **default off**:

| Flag | Effect |
|---|---|
| `--host <ipv4>` | Bind `0.0.0.0` and advertise this LAN IP in the manifest's bootstrap addresses, so other LAN devices can connect. |
| `--evm-network arbitrum-sepolia` | Verify payments against the **real deployed Arbitrum Sepolia contracts** (no local Anvil, empty wallet key) — exercises the external-signer payment flow. |
| `--serve-port <port>` | Serve the manifest over a small read-only HTTP API (`GET /api/devnet-manifest.json` + `/api/info`) so devices fetch it instead of copying files. |

```bash
# unchanged default behavior (single machine, local Anvil)
ant-devnet --preset small --enable-evm

# LAN devnet backed by Arbitrum Sepolia, manifest served over HTTP
ant-devnet --preset small --host 192.168.1.100 --evm-network arbitrum-sepolia --serve-port 8088
```

## Why here

`ant-devnet` is already the maintained local-devnet tool; this is a focused enhancement to it, not a new binary or module — **no new dependencies** (the manifest server is hand-rolled HTTP/1.1). It's the node half of enabling on-device testing of the mobile SDK; the client half already shipped in the Autonomi mobile FFI.

## Backward compatibility / blast radius

- **Opt-in and default-off.** No `--host` → `advertise_ip = None` → `.local(true)` + `127.0.0.1` bootstrap addresses, byte-identical to today.
- **Confined to the harness.** Only the `ant-devnet` binary and the `Devnet`/`DevnetConfig` type change. The real node binary (`ant-node`) and the wire protocol are untouched, and nothing here is on the production node path — so **deployed testnets are unaffected**.
- **Minor API note:** adds one field to the public `DevnetConfig` (`advertise_ip: Option<Ipv4Addr>`). It's covered by the `Default` impl, so `..Default::default()` construction is unaffected; only a struct-literal build without `..Default::default()` would need the new field.

## Tests

- `cli.rs`: LAN flags default to `None` (backward-compat contract); parse into the expected typed values; non-IPv4 `--host` is rejected.
- `devnet.rs`: `DevnetConfig::default().advertise_ip` is `None`.
- `cargo fmt --all --check` clean; strict clippy gates (`-D clippy::panic/unwrap_used/expect_used`) pass; release build green.

Proven end-to-end out-of-band: a physical Android device completed a full paid upload + byte-perfect download round-trip against a Sepolia-backed LAN devnet launched with these flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)