### PR TITLE
chore: add PR template and required CI checks (V2-719, V2-720)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+## Linear issue
+<!-- REQUIRED. Link the issue: an issue key like V2-123, or a linear.app URL.
+     CI blocks PRs with no linked Linear issue. -->
+
+## Risk tier
+<!-- Check exactly one. Boundary question: does this change node behavior, the wire
+     protocol, stored-data format, payments/economics, or the upgrade mechanism?
+     If yes -> T2/T3, and it rides the weekly release train.
+     If no  -> T0/T1, and it may ship via the client track.
+     Propose the tier; a human confirms it at review. -->
+- [ ] T0 — docs / tooling / CI / pure UX-output. Repo CI only.
+- [ ] T1 — client-only, no network-facing behavior change. CI + prod compat smoke.
+- [ ] T2 — node/client logic with behavioral surface, no protocol/format/economics change. Dev testnet + ADR.
+- [ ] T3 — protocol / storage format / payments / routing. T2 evidence + adversarial testing.
+
+## Compatibility
+<!-- State the impact on each axis, or "none". -->
+- Wire:
+- Storage:
+- API:
+
+## Semver impact
+<!-- Check exactly one. This is where the crate's bump level is decided, while the
+     context is fresh; the train-manifest skill maps it to a per-crate version bump. -->
+- [ ] breaking
+- [ ] feature
+- [ ] fix
+
+## Test evidence
+<!-- Per the tier: what was run, at what scale, and the result. Attach or link artifacts. -->
+
+## New dependency
+<!-- Any new external dependency? Write "none", or list them. New deps need explicit
+     human acknowledgement in review. -->
+
+## ADR
+<!-- REQUIRED for Tier 2/3 — link the ADR. Write "n/a" for Tier 0/1. -->
+
+## Mitigation / rollback
+<!-- One line: how we back this out or limit the blast radius if it misbehaves. -->

--- a/.github/scripts/check_pr.py
+++ b/.github/scripts/check_pr.py
@@ -31,7 +31,12 @@ LINEAR_TEAM_PREFIXES = ("V2", "AUTO", "REL", "INFRA", "QA")
 LINEAR_KEY = re.compile(
     r"\b(?:" + "|".join(LINEAR_TEAM_PREFIXES) + r")-[0-9]+\b", re.IGNORECASE
 )
-LINEAR_URL = re.compile(r"linear\.app/", re.IGNORECASE)
+# A real Linear issue URL: linear.app/<workspace>/issue/<KEY>[/<slug>]. Constrained
+# to the /issue/<key> path so generic pages (linear.app/changelog,
+# linear.app/not-an-issue) do not count as a linked issue.
+LINEAR_URL = re.compile(
+    r"linear\.app/[^/\s]+/issue/[A-Za-z][A-Za-z0-9]*-[0-9]+", re.IGNORECASE
+)
 
 # Canonical section headings, exactly as they appear in the template, keyed by
 # their lower-cased form. Used so failure messages name the real heading.
@@ -99,8 +104,8 @@ def check_linear():
         "❌ No linked Linear issue found.\n\n"
         "Every PR must reference a Linear issue — an issue key ("
         + " / ".join(f"{p}-123" for p in LINEAR_TEAM_PREFIXES)
-        + ") in the PR title, body, or branch name, or a linear.app issue URL in\n"
-        "the body. Add it to the '## Linear issue' section and update the PR."
+        + "), or a linear.app/<workspace>/issue/<key> URL — in the PR title, body,\n"
+        "or branch name. Add it to the '## Linear issue' section and update the PR."
     )
 
 

--- a/.github/scripts/check_pr.py
+++ b/.github/scripts/check_pr.py
@@ -20,14 +20,31 @@ import os
 import re
 import sys
 
