### PR TITLE
fix(replication): stop the first-audit scheduler from targeting the local peer

### DIFF
--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -101,6 +101,30 @@ struct FirstAuditObservability {
     inflight: AtomicU64,
 }
 
+/// Test-only snapshot of the first-audit scheduler counters.
+///
+/// Lets e2e tests assert on the scheduler's decisions (e.g. that a
+/// self-targeting monetized pin was dropped and never launched) instead of
+/// scraping log lines.
+#[cfg(any(test, feature = "test-utils"))]
+#[derive(Debug, Clone, Copy)]
+pub struct FirstAuditStats {
+    /// Events ingested from the monetized-pin channel.
+    pub received: u64,
+    /// Events accepted into the pending first-audit queue.
+    pub queued: u64,
+    /// Events dropped because they targeted the local peer.
+    pub self_target_skipped: u64,
+    /// Audits launched.
+    pub launched: u64,
+    /// Launched audits that passed.
+    pub passed: u64,
+    /// Launched audits that timed out (non-response lane).
+    pub timed_out: u64,
+    /// Launched audits that ended in a confirmed failure.
+    pub failed: u64,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FirstAuditTerminalOutcome {
     Passed,
@@ -162,8 +186,9 @@ enum FirstAuditQueueOutcome {
 /// is one of them, so each verified payment surfaces a self-targeting event.
 /// The node cannot audit itself over the network (there is no dialable address
 /// for the local peer, so the challenge fails instantly and is miscounted as a
-/// timeout), and the pin still receives its deterministic first audit from the
-/// payment's other payees. A self-target is therefore never queued — and hence
+/// timeout), while any other payee that verifies the same payment schedules its
+/// own deterministic first audit of this node's pin — a self-dial adds no
+/// coverage either way. A self-target is therefore never queued — and hence
 /// never launched nor marked first-audited.
 fn queue_first_audit_event(
     pending: &mut LruCache<PeerId, MonetizedPinEvent>,
@@ -472,6 +497,10 @@ pub struct ReplicationEngine {
     /// ADR-0004: receiver half of the monetized-pin channel, taken by
     /// `start_first_audit_drainer`.
     monetized_pin_rx: Option<mpsc::UnboundedReceiver<MonetizedPinEvent>>,
+    /// Counters shared with the first-audit drainer task, so the scheduler's
+    /// decisions (queued / launched / self-target skipped / outcome) stay
+    /// observable from the engine after the drainer takes the receiver.
+    first_audit_observability: Arc<FirstAuditObservability>,
     /// Shutdown token.
     shutdown: CancellationToken,
     /// Background task handles.
@@ -542,6 +571,7 @@ impl ReplicationEngine {
             possession_check_rx: Some(possession_check_rx),
             monetized_pin_tx,
             monetized_pin_rx: Some(monetized_pin_rx),
+            first_audit_observability: Arc::new(FirstAuditObservability::default()),
             shutdown,
             task_handles: Vec::new(),
         };
@@ -656,6 +686,24 @@ impl ReplicationEngine {
             Some(&credit),
         )
         .await
+    }
+
+    /// Test-only: snapshot the first-audit scheduler's counters. Lets e2e
+    /// tests assert what the live drainer decided for an injected
+    /// [`MonetizedPinEvent`] (dropped as self-target vs queued and launched).
+    #[cfg(any(test, feature = "test-utils"))]
+    #[must_use]
+    pub fn first_audit_stats(&self) -> FirstAuditStats {
+        let o = &self.first_audit_observability;
+        FirstAuditStats {
+            received: o.received.load(Ordering::Relaxed),
+            queued: o.queued.load(Ordering::Relaxed),
+            self_target_skipped: o.self_target_skipped.load(Ordering::Relaxed),
+            launched: o.launched.load(Ordering::Relaxed),
+            passed: o.passed.load(Ordering::Relaxed),
+            timed_out: o.timed_out.load(Ordering::Relaxed),
+            failed: o.failed.load(Ordering::Relaxed),
+        }
     }
 
     /// Test-only: run the possession check immediately for `key` against
@@ -929,7 +977,7 @@ impl ReplicationEngine {
             cooldown: Arc::clone(&self.audit_on_gossip_cooldown),
         };
         let shutdown = self.shutdown.clone();
-        let observability = Arc::new(FirstAuditObservability::default());
+        let observability = Arc::clone(&self.first_audit_observability);
         let self_peer = *self.p2p_node.peer_id();
 
         let handle = tokio::spawn(async move {

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -88,6 +88,7 @@ struct FirstAuditObservability {
     coalesced: AtomicU64,
     duplicates: AtomicU64,
     capacity_evicted: AtomicU64,
+    self_target_skipped: AtomicU64,
     cooldown_deferred_attempts: AtomicU64,
     launched: AtomicU64,
     passed: AtomicU64,
@@ -145,15 +146,33 @@ fn first_audit_terminal_outcome(result: &AuditTickResult) -> FirstAuditTerminalO
 enum FirstAuditQueueOutcome {
     Queued,
     Coalesced,
-    CapacityEvicted { peer: PeerId, pin: [u8; 32] },
+    CapacityEvicted {
+        peer: PeerId,
+        pin: [u8; 32],
+    },
+    /// The event targets the local peer itself — dropped, never queued.
+    SelfTargetSkipped,
 }
 
 /// Insert newest-per-peer work while exposing the bounded LRU's otherwise
 /// silent capacity eviction. This preserves `LruCache::put` semantics exactly.
+///
+/// An event targeting the local peer is dropped instead of queued: the
+/// verifier walks every quote in a verified payment and the node's own quote
+/// is one of them, so each verified payment surfaces a self-targeting event.
+/// The node cannot audit itself over the network (there is no dialable address
+/// for the local peer, so the challenge fails instantly and is miscounted as a
+/// timeout), and the pin still receives its deterministic first audit from the
+/// payment's other payees. A self-target is therefore never queued — and hence
+/// never launched nor marked first-audited.
 fn queue_first_audit_event(
     pending: &mut LruCache<PeerId, MonetizedPinEvent>,
     event: MonetizedPinEvent,
+    self_peer: &PeerId,
 ) -> FirstAuditQueueOutcome {
+    if event.peer == *self_peer {
+        return FirstAuditQueueOutcome::SelfTargetSkipped;
+    }
     match pending.push(event.peer, event) {
         None => FirstAuditQueueOutcome::Queued,
         Some((replaced_peer, _)) if replaced_peer == event.peer => {
@@ -911,6 +930,7 @@ impl ReplicationEngine {
         };
         let shutdown = self.shutdown.clone();
         let observability = Arc::new(FirstAuditObservability::default());
+        let self_peer = *self.p2p_node.peer_id();
 
         let handle = tokio::spawn(async move {
             // Bounded dedup of pins that have ALREADY been given their
@@ -961,7 +981,7 @@ impl ReplicationEngine {
                                     e.peer, hex::encode(e.pin), e.key_count, pending.len()
                                 );
                             } else {
-                                match queue_first_audit_event(&mut pending, e) {
+                                match queue_first_audit_event(&mut pending, e, &self_peer) {
                                     FirstAuditQueueOutcome::Queued => {
                                         observability.queued.fetch_add(1, Ordering::Relaxed);
                                         debug!(
@@ -986,6 +1006,15 @@ impl ReplicationEngine {
                                             hex::encode(pin), e.peer, hex::encode(e.pin), pending.len()
                                         );
                                     }
+                                    FirstAuditQueueOutcome::SelfTargetSkipped => {
+                                        observability
+                                            .self_target_skipped
+                                            .fetch_add(1, Ordering::Relaxed);
+                                        debug!(
+                                            "First-audit scheduler: audit_trigger=first_monetized outcome=self_target_skipped peer={} pin={} key_count={} pending={}",
+                                            e.peer, hex::encode(e.pin), e.key_count, pending.len()
+                                        );
+                                    }
                                 }
                             }
                             let mut drained = 1usize;
@@ -998,7 +1027,7 @@ impl ReplicationEngine {
                                                 .duplicates
                                                 .fetch_add(1, Ordering::Relaxed);
                                         } else {
-                                            match queue_first_audit_event(&mut pending, e) {
+                                            match queue_first_audit_event(&mut pending, e, &self_peer) {
                                                 FirstAuditQueueOutcome::Queued => {
                                                     observability
                                                         .queued
@@ -1015,6 +1044,11 @@ impl ReplicationEngine {
                                                         .fetch_add(1, Ordering::Relaxed);
                                                     observability
                                                         .capacity_evicted
+                                                        .fetch_add(1, Ordering::Relaxed);
+                                                }
+                                                FirstAuditQueueOutcome::SelfTargetSkipped => {
+                                                    observability
+                                                        .self_target_skipped
                                                         .fetch_add(1, Ordering::Relaxed);
                                                 }
                                             }
@@ -1034,12 +1068,13 @@ impl ReplicationEngine {
 
                 if last_summary.elapsed() >= config::FIRST_AUDIT_SUMMARY_INTERVAL {
                     info!(
-                        "First-audit scheduler summary: audit_trigger=first_monetized received={} queued={} coalesced={} duplicates={} capacity_evicted={} cooldown_deferred_attempts={} launched={} passed={} timeout={} failed={} bootstrap_claims={} idle={} insufficient_keys={} outside_answerability_window={} pending={} inflight={}",
+                        "First-audit scheduler summary: audit_trigger=first_monetized received={} queued={} coalesced={} duplicates={} capacity_evicted={} self_target_skipped={} cooldown_deferred_attempts={} launched={} passed={} timeout={} failed={} bootstrap_claims={} idle={} insufficient_keys={} outside_answerability_window={} pending={} inflight={}",
                         observability.received.load(Ordering::Relaxed),
                         observability.queued.load(Ordering::Relaxed),
                         observability.coalesced.load(Ordering::Relaxed),
                         observability.duplicates.load(Ordering::Relaxed),
                         observability.capacity_evicted.load(Ordering::Relaxed),
+                        observability.self_target_skipped.load(Ordering::Relaxed),
                         observability.cooldown_deferred_attempts.load(Ordering::Relaxed),
                         observability.launched.load(Ordering::Relaxed),
                         observability.passed.load(Ordering::Relaxed),
@@ -5553,6 +5588,7 @@ mod tests {
     #[test]
     fn first_audit_queue_exposes_coalescing_and_capacity_eviction() {
         let mut pending = LruCache::new(NonZeroUsize::new(1).unwrap());
+        let self_peer = test_peer(9);
         let first = MonetizedPinEvent {
             peer: test_peer(1),
             pin: [1; 32],
@@ -5570,15 +5606,15 @@ mod tests {
         };
 
         assert_eq!(
-            queue_first_audit_event(&mut pending, first),
+            queue_first_audit_event(&mut pending, first, &self_peer),
             FirstAuditQueueOutcome::Queued
         );
         assert_eq!(
-            queue_first_audit_event(&mut pending, replacement),
+            queue_first_audit_event(&mut pending, replacement, &self_peer),
             FirstAuditQueueOutcome::Coalesced
         );
         assert_eq!(
-            queue_first_audit_event(&mut pending, other_peer),
+            queue_first_audit_event(&mut pending, other_peer, &self_peer),
             FirstAuditQueueOutcome::CapacityEvicted {
                 peer: first.peer,
                 pin: replacement.pin,
@@ -5589,6 +5625,42 @@ mod tests {
             pending.peek(&other_peer.peer).map(|event| event.pin),
             Some([3; 32])
         );
+    }
+
+    /// A verified payment's quote list includes the local node's own quote, so
+    /// the verifier emits a monetized-pin event for the local peer on every
+    /// payment it verifies. The node cannot network-audit itself, so the
+    /// scheduler must drop such an event at ingress: never queued, and hence
+    /// never launched nor marked first-audited.
+    #[test]
+    fn first_audit_queue_drops_self_targeting_events() {
+        let mut pending = LruCache::new(NonZeroUsize::new(4).unwrap());
+        let self_peer = test_peer(1);
+        let self_event = MonetizedPinEvent {
+            peer: self_peer,
+            pin: [7; 32],
+            key_count: 1,
+            quote_ts: SystemTime::now(),
+        };
+
+        assert_eq!(
+            queue_first_audit_event(&mut pending, self_event, &self_peer),
+            FirstAuditQueueOutcome::SelfTargetSkipped
+        );
+        assert!(pending.is_empty());
+
+        // A remote peer's event still queues normally under the same filter.
+        let remote_event = MonetizedPinEvent {
+            peer: test_peer(2),
+            pin: [8; 32],
+            ..self_event
+        };
+        assert_eq!(
+            queue_first_audit_event(&mut pending, remote_event, &self_peer),
+            FirstAuditQueueOutcome::Queued
+        );
+        assert_eq!(pending.len(), 1);
+        assert!(pending.peek(&self_peer).is_none());
     }
 
     #[test]

--- a/tests/e2e/subtree_audit_testnet.rs
+++ b/tests/e2e/subtree_audit_testnet.rs
@@ -15,9 +15,32 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
+use std::time::{Duration, SystemTime};
+
 use super::TestHarness;
 use ant_node::replication::audit::AuditTickResult;
+use ant_node::replication::{FirstAuditStats, MonetizedPinEvent, ReplicationEngine};
 use serial_test::serial;
+use tokio::time::sleep;
+
+/// Poll `engine`'s first-audit scheduler counters until `done(stats)` holds or
+/// `deadline` elapses; returns the last snapshot either way. The drainer is a
+/// live background task, so tests observe it converge instead of sleeping a
+/// fixed amount.
+async fn wait_for_first_audit_stats(
+    engine: &ReplicationEngine,
+    deadline: Duration,
+    done: impl Fn(&FirstAuditStats) -> bool,
+) -> FirstAuditStats {
+    let start = std::time::Instant::now();
+    loop {
+        let stats = engine.first_audit_stats();
+        if done(&stats) || start.elapsed() >= deadline {
+            return stats;
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+}
 
 /// Store the same `n` chunks on both `a` (the audited holder) and `b` (the
 /// auditor — NOT because verification needs them: round 2 demands the bytes
@@ -154,6 +177,125 @@ async fn data_deleting_node_fails_subtree_audit() {
     assert!(
         matches!(result, AuditTickResult::Failed { .. }),
         "a node that deleted its committed data must FAIL the audit, got {result:?}"
+    );
+
+    harness.teardown().await.expect("teardown");
+}
+
+/// SELF FILTER: a monetized-pin event targeting the node's own peer ID (the
+/// payment verifier emits one for every payment it verifies, because the
+/// node's own quote is in the payment's quote list) must be dropped by the
+/// live first-audit drainer at ingress — never queued, never launched — and
+/// counted as `self_target_skipped`.
+///
+/// Without the filter this exact scenario launches an audit the node addresses
+/// to itself; the dial fails instantly with `Peer not found` and is miscounted
+/// as a subtree audit timeout.
+#[tokio::test]
+#[serial]
+async fn first_audit_drainer_drops_self_targeting_monetized_pin() {
+    let harness = TestHarness::setup_small().await.expect("setup");
+
+    let node = harness.test_node(4).expect("node");
+    let engine = node.replication_engine.as_ref().expect("engine");
+    let self_peer = *node.p2p_node.as_ref().expect("p2p").peer_id();
+
+    let before = engine.first_audit_stats();
+    assert_eq!(before.received, 0, "no events expected before injection");
+
+    engine
+        .monetized_pin_sender()
+        .send(MonetizedPinEvent {
+            peer: self_peer,
+            pin: [0x42; 32],
+            key_count: 8,
+            quote_ts: SystemTime::now(),
+        })
+        .expect("drainer alive");
+
+    let stats = wait_for_first_audit_stats(engine, Duration::from_secs(10), |s| {
+        s.received >= 1 && s.self_target_skipped >= 1
+    })
+    .await;
+
+    assert_eq!(stats.received, 1, "drainer must have ingested the event");
+    assert_eq!(
+        stats.self_target_skipped, 1,
+        "a self-targeting event must be counted as skipped, got {stats:?}"
+    );
+    assert_eq!(
+        stats.queued, 0,
+        "a self-targeting event must never enter the pending queue, got {stats:?}"
+    );
+    assert_eq!(
+        stats.launched, 0,
+        "the scheduler must never launch an audit against the local peer, got {stats:?}"
+    );
+
+    harness.teardown().await.expect("teardown");
+}
+
+/// REMOTE STILL AUDITED: the same injection for a REMOTE peer's real
+/// commitment passes through the self filter, gets queued, launches over the
+/// live wire, and completes as a passed first audit — proving the filter does
+/// not suppress the deterministic first audit of legitimate monetized pins.
+#[tokio::test]
+#[serial]
+async fn first_audit_drainer_launches_and_passes_remote_monetized_pin() {
+    let harness = TestHarness::setup_small().await.expect("setup");
+    harness.warmup_dht().await.expect("warmup");
+
+    let (a_idx, b_idx) = (1, 2);
+    commit_and_seed(&harness, a_idx, b_idx, 64).await;
+
+    let a = harness.test_node(a_idx).expect("a");
+    let a_peer = *a.p2p_node.as_ref().expect("a p2p").peer_id();
+    let a_built = a
+        .replication_engine
+        .as_ref()
+        .expect("a engine")
+        .commitment_state()
+        .current()
+        .expect("a has a commitment");
+    let (a_pin, a_key_count) = (a_built.hash(), a_built.commitment().key_count);
+
+    let b_engine = harness
+        .test_node(b_idx)
+        .expect("b")
+        .replication_engine
+        .as_ref()
+        .expect("b engine");
+
+    b_engine
+        .monetized_pin_sender()
+        .send(MonetizedPinEvent {
+            peer: a_peer,
+            pin: a_pin,
+            key_count: a_key_count,
+            quote_ts: SystemTime::now(),
+        })
+        .expect("drainer alive");
+
+    let stats = wait_for_first_audit_stats(b_engine, Duration::from_secs(120), |s| {
+        s.passed >= 1 || s.timed_out >= 1 || s.failed >= 1
+    })
+    .await;
+
+    assert_eq!(
+        stats.self_target_skipped, 0,
+        "a remote event must not be misfiltered, got {stats:?}"
+    );
+    assert_eq!(
+        stats.queued, 1,
+        "remote event must be queued, got {stats:?}"
+    );
+    assert_eq!(
+        stats.launched, 1,
+        "remote event must launch an audit, got {stats:?}"
+    );
+    assert_eq!(
+        stats.passed, 1,
+        "the live-wire first audit of an honest holder must pass, got {stats:?}"
     );
 
     harness.teardown().await.expect("teardown");


### PR DESCRIPTION
## Problem

On every payment a node verifies, the payment's quote list includes the node's own quote, so the verifier emits a monetized-pin first-audit event targeting the local peer. The first-audit scheduler launched these audits without a self check, so the node tried to send an audit challenge to itself. The dial fails instantly (`Peer not found`, 0-1 ms, the local peer has no dialable address) and was counted as a subtree audit timeout.

Reported by @mickvandijke from two independent 400-node testnet runs: 396/396 and 382/423 `Peer not found` first-audit failures targeted the requester's own peer ID, about 8% of all first-monetized subtree audit starts, inflating the timeout metrics.

## Fix

Filter self-targets at the single ingress choke point (`queue_first_audit_event`) that both receive arms of the drainer feed through:

- A self-targeting event is never queued, never launched, and never marks its pin first-audited.
- A new `self_target_skipped` counter is reported in the periodic scheduler summary line, so a testnet run can confirm the filter is catching events (zero self-targeted outbound audit requests, non-zero skip counter) rather than the events silently not occurring.
- A `test-utils`-gated `first_audit_stats()` snapshot exposes the scheduler counters to e2e tests (they were previously created inside the drainer task and unobservable).

Audit coverage of the node's own pin is not reduced: a self-dial can never verify anything, while the payment's other payees each run the same cross-check on the same quote list and schedule their own first audit of this node (best-effort, as before).

## Evidence

Live-testnet e2e (multi-node in-process testnet, real QUIC wire, real LMDB, live drainer task):

- `first_audit_drainer_drops_self_targeting_monetized_pin`: a self event injected into the running drainer is ingested and dropped: `received: 1, self_target_skipped: 1, queued: 0, launched: 0`.
- `first_audit_drainer_launches_and_passes_remote_monetized_pin`: a remote peer's real commitment pin passes the filter and completes a passing live-wire subtree audit: `queued: 1, launched: 1, passed: 1`.
- Ablation (guard temporarily disabled, not committed): both test layers go red, and the e2e test reproduces the production bug exactly: `received: 1, queued: 1, launched: 1, timed_out: 1` — the node dialed itself and the instant `Peer not found` was recorded as an audit timeout.
- Unit tests cover the filter outcome directly (self dropped + pending untouched, remote unaffected, coalescing/eviction semantics unchanged).

An independent adversarial model review of the commit confirmed the filter is complete: the only production insertion into the pending queue is `queue_first_audit_event` (both receive arms), the cooldown re-put only recycles already-filtered events, and every other audit path (gossip-triggered, possession checks, prune confirmation) already self-excludes. Two low-severity notes from that review are addressed in this PR (live-drainer test coverage; comment wording on other-payee coverage being best-effort).

## Not included

Remote-peer `Peer not found` results are still classified as timeouts. Splitting those into a distinct unreachable outcome touches audit failure classification and is left for a follow-up.

Semver: patch, internal behavior only (one new field in an internal summary log line; the stats accessor is test-utils-gated).