-# A Linear issue key (e.g. V2-123, ENG-45) or a linear.app URL. The key pattern
-# is deliberately broad and case-insensitive so it also matches Linear-generated
-# branch names (which are lower-cased, e.g. chrisoneil/v2-720-...). It can match
-# the odd technical token like "UTF-8"; that permeability is acceptable for a
-# gate backed by human review and the train-manifest verification, and it keeps
-# false negatives (blocking a legitimate PR) rare.
-LINEAR_KEY = re.compile(r"\b[A-Za-z][A-Za-z0-9]*-[0-9]+\b")
+# Known Linear team keys (the issue-key prefixes). A Linear reference is a URL
+# under linear.app OR an issue key with one of these prefixes — this is what
+# keeps unrelated technical tokens like "UTF-8" / "SHA-256" / "RFC-123" from
+# satisfying the gate. Add a new team's key here when a team is created.
+LINEAR_TEAM_PREFIXES = ("V2", "AUTO", "REL", "INFRA", "QA")
+
+# Case-insensitive so it also matches Linear-generated branch names, which are
+# lower-cased (e.g. chrisoneil/v2-720-...).
+LINEAR_KEY = re.compile(
+    r"\b(?:" + "|".join(LINEAR_TEAM_PREFIXES) + r")-[0-9]+\b", re.IGNORECASE
+)
 LINEAR_URL = re.compile(r"linear\.app/", re.IGNORECASE)
+
+# Canonical section headings, exactly as they appear in the template, keyed by
+# their lower-cased form. Used so failure messages name the real heading.
+CANONICAL_HEADINGS = {
+    "linear issue": "Linear issue",
+    "risk tier": "Risk tier",
+    "compatibility": "Compatibility",
+    "semver impact": "Semver impact",
+    "test evidence": "Test evidence",
+    "new dependency": "New dependency",
+    "adr": "ADR",
+    "mitigation / rollback": "Mitigation / rollback",
+}
 
 
 def env(name):
@@ -45,11 +62,13 @@ def ok(msg):
 
 
 def strip_comments(text):
-    """Remove HTML comments so template scaffolding does not count as content."""
+    """Remove HTML comments so template scaffolding and its examples (e.g. the
+    'V2-123' hint in the Linear-issue comment) never count as real content."""
     return re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
 
 
-def has_linear_ref(*parts):
+def linear_ref(*parts):
+    """Return the first Linear URL/key found in the given (comment-free) parts."""
     haystack = "\n".join(parts)
     m = LINEAR_URL.search(haystack) or LINEAR_KEY.search(haystack)
     return m.group(0) if m else None
@@ -72,15 +91,16 @@ def sections(body):
 
 
 def check_linear():
-    ref = has_linear_ref(env("PR_TITLE"), env("PR_BODY"), env("PR_BRANCH"))
+    # Strip comments from the body so the template's own example does not count.
+    ref = linear_ref(env("PR_TITLE"), strip_comments(env("PR_BODY")), env("PR_BRANCH"))
     if ref:
         ok(f"✅ Linear reference found: {ref}")
     fail(
         "❌ No linked Linear issue found.\n\n"
-        "Every PR must reference a Linear issue — an issue key like V2-123 in\n"
-        "the PR title, body, or branch name, or a linear.app link in the body.\n\n"
-        "Add it to the '## Linear issue' section of the PR description and update\n"
-        "the pull request."
+        "Every PR must reference a Linear issue — an issue key ("
+        + " / ".join(f"{p}-123" for p in LINEAR_TEAM_PREFIXES)
+        + ") in the PR title, body, or branch name, or a linear.app issue URL in\n"
+        "the body. Add it to the '## Linear issue' section and update the PR."
     )
 
 
@@ -103,18 +123,9 @@ def check_template():
             "template into the PR body and fill every field."
         )
 
-    for heading in (
-        "linear issue",
-        "risk tier",
-        "compatibility",
-        "semver impact",
-        "test evidence",
-        "new dependency",
-        "adr",
-        "mitigation / rollback",
-    ):
+    for heading in CANONICAL_HEADINGS:
         if heading not in secs:
-            errors.append(f"missing section: ## {heading.title()}")
+            errors.append(f"missing section: ## {CANONICAL_HEADINGS[heading]}")
 
     # Exactly one Risk tier box checked.
     tiers = re.findall(
@@ -140,26 +151,30 @@ def check_template():
     # Free-text sections that must not be empty.
     for heading in ("test evidence", "new dependency", "mitigation / rollback"):
         if heading in secs and not strip_comments(secs[heading]).strip():
-            errors.append(f"'## {heading.title()}' is empty")
+            errors.append(f"'## {CANONICAL_HEADINGS[heading]}' is empty")
 
-    # Compatibility: at least one axis filled (a value after the colon).
+    # Compatibility: every axis must carry a value (use 'none' where N/A).
+    # Use [ \t] rather than \s after the colon so an empty axis cannot "borrow"
+    # the next line's content across a newline.
     comp = strip_comments(secs.get("compatibility", ""))
-    if not re.search(r"^\s*-\s*(Wire|Storage|API)\s*:\s*\S", comp, re.MULTILINE):
-        errors.append(
-            "'## Compatibility': fill at least one of Wire/Storage/API (use 'none')"
-        )
+    for axis in ("Wire", "Storage", "API"):
+        if not re.search(rf"^[ \t]*-[ \t]*{axis}[ \t]*:[ \t]*\S", comp, re.MULTILINE):
+            errors.append(
+                f"'## Compatibility': fill in {axis} (use 'none' if not applicable)"
+            )
 
-    # Linear reference present in its own section.
-    if "linear issue" in secs and not has_linear_ref(
-        strip_comments(secs["linear issue"])
-    ):
+    # Linear reference present in its own section (comments stripped).
+    if "linear issue" in secs and not linear_ref(strip_comments(secs["linear issue"])):
         errors.append("'## Linear issue': add the issue key or a linear.app link")
 
-    # ADR required for Tier 2/3.
-    if tier in ("T2", "T3"):
-        adr = strip_comments(secs.get("adr", ""))
-        if not re.search(r"https?://", adr):
-            errors.append(f"ADR is required for {tier}: add an ADR link in '## ADR'")
+    # ADR must be filled explicitly: 'n/a' for T0/T1, a link for T2/T3.
+    adr = strip_comments(secs.get("adr", "")).strip()
+    if not adr:
+        errors.append(
+            "'## ADR' is empty: write 'n/a' for Tier 0/1, or an ADR link for Tier 2/3"
+        )
+    elif tier in ("T2", "T3") and not re.search(r"https?://", adr):
+        errors.append(f"ADR is required for {tier}: add an ADR link in '## ADR'")
 
     if errors:
         fail(

--- a/.github/scripts/check_pr.py
+++ b/.github/scripts/check_pr.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Release-process PR checks.
+
+Two modes, each wired to its own required status check:
+
+  check_pr.py linear     V2-720 — require a linked Linear issue on every PR
+                         (main + rc-*).
+  check_pr.py template   V2-719 — require the standard PR template to be present
+                         and fully filled (enforced on PRs targeting main; a
+                         no-op that passes on rc-* so hotfix/regression PRs are
+                         not forced to carry the full template).
+
+PR fields are read from the environment (set by the workflow from the event
+payload): PR_TITLE, PR_BODY, PR_BRANCH, PR_BASE.
+
+This file is duplicated verbatim across the six crate repos; keep them
+identical when updating.
+"""
+import os
+import re
+import sys
+
+# A Linear issue key (e.g. V2-123, ENG-45) or a linear.app URL. The key pattern
+# is deliberately broad and case-insensitive so it also matches Linear-generated
+# branch names (which are lower-cased, e.g. chrisoneil/v2-720-...). It can match
+# the odd technical token like "UTF-8"; that permeability is acceptable for a
+# gate backed by human review and the train-manifest verification, and it keeps
+# false negatives (blocking a legitimate PR) rare.
+LINEAR_KEY = re.compile(r"\b[A-Za-z][A-Za-z0-9]*-[0-9]+\b")
+LINEAR_URL = re.compile(r"linear\.app/", re.IGNORECASE)
+
+
+def env(name):
+    return os.environ.get(name, "") or ""
+
+
+def fail(msg):
+    print(msg)
+    sys.exit(1)
+
+
+def ok(msg):
+    print(msg)
+    sys.exit(0)
+
+
+def strip_comments(text):
+    """Remove HTML comments so template scaffolding does not count as content."""
+    return re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
+
+
+def has_linear_ref(*parts):
+    haystack = "\n".join(parts)
+    m = LINEAR_URL.search(haystack) or LINEAR_KEY.search(haystack)
+    return m.group(0) if m else None
+
+
+def sections(body):
+    """Split a markdown body into {heading-lowercased: text-until-next-##}."""
+    result, current, buf = {}, None, []
+    for line in body.splitlines():
+        m = re.match(r"^\s*##\s+(.*?)\s*$", line)
+        if m:
+            if current is not None:
+                result[current] = "\n".join(buf)
+            current, buf = m.group(1).strip().lower(), []
+        elif current is not None:
+            buf.append(line)
+    if current is not None:
+        result[current] = "\n".join(buf)
+    return result
+
+
+def check_linear():
+    ref = has_linear_ref(env("PR_TITLE"), env("PR_BODY"), env("PR_BRANCH"))
+    if ref:
+        ok(f"✅ Linear reference found: {ref}")
+    fail(
+        "❌ No linked Linear issue found.\n\n"
+        "Every PR must reference a Linear issue — an issue key like V2-123 in\n"
+        "the PR title, body, or branch name, or a linear.app link in the body.\n\n"
+        "Add it to the '## Linear issue' section of the PR description and update\n"
+        "the pull request."
+    )
+
+
+def check_template():
+    base = env("PR_BASE")
+    if base and base != "main":
+        ok(f"✅ pr-template not enforced on base '{base}' (main only).")
+
+    body = env("PR_BODY")
+    secs = sections(body)
+    errors = []
+
+    # The Risk tier / Semver impact headings are the sentinels that the template
+    # is actually in use.
+    if "risk tier" not in secs or "semver impact" not in secs:
+        fail(
+            "❌ PR template not detected.\n\n"
+            "Your PR description must use .github/PULL_REQUEST_TEMPLATE.md (the\n"
+            "'## Risk tier' and '## Semver impact' sections are missing). Copy the\n"
+            "template into the PR body and fill every field."
+        )
+
+    for heading in (
+        "linear issue",
+        "risk tier",
+        "compatibility",
+        "semver impact",
+        "test evidence",
+        "new dependency",
+        "adr",
+        "mitigation / rollback",
+    ):
+        if heading not in secs:
+            errors.append(f"missing section: ## {heading.title()}")
+
+    # Exactly one Risk tier box checked.
+    tiers = re.findall(
+        r"^\s*-\s*\[[xX]\]\s*(T[0-3])\b", secs.get("risk tier", ""), re.MULTILINE
+    )
+    if len(tiers) != 1:
+        errors.append(
+            f"Risk tier: check exactly one box (found {len(tiers)} checked)"
+        )
+    tier = tiers[0] if len(tiers) == 1 else None
+
+    # Exactly one Semver impact box checked.
+    semver = re.findall(
+        r"^\s*-\s*\[[xX]\]\s*(breaking|feature|fix)\b",
+        secs.get("semver impact", ""),
+        re.MULTILINE | re.IGNORECASE,
+    )
+    if len(semver) != 1:
+        errors.append(
+            f"Semver impact: check exactly one box (found {len(semver)} checked)"
+        )
+
+    # Free-text sections that must not be empty.
+    for heading in ("test evidence", "new dependency", "mitigation / rollback"):
+        if heading in secs and not strip_comments(secs[heading]).strip():
+            errors.append(f"'## {heading.title()}' is empty")
+
+    # Compatibility: at least one axis filled (a value after the colon).
+    comp = strip_comments(secs.get("compatibility", ""))
+    if not re.search(r"^\s*-\s*(Wire|Storage|API)\s*:\s*\S", comp, re.MULTILINE):
+        errors.append(
+            "'## Compatibility': fill at least one of Wire/Storage/API (use 'none')"
+        )
+
+    # Linear reference present in its own section.
+    if "linear issue" in secs and not has_linear_ref(
+        strip_comments(secs["linear issue"])
+    ):
+        errors.append("'## Linear issue': add the issue key or a linear.app link")
+
+    # ADR required for Tier 2/3.
+    if tier in ("T2", "T3"):
+        adr = strip_comments(secs.get("adr", ""))
+        if not re.search(r"https?://", adr):
+            errors.append(f"ADR is required for {tier}: add an ADR link in '## ADR'")
+
+    if errors:
+        fail(
+            "❌ PR template incomplete:\n"
+            + "\n".join(f"  - {e}" for e in errors)
+            + "\n\nFill in .github/PULL_REQUEST_TEMPLATE.md completely and update the PR."
+        )
+    ok(f"✅ PR template complete (tier {tier}).")
+
+
+def main():
+    mode = sys.argv[1] if len(sys.argv) > 1 else ""
+    if mode == "linear":
+        check_linear()
+    elif mode == "template":
+        check_template()
+    else:
+        fail(f"usage: check_pr.py [linear|template] (got: {mode!r})")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_check_pr.py
+++ b/.github/scripts/test_check_pr.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Test matrix for check_pr.py — runs the real checker as a subprocess against a
+set of PR fields and asserts the pass/fail outcome. No third-party deps; run with
+`python3 .github/scripts/test_check_pr.py` (also executed by the pr-checks
+workflow's self-test job).
+
+This file is duplicated verbatim across the six crate repos; keep it identical.
+"""
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+CHECKER = os.path.join(HERE, "check_pr.py")
+
+VALID_BODY = """\
+## Linear issue
+- https://linear.app/autonominetwork/issue/V2-719/add-the-standard-pr-template
+
+## Risk tier
+- [x] T0 — docs / tooling / CI.
+
+## Compatibility
+- Wire: none
+- Storage: none
+- API: none
+
+## Semver impact
+- [x] fix
+
+## Test evidence
+Ran the checker test matrix; all cases pass.
+
+## New dependency
+none
+
+## ADR
+n/a
+
+## Mitigation / rollback
+Revert the PR.
+"""
+
+
+def body_without(section_swap):
+    """Return VALID_BODY with a section's content replaced (old -> new)."""
+    old, new = section_swap
+    assert old in VALID_BODY, old
+    return VALID_BODY.replace(old, new)
+
+
+# Unfilled template: the only Linear-looking token is the example in a comment.
+UNFILLED = """\
+## Linear issue
+<!-- REQUIRED. Link the issue: an issue key like V2-123, or a linear.app URL. -->
+## Risk tier
+- [ ] T0
+## Semver impact
+- [ ] fix
+"""
+
+# (name, mode, env, expected_exit)
+CASES = [
+    # --- linear-link: rejections ---
+    ("linear: UTF-8 only", "linear", {"PR_TITLE": "fix UTF-8", "PR_BRANCH": "fix/utf8"}, 1),
+    ("linear: SHA-256 / RFC-123", "linear", {"PR_TITLE": "SHA-256 RFC-123", "PR_BRANCH": "x"}, 1),
+    ("linear: linear.app/changelog", "linear", {"PR_BODY": "see https://linear.app/changelog", "PR_BRANCH": "x"}, 1),
+    ("linear: linear.app/not-an-issue", "linear", {"PR_BODY": "https://linear.app/not-an-issue", "PR_BRANCH": "x"}, 1),
+    ("linear: unfilled template (example in comment)", "linear", {"PR_BODY": UNFILLED, "PR_BRANCH": "x"}, 1),
+    # --- linear-link: acceptances ---
+    ("linear: issue URL in body", "linear", {"PR_BODY": "https://linear.app/autonominetwork/issue/V2-719/foo"}, 0),
+    ("linear: key in branch (lowercased)", "linear", {"PR_BRANCH": "chrisoneil/v2-720-ci-check"}, 0),
+    ("linear: key in title", "linear", {"PR_TITLE": "AUTO-42 do the thing", "PR_BRANCH": "x"}, 0),
+    # --- pr-template: acceptances ---
+    ("template: valid T0 body", "template", {"PR_BASE": "main", "PR_BODY": VALID_BODY}, 0),
+    ("template: rc-* base is a no-op pass", "template", {"PR_BASE": "rc-2025.10", "PR_BODY": "anything"}, 0),
+    ("template: T2 with ADR link", "template", {"PR_BASE": "main", "PR_BODY": body_without(
+        ("- [x] T0 — docs / tooling / CI.", "- [x] T2 — behavioural.")).replace(
+        "n/a", "https://github.com/x/adr/0001.md")}, 0),
+    # --- pr-template: rejections ---
+    ("template: not the template", "template", {"PR_BASE": "main", "PR_BODY": "freeform text"}, 1),
+    ("template: only Wire axis filled", "template", {"PR_BASE": "main", "PR_BODY": body_without(
+        ("- Storage: none\n- API: none", "- Storage:\n- API:"))}, 1),
+    ("template: empty ADR (T0)", "template", {"PR_BASE": "main", "PR_BODY": body_without(("n/a", ""))}, 1),
+    ("template: T2 with ADR n/a (no link)", "template", {"PR_BASE": "main", "PR_BODY": body_without(
+        ("- [x] T0 — docs / tooling / CI.", "- [x] T2 — behavioural."))}, 1),
+    ("template: no tier checked", "template", {"PR_BASE": "main", "PR_BODY": body_without(
+        ("- [x] T0 — docs / tooling / CI.", "- [ ] T0 — docs / tooling / CI."))}, 1),
+    ("template: two tiers checked", "template", {"PR_BASE": "main", "PR_BODY": body_without(
+        ("- [x] T0 — docs / tooling / CI.", "- [x] T0 a\n- [x] T2 b"))}, 1),
+]
+
+
+def run(mode, env):
+    full = dict(os.environ)
+    for k in ("PR_TITLE", "PR_BODY", "PR_BRANCH", "PR_BASE"):
+        full.pop(k, None)
+    full.update(env)
+    return subprocess.run(
+        [sys.executable, CHECKER, mode], env=full, capture_output=True, text=True
+    ).returncode
+
+
+def main():
+    failures = 0
+    for name, mode, env, expected in CASES:
+        got = run(mode, env)
+        status = "ok" if got == expected else "FAIL"
+        if got != expected:
+            failures += 1
+        print(f"[{status}] {name} (mode={mode}, expected={expected}, got={got})")
+    print(f"\n{len(CASES) - failures}/{len(CASES)} cases passed")
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,42 @@
+# Release-process PR checks (Linear link + PR template).
+# Issues: V2-720 (linear-link) and V2-719 (pr-template).
+# This file is intentionally duplicated verbatim across the six crate repos;
+# keep them identical when updating.
+name: pr-checks
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches:
+      - main
+      - 'rc-*'
+
+permissions:
+  contents: read
+
+jobs:
+  linear-link:
+    name: linear-link
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Require a linked Linear issue
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_BASE: ${{ github.base_ref }}
+        run: python3 .github/scripts/check_pr.py linear
+
+  pr-template:
+    name: pr-template
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Require the PR template fields
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_BASE: ${{ github.base_ref }}
+        run: python3 .github/scripts/check_pr.py template

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,7 +6,7 @@ name: pr-checks
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
     branches:
       - main
       - 'rc-*'

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -40,3 +40,11 @@ jobs:
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}
           PR_BASE: ${{ github.base_ref }}
         run: python3 .github/scripts/check_pr.py template
+
+  self-test:
+    name: self-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run the checker's test matrix
+        run: python3 .github/scripts/test_check_pr.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,3 +106,20 @@ on startup when no `--bootstrap` CLI argument is provided.
 1. Verify you're targeting ports 10000-10999 only
 2. Double-check service names contain "ant-node"
 3. Never run broad `pkill` commands that could affect other services
+
+## Pull requests: fill the template
+
+When you open a pull request, you MUST use `.github/PULL_REQUEST_TEMPLATE.md` as
+the PR body and fill it in completely — do not open a PR with an empty or ad-hoc
+description.
+
+- **Fill every field.** Leave nothing blank; if a value isn't determinable, ask
+  before opening the PR.
+- **Link the Linear issue** — an issue key like `V2-123` or a `linear.app` URL.
+  CI blocks PRs with no linked Linear issue.
+- **Check exactly one Risk tier box and exactly one Semver impact box.** Propose
+  them from the change; a human confirms them at review.
+- An **ADR link is required for Tier 2/3**.
+
+CI enforces the Linear link and the template fields (`linear-link` and
+`pr-template` status checks); a PR that omits them fails its checks.


### PR DESCRIPTION
## Linear issue
- https://linear.app/autonominetwork/issue/V2-719 (add the standard PR template)
- https://linear.app/autonominetwork/issue/V2-720 (require a linked Linear issue on every PR)

## Risk tier
- [x] T0 — docs / tooling / CI / pure UX-output. Repo CI only.
- [ ] T1 — client-only, no network-facing behavior change. CI + prod compat smoke.
- [ ] T2 — node/client logic with behavioral surface, no protocol/format/economics change. Dev testnet + ADR.
- [ ] T3 — protocol / storage format / payments / routing. T2 evidence + adversarial testing.

## Compatibility
- Wire: none
- Storage: none
- API: none

## Semver impact
- [ ] breaking
- [ ] feature
- [x] fix

## Test evidence
`check_pr.py` was exercised locally across its cases: missing Linear reference
fails `linear`; a key in the title/body/branch passes; a body without the
template fails `template`; an rc-* base is a no-op pass; a fully-filled template
passes; and the failure modes (no/duplicate tier or semver box, empty section,
Tier 2/3 without an ADR link) each fail with a specific message. This PR's own
description is validated by the new checks.

## New dependency
none

## ADR
n/a

## Mitigation / rollback
Revert this PR; the template and checks are additive and carry no runtime effect.
