### PR TITLE
Reduce storage-commitment audit egress by verifying co-held leaves locally

### DIFF
--- a/src/replication/audit.rs
+++ b/src/replication/audit.rs
@@ -48,7 +48,11 @@ pub enum AuditTickResult {
         /// The peer claiming bootstrap status.
         peer: PeerId,
     },
-    /// No eligible peers for audit this tick.
+    /// No eligible peers for audit this tick, OR the auditor could not run a
+    /// meaningful check (e.g. the responsible-chunk audit found every sampled
+    /// key's own local copy unreadable). Nothing was proven either way: no
+    /// holder credit, no trust event, no penalty. The audit simply did not
+    /// happen this tick, exactly like having no peer to audit.
     Idle,
     /// Audit skipped (not enough local keys).
     InsufficientKeys,
@@ -535,62 +539,155 @@ async fn verify_digests(
     }
 
     let challenged_peer_bytes = challenged_peer.as_bytes();
-    let mut failed_keys = Vec::new();
-
+    let mut checks = Vec::with_capacity(keys.len());
     for (i, key) in keys.iter().enumerate() {
-        let received_digest = &digests[i];
-
-        // Check for absent sentinel.
-        if *received_digest == ABSENT_KEY_DIGEST {
-            failed_keys.push(AuditKeyFailure::absent(*key));
-            continue;
-        }
-
-        // Recompute expected digest from local copy.
+        // Read the local copy (logging the gone-vs-error distinction), then
+        // classify the peer's digest against it via the pure `classify_local_digest`.
         let local_bytes = match storage.get_raw(key).await {
-            Ok(Some(bytes)) => bytes,
+            Ok(Some(bytes)) => Some(bytes),
             Ok(None) => {
-                // We should hold this key (we sampled it), but it's gone.
                 warn!(
                     "Audit: local key {} disappeared during audit",
                     hex::encode(key)
                 );
-                continue;
+                None
             }
             Err(e) => {
                 warn!("Audit: failed to read local key {}: {e}", hex::encode(key));
-                continue;
+                None
             }
         };
+        checks.push(classify_local_digest(
+            &digests[i],
+            key,
+            nonce,
+            challenged_peer_bytes,
+            local_bytes.as_deref(),
+        ));
+    }
 
-        let expected = compute_audit_digest(nonce, challenged_peer_bytes, key, &local_bytes);
-        if *received_digest != expected {
-            failed_keys.push(AuditKeyFailure::digest_mismatch(*key));
+    match aggregate_digest_checks(challenged_peer, checks, keys.len()) {
+        // No key explicitly failed: Passed (all verified) or Idle (any skip).
+        Ok(verdict) => verdict,
+        // Step 9: responsibility confirmation for the failed keys.
+        Err(failed_keys) => {
+            handle_classified_audit_failure(
+                challenged_peer,
+                challenge_id,
+                &failed_keys,
+                AuditFailureReason::DigestMismatch,
+                keys.len(),
+                p2p_node,
+                config,
+            )
+            .await
         }
     }
+}
 
-    if failed_keys.is_empty() {
-        info!(
-            "Audit: peer {challenged_peer} passed (all {} keys verified)",
-            keys.len()
-        );
-        return AuditTickResult::Passed {
-            challenged_peer: *challenged_peer,
-            keys_checked: keys.len(),
-        };
+/// Fold per-key [`DigestCheck`] outcomes into the responsible-audit result.
+///
+/// `Ok` when NO key explicitly failed: `Passed` iff every key verified, else
+/// `Idle` (any key was skipped — the response was not fully verified, so it must
+/// not mint a pass; see [`no_failure_verdict`]). `Err(failed_keys)` when at
+/// least one key failed, for the caller's responsibility-confirmation path.
+///
+/// Pure, so the security-critical fold — a skipped key must count as `skipped`,
+/// never `verified` — is unit-tested without a live `P2PNode`.
+fn aggregate_digest_checks(
+    challenged_peer: &PeerId,
+    checks: Vec<DigestCheck>,
+    challenged: usize,
+) -> Result<AuditTickResult, Vec<AuditKeyFailure>> {
+    let mut verified = 0usize;
+    let mut skipped = 0usize;
+    let mut failed_keys = Vec::new();
+    for check in checks {
+        match check {
+            DigestCheck::Verified => verified += 1,
+            DigestCheck::Skipped => skipped += 1,
+            DigestCheck::Failed(f) => failed_keys.push(f),
+        }
     }
+    if failed_keys.is_empty() {
+        Ok(no_failure_verdict(
+            challenged_peer,
+            challenged,
+            verified,
+            skipped,
+        ))
+    } else {
+        Err(failed_keys)
+    }
+}
 
-    // Step 9: Responsibility confirmation for failed keys.
-    handle_classified_audit_failure(
-        challenged_peer,
-        challenge_id,
-        &failed_keys,
-        AuditFailureReason::DigestMismatch,
-        keys.len(),
-        p2p_node,
-        config,
-    )
-    .await
+/// Outcome of checking one challenged key's digest against the auditor's own copy.
+#[cfg_attr(test, derive(Debug))]
+enum DigestCheck {
+    /// The peer's digest matches the digest recomputed from local bytes.
+    Verified,
+    /// The auditor's own copy was unreadable, so the peer's digest for this key
+    /// could not be checked. Not the peer's fault; not a pass either.
+    Skipped,
+    /// A provable failure: the absent sentinel, or a digest that disagrees with
+    /// the local copy.
+    Failed(AuditKeyFailure),
+}
+
+/// Classify one challenged key's response against the auditor's local copy.
+///
+/// `local_bytes` is `None` when the auditor's own copy is unreadable (gone or a
+/// read error) — the peer's digest is then unverifiable, so the key is
+/// [`DigestCheck::Skipped`], never silently treated as a pass. The absent
+/// sentinel and a digest that disagrees with the local bytes are provable
+/// failures.
+fn classify_local_digest(
+    received_digest: &[u8; 32],
+    key: &XorName,
+    nonce: &[u8; 32],
+    challenged_peer_bytes: &[u8; 32],
+    local_bytes: Option<&[u8]>,
+) -> DigestCheck {
+    if *received_digest == ABSENT_KEY_DIGEST {
+        return DigestCheck::Failed(AuditKeyFailure::absent(*key));
+    }
+    let Some(bytes) = local_bytes else {
+        return DigestCheck::Skipped;
+    };
+    if *received_digest == compute_audit_digest(nonce, challenged_peer_bytes, key, bytes) {
+        DigestCheck::Verified
+    } else {
+        DigestCheck::Failed(AuditKeyFailure::digest_mismatch(*key))
+    }
+}
+
+/// Decide the verdict of a responsible-chunk audit when NO key explicitly
+/// failed (no absent sentinel, no digest mismatch on a readable key).
+///
+/// A `Passed` here means "the whole response was verified against local bytes".
+/// If any key was `skipped` (its own local copy was unreadable, so the peer's
+/// digest for it could not be checked), the response was NOT fully verified, so
+/// the tick yields no verdict (`Idle`: no success trust event, no penalty)
+/// rather than a pass reflecting only the keys that were readable. `verified ==
+/// 0` (nothing readable at all) is the same no-verdict case.
+fn no_failure_verdict(
+    challenged_peer: &PeerId,
+    challenged: usize,
+    verified: usize,
+    skipped: usize,
+) -> AuditTickResult {
+    if skipped > 0 || verified == 0 {
+        warn!(
+            "Audit: {skipped} of {challenged} challenged keys for {challenged_peer} were \
+             locally unverifiable; audit did not conclude this tick (Idle, no verdict)"
+        );
+        return AuditTickResult::Idle;
+    }
+    info!("Audit: peer {challenged_peer} passed (all {verified} keys verified)");
+    AuditTickResult::Passed {
+        challenged_peer: *challenged_peer,
+        keys_checked: verified,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -874,6 +971,139 @@ mod tests {
     /// Build a `PeerId` matching the raw bytes used in a challenge.
     fn peer_id_from_bytes(bytes: [u8; 32]) -> PeerId {
         PeerId::from_bytes(bytes)
+    }
+
+    // -- classify_local_digest: per-key skip/verify/fail accounting -----------
+
+    #[test]
+    fn classify_local_digest_verified_on_matching_local_bytes() {
+        let (key, nonce, peer, bytes) = ([1u8; 32], [2u8; 32], [3u8; 32], b"chunk-bytes");
+        let good = compute_audit_digest(&nonce, &peer, &key, bytes);
+        assert!(matches!(
+            classify_local_digest(&good, &key, &nonce, &peer, Some(bytes)),
+            DigestCheck::Verified
+        ));
+    }
+
+    #[test]
+    fn classify_local_digest_skipped_when_local_copy_unreadable() {
+        // When a key's own local copy is unreadable, its digest cannot be
+        // checked, so the outcome is Skipped (not Verified) regardless of the
+        // received digest value. no_failure_verdict then turns any skip into
+        // Idle, so an unverified key never contributes to a pass.
+        let (key, nonce, peer) = ([1u8; 32], [2u8; 32], [3u8; 32]);
+        let unchecked = [0xAB; 32];
+        assert!(matches!(
+            classify_local_digest(&unchecked, &key, &nonce, &peer, None),
+            DigestCheck::Skipped
+        ));
+    }
+
+    #[test]
+    fn classify_local_digest_failed_on_digest_mismatch() {
+        let (key, nonce, peer, bytes) = ([1u8; 32], [2u8; 32], [3u8; 32], b"chunk-bytes");
+        let wrong = [0xCD; 32];
+        assert!(matches!(
+            classify_local_digest(&wrong, &key, &nonce, &peer, Some(bytes)),
+            DigestCheck::Failed(_)
+        ));
+    }
+
+    #[test]
+    fn classify_local_digest_absent_sentinel_fails_even_when_local_unreadable() {
+        // Precedence: the peer's explicit admission of absence is a provable
+        // failure that must NOT be downgraded to `Skipped` just because the
+        // auditor's own copy is also unreadable (`None`). Absent is checked
+        // before the local read.
+        let (key, nonce, peer) = ([1u8; 32], [2u8; 32], [3u8; 32]);
+        match classify_local_digest(&ABSENT_KEY_DIGEST, &key, &nonce, &peer, None) {
+            DigestCheck::Failed(f) => assert_eq!(f.kind, AuditKeyFailureKind::Absent),
+            other => panic!("absent sentinel must fail, got {other:?}"),
+        }
+    }
+
+    // -- aggregate_digest_checks: the composed fold verify_digests uses --------
+
+    fn peer() -> PeerId {
+        peer_id_from_bytes([0x44; 32])
+    }
+
+    #[test]
+    fn aggregate_all_verified_is_passed() {
+        let checks = vec![DigestCheck::Verified, DigestCheck::Verified];
+        assert!(matches!(
+            aggregate_digest_checks(&peer(), checks, 2),
+            Ok(AuditTickResult::Passed {
+                keys_checked: 2,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn aggregate_verified_plus_skipped_is_idle_not_passed() {
+        // The composition the split helpers alone do not cover: if any key was
+        // skipped, the fold must return Idle (not Passed), so a skipped key is
+        // never counted as verified.
+        let checks = vec![DigestCheck::Verified, DigestCheck::Skipped];
+        assert!(matches!(
+            aggregate_digest_checks(&peer(), checks, 2),
+            Ok(AuditTickResult::Idle)
+        ));
+    }
+
+    #[test]
+    fn aggregate_any_failed_returns_failed_keys_for_confirmation() {
+        let bad = [9u8; 32];
+        let checks = vec![
+            DigestCheck::Verified,
+            DigestCheck::Failed(AuditKeyFailure::digest_mismatch(bad)),
+        ];
+        match aggregate_digest_checks(&peer(), checks, 2) {
+            Err(failed) => {
+                assert_eq!(failed.len(), 1);
+                assert_eq!(failed[0].key, bad);
+                assert_eq!(failed[0].kind, AuditKeyFailureKind::DigestMismatch);
+            }
+            Ok(v) => panic!("a failed key must not yield a verdict, got {v:?}"),
+        }
+    }
+
+    // -- no_failure_verdict: a partial local-read failure must not mint a pass --
+
+    #[test]
+    fn no_failure_verdict_passes_only_when_every_key_verified() {
+        let peer = peer_id_from_bytes([0x11; 32]);
+        // All three challenged keys verified, none skipped -> Passed.
+        assert!(matches!(
+            no_failure_verdict(&peer, 3, 3, 0),
+            AuditTickResult::Passed {
+                keys_checked: 3,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn no_failure_verdict_is_idle_when_any_key_skipped() {
+        let peer = peer_id_from_bytes([0x22; 32]);
+        // One key verified, one skipped (its local copy was unreadable, so its
+        // digest could not be checked). The response was not fully verified, so
+        // the verdict is Idle rather than a pass over only the readable key.
+        assert!(matches!(
+            no_failure_verdict(&peer, 2, 1, 1),
+            AuditTickResult::Idle
+        ));
+    }
+
+    #[test]
+    fn no_failure_verdict_is_idle_when_nothing_verified() {
+        let peer = peer_id_from_bytes([0x33; 32]);
+        // Every local read skipped: nothing proven either way -> no verdict.
+        assert!(matches!(
+            no_failure_verdict(&peer, 2, 0, 2),
+            AuditTickResult::Idle
+        ));
     }
 
     // -- handle_audit_challenge: present keys ---------------------------------

--- a/src/replication/commitment_state.rs
+++ b/src/replication/commitment_state.rs
@@ -405,6 +405,15 @@ impl PersistedRetention {
 /// it gets gossiped. Rotation and gossip are the only paths that mutate this.
 pub struct ResponderCommitmentState {
     inner: RwLock<Inner>,
+    /// Test-only: `(pinned commitment hash, keys)` of each round-2
+    /// `SubtreeByteChallenge` this responder received. Lets an e2e test assert
+    /// that co-held sampled leaves are verified LOCALLY by the auditor (so this
+    /// responder receives NO byte challenge for them — the egress saving),
+    /// CORRELATED to a specific audited commitment (a freshly-rebuilt commitment
+    /// held by only one auditor pins uniquely to that auditor's audit). Never
+    /// read or written in production builds.
+    #[cfg(any(test, feature = "test-utils"))]
+    observed_byte_challenges: RwLock<Vec<([u8; 32], Vec<XorName>)>>,
 }
 
 /// A commitment hash that was emitted on the wire, with the monotonic instant at
@@ -460,7 +469,33 @@ impl ResponderCommitmentState {
                 has_current: false,
                 recently_gossiped: Vec::with_capacity(RETAINED_GOSSIPED_COMMITMENTS),
             }),
+            #[cfg(any(test, feature = "test-utils"))]
+            observed_byte_challenges: RwLock::new(Vec::new()),
         }
+    }
+
+    /// Test-only: record an incoming round-2 byte challenge for `pin`.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn record_byte_challenge(&self, pin: [u8; 32], keys: &[XorName]) {
+        self.observed_byte_challenges
+            .write()
+            .push((pin, keys.to_vec()));
+    }
+
+    /// Test-only: the distinct keys this responder has been asked to serve in
+    /// round-2 byte challenges pinned to `pin` since construction.
+    #[cfg(any(test, feature = "test-utils"))]
+    #[must_use]
+    pub fn byte_challenge_keys_for_pin(
+        &self,
+        pin: &[u8; 32],
+    ) -> std::collections::BTreeSet<XorName> {
+        self.observed_byte_challenges
+            .read()
+            .iter()
+            .filter(|(p, _)| p == pin)
+            .flat_map(|(_, keys)| keys.iter().copied())
+            .collect()
     }
 
     /// Rotate: the freshly-rebuilt commitment becomes `current`. Slots that are

--- a/src/replication/config.rs
+++ b/src/replication/config.rs
@@ -267,7 +267,12 @@ pub const PRUNE_HYSTERESIS_DURATION: Duration = Duration::from_secs(PRUNE_HYSTER
 /// half-interpreted exchange, no spurious eviction. Replication between
 /// matched-version peers is unaffected. (DHT routing/lookups are a separate
 /// protocol and continue to span both versions.)
-pub const REPLICATION_PROTOCOL_ID: &str = "autonomi.ant.replication.v2";
+/// v3: the possession digest (`compute_audit_digest`) became a keyed BLAKE3
+/// hash (the nonce enters every 1 KiB block via `derive_key`) instead of the
+/// old flat prefix hash. A v2 auditor would compute the old digest and read
+/// every v3 answer as a mismatch (and vice versa), so v2 and v3 nodes must not
+/// exchange replication traffic; same clean-cutover pattern as v1→v2.
+pub const REPLICATION_PROTOCOL_ID: &str = "autonomi.ant.replication.v3";
 
 /// 10 MiB — maximum replication wire message size (accommodates hint batches).
 const REPLICATION_MESSAGE_SIZE_MIB: usize = 10;
@@ -484,13 +489,13 @@ pub const FIRST_AUDIT_COUNT_JUMP_DEN: u64 = 2;
 /// its next settled payment re-nominates the paid pin.
 pub const FIRST_AUDIT_INGRESS_CAPACITY: usize = 1024;
 
-/// Number of subtree leaves spot-checked against real chunk bytes per audit
-/// (ADR-0002 real-bytes layer).
+/// Number of subtree leaves spot-checked per audit (ADR-0002 real-bytes layer).
 ///
-/// The auditor clamps this to its 3..=5 band (`BYTE_SPOTCHECK_MIN..=MAX` in
-/// `storage_commitment_audit`), so this is the effective MAXIMUM — set it
-/// within the band rather than advertising a sample size the auditor never
-/// requests.
+/// A sampled leaf the auditor co-holds is verified against its own bytes (zero
+/// egress); any other sampled leaf is wire-challenged. The auditor clamps this
+/// to its 3..=5 band (`BYTE_SPOTCHECK_MIN..=MAX` in `storage_commitment_audit`),
+/// so this is the effective MAXIMUM — set it within the band rather than
+/// advertising a sample size the auditor never requests.
 pub const AUDIT_SPOTCHECK_COUNT: u32 = 5;
 
 /// Conservative leaf-count hint for sizing the subtree-audit response deadline.
@@ -897,13 +902,14 @@ mod tests {
     }
 
     #[test]
-    fn replication_protocol_id_is_v2() {
-        // The v12 storage-bound audit changes replication SEMANTICS. The
-        // protocol id MUST advance past v1 so v1 and v2 nodes never exchange
-        // replication traffic they can only half-interpret (rollout safety —
-        // see the const's doc). If this regresses to v1, mixed-version nodes
-        // would talk past each other and risk spurious penalties.
-        assert_eq!(REPLICATION_PROTOCOL_ID, "autonomi.ant.replication.v2");
+    fn replication_protocol_id_is_v3() {
+        // The keyed possession digest changes replication SEMANTICS: a v2
+        // auditor computes the old flat digest and would read every v3 answer
+        // as a digest mismatch (a confirmed failure!). The protocol id MUST
+        // advance so v2 and v3 nodes never exchange replication traffic they
+        // can only half-interpret (rollout safety — see the const's doc). If
+        // this regresses, mixed-version nodes would risk spurious penalties.
+        assert_eq!(REPLICATION_PROTOCOL_ID, "autonomi.ant.replication.v3");
     }
 
     #[test]

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -1479,6 +1479,7 @@ impl ReplicationEngine {
             pin,
             key_count,
             Some(&credit),
+            &self.storage,
         )
         .await
     }
@@ -1769,6 +1770,7 @@ impl ReplicationEngine {
             config: Arc::clone(&self.config),
             recent_provers: Arc::clone(&self.recent_provers),
             sync_state: Arc::clone(&self.sync_state),
+            storage: Arc::clone(&self.storage),
             cooldown: Arc::clone(&self.audit_on_gossip_cooldown),
             lottery_attempts: Arc::clone(&self.gossip_lottery_attempts),
         };
@@ -1880,6 +1882,10 @@ impl ReplicationEngine {
                             let credit = storage_commitment_audit::AuditCredit {
                                 recent_provers: &trigger.recent_provers,
                             };
+                            // Monetized first audit: same run_subtree_audit as
+                            // the gossip path. Rare and budget-capped; it keeps
+                            // commitment inflation costing real storage at the
+                            // payment moment.
                             let result = storage_commitment_audit::run_subtree_audit(
                                 &trigger.p2p_node,
                                 &trigger.config,
@@ -1887,6 +1893,7 @@ impl ReplicationEngine {
                                 event.pin,
                                 event.key_count,
                                 Some(&credit),
+                                &trigger.storage,
                             )
                             .await;
                             let outcome = first_audit_terminal_outcome(&result);
@@ -2031,6 +2038,7 @@ impl ReplicationEngine {
             config: Arc::clone(&config),
             recent_provers: Arc::clone(&recent_provers),
             sync_state: Arc::clone(&sync_state),
+            storage: Arc::clone(&storage),
             cooldown: Arc::clone(&audit_on_gossip_cooldown),
             lottery_attempts: Arc::clone(&gossip_lottery_attempts),
         };
@@ -2201,6 +2209,7 @@ impl ReplicationEngine {
             config: Arc::clone(&config),
             recent_provers: Arc::clone(&self.recent_provers),
             sync_state: Arc::clone(&sync_state),
+            storage: Arc::clone(&self.storage),
             cooldown: Arc::clone(&self.audit_on_gossip_cooldown),
             lottery_attempts: Arc::clone(&self.gossip_lottery_attempts),
         };
@@ -5540,6 +5549,9 @@ async fn handle_audit_result(
                     .await;
             }
         }
+        // Idle also covers "every challenged key's local copy was unreadable"
+        // (the auditor's own storage trouble): nothing verified either way, no
+        // trust event, no bootstrap-claim change — it must not mint a pass.
         AuditTickResult::Idle | AuditTickResult::InsufficientKeys => {}
     }
 }
@@ -5587,6 +5599,9 @@ struct GossipAuditTrigger {
     config: Arc<ReplicationConfig>,
     recent_provers: Arc<RwLock<RecentProvers>>,
     sync_state: Arc<RwLock<NeighborSyncState>>,
+    /// This node's own chunk store: a sampled leaf the auditor co-holds is
+    /// verified against its own bytes (zero egress) instead of wire-challenged.
+    storage: Arc<LmdbStorage>,
     /// Shared "an audit actually launched" cooldown, consulted by BOTH the
     /// gossip-lottery path and the monetized first-audit scheduler. Stamped
     /// only when a real audit is about to be sent — never by a losing lottery
@@ -5741,6 +5756,9 @@ async fn maybe_trigger_gossip_audit(
         let credit = storage_commitment_audit::AuditCredit {
             recent_provers: &trigger.recent_provers,
         };
+        // Gossip-triggered audit of a self-close neighbour's commitment. A
+        // co-held sampled leaf is verified against our own bytes (zero egress);
+        // the rest are wire-challenged (see run_subtree_audit).
         let result = storage_commitment_audit::run_subtree_audit(
             &trigger.p2p_node,
             &trigger.config,
@@ -5748,6 +5766,7 @@ async fn maybe_trigger_gossip_audit(
             target.pin_hash,
             target.key_count,
             Some(&credit),
+            &trigger.storage,
         )
         .await;
         handle_subtree_audit_result(

--- a/src/replication/possession.rs
+++ b/src/replication/possession.rs
@@ -3,8 +3,8 @@
 //! After a node fresh-replicates a chunk, every close-group peer responsible
 //! for it is checked 5-15 minutes later for actual possession. The check is a
 //! single-key cryptographic
-//! [`AuditChallenge`]: the probed
-//! peer must return `BLAKE3(nonce ‖ peer_id ‖ key ‖ bytes)` computed over the
+//! [`AuditChallenge`]: the probed peer must return
+//! `compute_audit_digest(nonce, peer_id, key, bytes)` computed over the
 //! chunk it claims to hold. It cannot produce that digest without the bytes, so
 //! — unlike a self-reported presence flag — a peer cannot escape the check by
 //! falsely asserting possession. A peer that holds the chunk earns nothing —

--- a/src/replication/protocol.rs
+++ b/src/replication/protocol.rs
@@ -1023,11 +1023,24 @@ pub enum SubtreeByteResponse {
 // Audit digest helper
 // ---------------------------------------------------------------------------
 
-/// Compute `AuditKeyDigest(K_i) = BLAKE3(nonce || challenged_peer_id || K_i || record_bytes_i)`.
+/// Domain-separation context for the audit digest key derivation. Versioned
+/// with the replication protocol so no other BLAKE3 use in the codebase (or a
+/// future digest revision) can ever produce a colliding key from the same
+/// 96 bytes of challenge material.
+const AUDIT_DIGEST_KEY_CONTEXT: &str = "autonomi.ant.replication.v3.audit-digest-key";
+
+/// Compute the keyed possession digest.
 ///
-/// Returns the 32-byte BLAKE3 digest binding the nonce, peer identity, key,
-/// and record content together so a peer cannot forge proofs without holding
-/// the actual data.
+/// `BLAKE3_keyed(BLAKE3_derive_key(ctx, nonce || challenged_peer_id || K_i), record_bytes_i)`
+/// with `ctx` the versioned domain-separation string `AUDIT_DIGEST_KEY_CONTEXT`.
+/// Returns the 32-byte digest binding the nonce, peer identity, key, and
+/// record content together so a peer cannot forge proofs without holding the
+/// actual data.
+///
+/// The challenge context enters as the BLAKE3 *key*, not as an input prefix.
+/// In keyed mode the key replaces the IV of every 1 KiB block's compression, so
+/// every block's chaining value depends on the fresh nonce and the digest is
+/// bound to the challenge over the entire content.
 #[must_use]
 pub fn compute_audit_digest(
     nonce: &[u8; 32],
@@ -1035,12 +1048,12 @@ pub fn compute_audit_digest(
     key: &XorName,
     record_bytes: &[u8],
 ) -> [u8; 32] {
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(nonce);
-    hasher.update(challenged_peer_id);
-    hasher.update(key);
-    hasher.update(record_bytes);
-    *hasher.finalize().as_bytes()
+    let mut key_hasher = blake3::Hasher::new_derive_key(AUDIT_DIGEST_KEY_CONTEXT);
+    key_hasher.update(nonce);
+    key_hasher.update(challenged_peer_id);
+    key_hasher.update(key);
+    let digest_key = *key_hasher.finalize().as_bytes();
+    *blake3::keyed_hash(&digest_key, record_bytes).as_bytes()
 }
 
 // ---------------------------------------------------------------------------
@@ -1763,6 +1776,33 @@ mod tests {
         assert_ne!(
             digest_a, digest_b,
             "different keys must produce different digests"
+        );
+    }
+
+    #[test]
+    fn audit_digest_is_the_domain_separated_keyed_construction() {
+        // Pin the exact KEYED construction: the challenge context enters as the
+        // BLAKE3 key (mixed into every 1 KiB block's compression via
+        // `derive_key`), never as an input prefix. A regression to a flat
+        // `BLAKE3(nonce || ... || bytes)` prefix produces a different digest and
+        // fails this exact-equality check. Use a multi-block record so the
+        // block-key mixing is actually exercised past block 0.
+        let nonce = [0x01; 32];
+        let peer_id = [0x02; 32];
+        let key: XorName = [0x03; 32];
+        let record_bytes = vec![0x5A; 8 * 1024];
+
+        let mut key_hasher =
+            blake3::Hasher::new_derive_key("autonomi.ant.replication.v3.audit-digest-key");
+        key_hasher.update(&nonce);
+        key_hasher.update(&peer_id);
+        key_hasher.update(&key);
+        let digest_key = *key_hasher.finalize().as_bytes();
+        let keyed = *blake3::keyed_hash(&digest_key, &record_bytes).as_bytes();
+        assert_eq!(
+            compute_audit_digest(&nonce, &peer_id, &key, &record_bytes),
+            keyed,
+            "digest must be BLAKE3_keyed(derive_key(ctx, nonce||peer||key), bytes)"
         );
     }
 

--- a/src/replication/recent_provers.rs
+++ b/src/replication/recent_provers.rs
@@ -44,8 +44,9 @@ use crate::ant_protocol::XorName;
 
 /// Maximum number of cached provers per key.
 ///
-/// Sized at 2× `CLOSE_GROUP_SIZE = 8`, giving 8 slack slots for churn
-/// without unbounded growth. LRU-evicted within the cap.
+/// Comfortably above `CLOSE_GROUP_SIZE = 7` (a key has at most 7 responsible
+/// holders), leaving slack slots for churn without unbounded growth.
+/// LRU-evicted within the cap.
 pub const MAX_PROVERS_PER_KEY: usize = 16;
 
 /// Maximum age of a cached prover entry before it is considered stale.

--- a/src/replication/storage_commitment_audit.rs
+++ b/src/replication/storage_commitment_audit.rs
@@ -8,6 +8,15 @@
 //! owns the auditor entry point [`run_subtree_audit`] and the responder handler
 //! [`handle_subtree_challenge`]; the pure proof maths live in
 //! [`crate::replication::subtree`].
+//!
+//! Round 2 draws ONE fresh-random sample over all leaves and verifies each
+//! sampled leaf the cheapest sound way, to reduce egress: a leaf the auditor
+//! already holds (and whose own copy passes the content-address self-check) is
+//! verified against the auditor's OWN canonical bytes (no chunk bytes on the
+//! wire); any other sampled leaf is wire-challenged for the original bytes. A
+//! gossip auditor is a self-close neighbour that holds a share of the peer's
+//! chunks, so it verifies those locally and saves that egress; the monetized
+//! first audit holds nothing and wire-challenges every sampled leaf.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -130,29 +139,32 @@ struct AuditCtx<'a> {
     expected_commitment_hash: [u8; 32],
     config: &'a ReplicationConfig,
     credit: Option<&'a AuditCredit<'a>>,
+    /// This auditor's own chunk store: a sampled leaf it co-holds is verified
+    /// against these canonical bytes (zero egress) instead of wire-challenged.
+    storage: &'a LmdbStorage,
 }
 
-/// Run one gossip-triggered subtree audit against `challenged_peer`, pinned to
-/// the commitment hash the peer just gossiped (`expected_commitment_hash`).
+/// Run one subtree audit against `challenged_peer`, pinned to the commitment
+/// hash the peer gossiped (`expected_commitment_hash`).
 ///
-/// ADR-0002 two-round audit. The auditor sends a fresh random nonce and runs:
+/// ADR-0002 audit. The auditor sends a fresh random nonce and runs:
 ///
 /// 1. **Structure** (round 1) — the returned subtree rebuilds to the pinned
 ///    root, within a size-scaled deadline.
-/// 2. **Real bytes** (round 2) — the auditor demands the ORIGINAL chunk content
-///    for a 3..=5 FRESHLY-RANDOM sample of the proven leaves (chosen after the
-///    proof arrives, not nonce-derived — see `random_spotcheck_leaves`) FROM the
-///    responder, and recomputes both the content-address hash and the nonce
-///    freshness hash from that served content. The auditor holds none of the
-///    peer's chunks.
-/// 3. **Timing** — each round's deadline is sized to an honest local-disk read,
-///    so a relay forced to fetch over the network blows it.
+/// 2. **Real bytes** (round 2) — one fresh-random sample over ALL leaves; a
+///    sampled leaf the auditor already holds is verified against its OWN
+///    canonical bytes (no chunk bytes on the wire), and any other sampled leaf
+///    is wire-challenged for the original bytes. This is the egress
+///    optimisation: a co-held leaf moves no chunk bytes.
+/// 3. **Timing** — the wire byte-response deadline is sized to an honest
+///    local-disk read.
 ///
-/// A timeout (either round) is reported as [`AuditFailureReason::Timeout`] (the
-/// caller applies the strike/grace policy). Any structural failure, served
-/// content that fails a hash, an explicit `Absent` for a committed sampled key,
-/// or a rejection of a recently gossiped commitment, is a confirmed failure
-/// acted on immediately. On a full pass, records the peer as a proven holder.
+/// A timeout is reported as [`AuditFailureReason::Timeout`] (the caller applies
+/// the strike/grace policy). Any structural failure, a committed hash that
+/// disagrees with the auditor's canonical bytes, served content that fails a
+/// hash, an explicit `Absent` for a committed sampled key, or a rejection of a
+/// recently gossiped commitment, is a confirmed failure acted on immediately.
+/// On a full pass, records the peer as a proven holder.
 pub async fn run_subtree_audit(
     p2p_node: &Arc<P2PNode>,
     config: &ReplicationConfig,
@@ -160,6 +172,7 @@ pub async fn run_subtree_audit(
     expected_commitment_hash: [u8; 32],
     key_count: u32,
     credit: Option<&AuditCredit<'_>>,
+    storage: &LmdbStorage,
 ) -> AuditTickResult {
     let (nonce, challenge_id) = {
         let mut rng = rand::thread_rng();
@@ -227,6 +240,7 @@ pub async fn run_subtree_audit(
         expected_commitment_hash,
         config,
         credit,
+        storage,
     };
     dispatch_subtree_response(resp_msg.body, &ctx).await
 }
@@ -451,11 +465,8 @@ async fn dispatch_subtree_response(
 /// gets exercised (no reimplementation that could drift).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum AuditVerdict {
-    /// All gates passed and at least one leaf was byte-verified.
-    Pass {
-        /// Number of leaves whose real bytes were verified in round 2.
-        checked: usize,
-    },
+    /// Every requested leaf's served content reproduced its committed hashes.
+    Pass,
     /// A confirmed failure with this reason (penalizable / acted upon).
     Fail(AuditFailureReason),
 }
@@ -563,8 +574,8 @@ fn random_spotcheck_leaves(
 ///
 /// For each sampled leaf the auditor recomputes, from the SERVED content:
 ///   - `BLAKE3(content) == leaf.bytes_hash` (the chunk's content address), AND
-///   - `BLAKE3(nonce ‖ peer ‖ key ‖ content) == leaf.nonced_hash` (freshness),
-///     i.e. `compute_audit_digest(nonce, peer, key, content)`.
+///   - `compute_audit_digest(nonce, peer, key, content) == leaf.nonced_hash`
+///     (freshness).
 ///
 /// The freshness inputs are byte-identical to what the responder used to BUILD
 /// the leaf in round 1 (`subtree_leaf` → `nonced_leaf_hash`): the SAME four
@@ -577,14 +588,13 @@ fn random_spotcheck_leaves(
 /// hold none of the peer's chunks. Any `Absent`/omitted committed key, or any
 /// served content that fails a hash, is a provable lie → confirmed
 /// [`AuditFailureReason::DigestMismatch`]. All sampled leaves verifying →
-/// `Pass { checked }`.
+/// [`AuditVerdict::Pass`].
 pub(crate) fn verify_byte_response(
     leaves: &[&crate::replication::subtree::SubtreeLeaf],
     nonce: &[u8; 32],
     challenged_peer_bytes: &[u8; 32],
     served: impl Fn(&XorName) -> Option<Option<Vec<u8>>>,
 ) -> AuditVerdict {
-    let mut checked = 0usize;
     for leaf in leaves {
         // Present{bytes} -> Some(Some(bytes)); Absent -> Some(None); omitted -> None.
         // A committed key the responder cannot / will not serve is a provable lie.
@@ -603,23 +613,55 @@ pub(crate) fn verify_byte_response(
             // hash: cannot be the chunk it committed to.
             return AuditVerdict::Fail(AuditFailureReason::DigestMismatch);
         }
-        checked += 1;
     }
-    AuditVerdict::Pass { checked }
+    AuditVerdict::Pass
 }
 
-/// Verify a subtree-proof response (auditor side), ADR-0002 two-round audit.
+// ---------------------------------------------------------------------------
+// Byte layer: verify a co-held leaf locally (zero egress), else wire-challenge
+// ---------------------------------------------------------------------------
+
+/// Whether a co-held leaf matches this node's OWN canonical bytes for its key.
+///
+/// Recomputes, from `bytes`, the committed content hash and the fresh-nonce
+/// possession digest, and requires both to equal the leaf's committed values.
+/// Because content addressing admits exactly one byte string for a key, a
+/// committed hash that disagrees with the canonical bytes could not have been
+/// computed from the real chunk, so the leaf fails verification.
+#[must_use]
+fn local_leaf_matches(
+    leaf: &crate::replication::subtree::SubtreeLeaf,
+    nonce: &[u8; 32],
+    challenged_peer_bytes: &[u8; 32],
+    bytes: &[u8],
+) -> bool {
+    let plain = *blake3::hash(bytes).as_bytes();
+    let nonced = crate::replication::subtree::nonced_leaf_hash(
+        nonce,
+        challenged_peer_bytes,
+        &leaf.key,
+        bytes,
+    );
+    leaf.bytes_hash == plain && leaf.nonced_hash == nonced
+}
+
+/// Verify a subtree-proof response (auditor side), ADR-0002.
 ///
 /// **Round 1** (this proof): pin + identity + signature + structure. If the
 /// proof structurally rebuilds to the pinned root, the tree SHAPE is committed —
-/// but not yet that the bytes are held. **Round 2**: the auditor picks a small
-/// freshly-random (post-proof) sample of the just-proven leaves and sends a
-/// [`SubtreeByteChallenge`] demanding their original chunk content FROM the
-/// responder, then verifies that content against the committed `bytes_hash`
-/// (content address) and `nonced_hash` (freshness). A responder that committed
-/// to a chunk it no longer holds cannot serve content that hashes to the
-/// committed address, so it fails — regardless of what the auditor holds. On a
-/// full pass, credits the peer as a proven holder.
+/// but not yet that the bytes are held.
+///
+/// **Round 2** (byte layer): draw ONE fresh-random post-proof sample over ALL
+/// leaves (the ADR's 3..=5 cut-and-choose) and verify each sampled leaf the
+/// cheapest sound way. A leaf the auditor already holds (and whose own copy
+/// passes the content-address self-check) is verified against the auditor's OWN
+/// canonical bytes — no chunk bytes on the wire. Any other sampled leaf (not
+/// held, unreadable, or a locally-corrupt copy) is wire-challenged for the
+/// original content. A local mismatch is a confirmed failure returned
+/// immediately.
+///
+/// A Pass is a whole-slice cut-and-choose that credits the peer as a proven
+/// holder of the committed keys.
 async fn verify_subtree_response(
     ctx: &AuditCtx<'_>,
     commitment: &StorageCommitment,
@@ -640,13 +682,7 @@ async fn verify_subtree_response(
         return failed(challenged_peer, challenge_id, reason);
     }
 
-    // -- Round 2: surprise byte challenge for a 3..=5 FRESHLY-RANDOM sample. --
-    // The sample is chosen now, with CSPRNG randomness, AFTER the round-1 proof
-    // is in hand — NOT derived from the round-1 nonce. The responder committed
-    // every leaf's `nonced_hash` in round 1 without knowing which leaves we will
-    // open, so it cannot have fabricated the un-opened ones (cut-and-choose).
-    // We cap the sample at the ADR's 3..=5 band (clamped to the subtree size) so
-    // the round-2 message and the responder's disk read stay cheap.
+    // -- Round 2: one fresh-random sample over ALL leaves (cut-and-choose). --
     let sample_n = ctx
         .config
         .audit_spotcheck_count()
@@ -662,114 +698,139 @@ async fn verify_subtree_response(
             AuditFailureReason::DigestMismatch,
         );
     }
-    // The sample is challenged in batches of MAX_BYTE_CHALLENGE_KEYS so each
-    // response — worst case, every requested chunk at MAX_CHUNK_SIZE — still
-    // encodes under MAX_REPLICATION_MESSAGE_SIZE. Each batch carries its own
-    // possession-in-time deadline (sized to its own length), so splitting does
-    // not widen the per-chunk window a relay would need to fetch over the
-    // network.
-    //
-    // CRITICAL: verify each batch's served bytes AS IT ARRIVES, against that
-    // batch's own sampled leaves, and return a CONFIRMED failure immediately.
-    // Deferring all verification until every batch is collected would let a
-    // later batch's timeout-lane Timeout (`round_failure`) mask a deterministic
-    // failure already proven by an earlier batch (an absent committed key or a
-    // hash mismatch) — a confirmed cheat would be downgraded to a timeout. A
-    // Timeout/Rejected/Malformed only becomes the verdict if NO earlier batch
-    // already produced confirmed bad bytes.
-    let verdict = 'rounds: {
-        for batch in sampled.chunks(MAX_BYTE_CHALLENGE_KEYS) {
-            let batch_keys: Vec<XorName> = batch.iter().map(|l| l.key).collect();
-            match request_byte_proof(ctx, &batch_keys).await {
-                ByteRound::Served(items) => {
-                    // Verify THIS batch now. A confirmed failure here is final —
-                    // a later batch's timeout must not be able to overwrite it.
-                    let v = verify_byte_response(
-                        batch,
-                        &ctx.nonce,
-                        challenged_peer.as_bytes(),
-                        |key| {
-                            items.iter().find_map(|it| match it {
-                                SubtreeByteItem::Present { key: k, bytes } if k == key => {
-                                    Some(Some(bytes.clone()))
-                                }
-                                SubtreeByteItem::Absent { key: k } if k == key => Some(None),
-                                _ => None,
-                            })
-                        },
-                    );
-                    if let AuditVerdict::Fail(reason) = v {
-                        break 'rounds AuditVerdict::Fail(reason);
-                    }
-                }
-                // The responder rejected the byte challenge for a recently
-                // pinned commitment → confirmed failure, same as round 1.
-                ByteRound::Rejected => {
-                    break 'rounds AuditVerdict::Fail(AuditFailureReason::Rejected)
-                }
-                // Transient reject (a local read error): ADR-0004 A1 routes it to
-                // the timeout lane — no trust penalty, but revoke the holder
-                // credit for THIS pinned commitment (the peer answered and could
-                // not prove possession) before taking the Timeout verdict. Scoped
-                // to the commitment hash, not the whole peer, so it never erases
-                // credit the peer re-earned for a newer commitment.
-                ByteRound::TransientReject => {
-                    if let Some(credit) = ctx.credit {
-                        credit
-                            .recent_provers
-                            .write()
-                            .await
-                            .forget_commitment(&ctx.expected_commitment_hash);
-                    }
-                    break 'rounds AuditVerdict::Fail(AuditFailureReason::Timeout);
-                }
-                // No response within the byte deadline (or transport error) →
-                // timeout (graced by the caller's strike policy — could be
-                // honest slowness). Keeps credit (a dropped packet is not
-                // evidence of loss). Only reached when no earlier batch already
-                // confirmed bad bytes.
-                ByteRound::Timeout => {
-                    break 'rounds AuditVerdict::Fail(AuditFailureReason::Timeout)
-                }
-                // Malformed/unexpected round-2 body.
-                ByteRound::Malformed => {
-                    break 'rounds AuditVerdict::Fail(AuditFailureReason::MalformedResponse)
-                }
-            }
-        }
-        // Every batch served bytes that verified.
-        AuditVerdict::Pass {
-            checked: sampled.len(),
-        }
-    };
 
-    match verdict {
-        AuditVerdict::Fail(reason) => {
-            warn!("Audit: {challenged_peer} failed subtree audit ({reason:?})");
-            failed(challenged_peer, challenge_id, reason)
-        }
-        AuditVerdict::Pass { checked } => {
-            // Closeness (ADR-0002, soft/observe-only) — see observe_closeness.
-            observe_closeness(ctx.p2p_node, ctx.config, challenged_peer, proof).await;
-            // Credit the peer as a proven holder of its committed keys.
-            if let (Some(credit), Some(pin)) = (ctx.credit, commitment_hash(commitment)) {
-                let now = std::time::Instant::now();
-                let mut provers = credit.recent_provers.write().await;
-                for leaf in &proof.leaves {
-                    provers.record_proof(leaf.key, *challenged_peer, pin, now);
+    // Real bytes, per leaf — the egress optimisation. For each sampled leaf: if
+    // this auditor already holds the key (and its own copy self-verifies),
+    // verify it against our OWN canonical bytes — no chunk bytes on the wire.
+    // Only a leaf we do NOT hold (or cannot vouch for) is wire-challenged,
+    // demanding the original content from the responder. A local mismatch is a
+    // CONFIRMED failure, returned immediately.
+    let mut wire_leaves: Vec<&crate::replication::subtree::SubtreeLeaf> = Vec::new();
+    for leaf in &sampled {
+        match get_raw_retrying(ctx.storage, &leaf.key).await {
+            Ok(Some(bytes)) if *blake3::hash(&bytes).as_bytes() == leaf.key => {
+                if !local_leaf_matches(leaf, &ctx.nonce, challenged_peer.as_bytes(), &bytes) {
+                    warn!(
+                        "Audit: {challenged_peer} committed hash for {} disagrees with this \
+                         auditor's canonical bytes (confirmed failure)",
+                        hex::encode(leaf.key)
+                    );
+                    return failed(
+                        challenged_peer,
+                        challenge_id,
+                        AuditFailureReason::DigestMismatch,
+                    );
                 }
+                // Verified locally, zero egress.
             }
-            info!(
-                "Audit: peer {challenged_peer} passed subtree audit ({} leaves, {checked} \
-                 byte-checked)",
-                proof.leaves.len()
-            );
-            AuditTickResult::Passed {
-                challenged_peer: *challenged_peer,
-                keys_checked: checked,
+            // Not co-held, unreadable, or a locally-corrupt copy: wire-check it
+            // so every sampled leaf still gets a verdict.
+            Ok(Some(_)) => {
+                warn!(
+                    "Audit: own copy of {} fails self-integrity; wire-checking it instead \
+                     (local corruption, not the peer's fault)",
+                    hex::encode(leaf.key)
+                );
+                wire_leaves.push(leaf);
+            }
+            Ok(None) => wire_leaves.push(leaf),
+            Err(e) => {
+                debug!(
+                    "Audit: read error on own copy of {} ({e}); wire-checking it instead",
+                    hex::encode(leaf.key)
+                );
+                wire_leaves.push(leaf);
             }
         }
     }
+
+    // Wire-challenge only the leaves we could not verify locally (ADR round 2).
+    if !wire_leaves.is_empty() {
+        if let AuditVerdict::Fail(reason) = wire_verify_leaves(ctx, &wire_leaves).await {
+            warn!("Audit: {challenged_peer} failed subtree audit ({reason:?})");
+            return failed(challenged_peer, challenge_id, reason);
+        }
+    }
+
+    // Every sampled leaf verified (locally or over the wire). Whole-slice
+    // cut-and-choose: credit the peer as a proven holder of its committed keys.
+    observe_closeness(ctx.p2p_node, ctx.config, challenged_peer, proof).await;
+    if let (Some(credit), Some(pin)) = (ctx.credit, commitment_hash(commitment)) {
+        let now = std::time::Instant::now();
+        let mut provers = credit.recent_provers.write().await;
+        for leaf in &proof.leaves {
+            provers.record_proof(leaf.key, *challenged_peer, pin, now);
+        }
+    }
+    info!(
+        "Audit: peer {challenged_peer} passed subtree audit ({} leaves, {} byte-checked, {} \
+         over the wire)",
+        proof.leaves.len(),
+        sampled.len(),
+        wire_leaves.len(),
+    );
+    AuditTickResult::Passed {
+        challenged_peer: *challenged_peer,
+        keys_checked: sampled.len(),
+    }
+}
+
+/// The ADR-0002 round-2 wire byte challenge for the sampled leaves the auditor
+/// could NOT verify locally: demand the original chunk content from the
+/// responder (batched under [`MAX_BYTE_CHALLENGE_KEYS`] to fit the wire cap) and
+/// verify each batch as it arrives.
+///
+/// Returns [`AuditVerdict::Pass`] iff every requested leaf's served content
+/// reproduced its committed hashes. A deterministic bad-bytes failure in any
+/// batch is returned immediately so a later batch's graced Timeout can never
+/// mask it (a confirmed cheat must not be downgraded).
+async fn wire_verify_leaves(
+    ctx: &AuditCtx<'_>,
+    leaves: &[&crate::replication::subtree::SubtreeLeaf],
+) -> AuditVerdict {
+    let challenged_peer = ctx.challenged_peer;
+    for batch in leaves.chunks(MAX_BYTE_CHALLENGE_KEYS) {
+        let batch_keys: Vec<XorName> = batch.iter().map(|l| l.key).collect();
+        match request_byte_proof(ctx, &batch_keys).await {
+            ByteRound::Served(items) => {
+                let v =
+                    verify_byte_response(batch, &ctx.nonce, challenged_peer.as_bytes(), |key| {
+                        items.iter().find_map(|it| match it {
+                            SubtreeByteItem::Present { key: k, bytes } if k == key => {
+                                Some(Some(bytes.clone()))
+                            }
+                            SubtreeByteItem::Absent { key: k } if k == key => Some(None),
+                            _ => None,
+                        })
+                    });
+                if let AuditVerdict::Fail(reason) = v {
+                    return AuditVerdict::Fail(reason);
+                }
+            }
+            // Repudiation of a recently pinned commitment → confirmed failure.
+            ByteRound::Rejected => return AuditVerdict::Fail(AuditFailureReason::Rejected),
+            // Transient local read error: timeout lane (no trust penalty), but
+            // revoke this pinned commitment's holder credit first — the peer
+            // answered and could not prove possession. Scoped to the commitment
+            // hash so it never erases credit re-earned for a newer commitment.
+            ByteRound::TransientReject => {
+                if let Some(credit) = ctx.credit {
+                    credit
+                        .recent_provers
+                        .write()
+                        .await
+                        .forget_commitment(&ctx.expected_commitment_hash);
+                }
+                return AuditVerdict::Fail(AuditFailureReason::Timeout);
+            }
+            // No response / transport error → graced timeout (keeps credit).
+            ByteRound::Timeout => return AuditVerdict::Fail(AuditFailureReason::Timeout),
+            ByteRound::Malformed => {
+                return AuditVerdict::Fail(AuditFailureReason::MalformedResponse)
+            }
+        }
+    }
+    AuditVerdict::Pass
 }
 
 /// Soft, density-aware closeness observation (ADR-0002). Logs — never fails —
@@ -1078,6 +1139,13 @@ pub async fn handle_subtree_byte_challenge(
         };
     };
 
+    // Test-only: record that these keys reached the round-2 byte challenge (for
+    // the pinned commitment), so an e2e test can prove co-held sampled leaves
+    // are verified locally instead (no byte challenge), correlated to a
+    // specific audit.
+    #[cfg(any(test, feature = "test-utils"))]
+    state.record_byte_challenge(challenge.expected_commitment_hash, &challenge.keys);
+
     let mut items = Vec::with_capacity(challenge.keys.len());
     for key in &challenge.keys {
         // Serve ONLY keys committed under this pin. A key the auditor asks for
@@ -1235,10 +1303,11 @@ mod tests {
         // Round 2: honest responder serves the real content for the sample.
         let s = sample(&proof, &nonce, built.commitment().key_count);
         assert!(!s.is_empty());
-        match verify_byte_response(&s, &nonce, &peer, served_honest) {
-            AuditVerdict::Pass { checked } => assert!(checked >= 1, "must verify >=1 leaf"),
-            other @ AuditVerdict::Fail(_) => panic!("expected Pass, got {other:?}"),
-        }
+        assert_eq!(
+            verify_byte_response(&s, &nonce, &peer, served_honest),
+            AuditVerdict::Pass,
+            "honest served content must verify"
+        );
     }
 
     #[test]
@@ -1376,10 +1445,9 @@ mod tests {
 
     #[test]
     fn auditor_holds_nothing_still_catches_deleter() {
-        // Explicit contract: the auditor's own storage is irrelevant. A deleter
-        // is caught purely from its served (absent) response. (Compare the OLD
-        // design, where an auditor holding none of the chunks went Inconclusive
-        // and the deleter walked free.)
+        // Explicit contract for the WIRE path (a sampled leaf the auditor does
+        // not co-hold): the auditor's own storage is irrelevant — a deleter is
+        // caught purely from its served (absent) response.
         let nonce = [0x21u8; 32];
         let (built, proof, peer) = honest(256, &nonce);
         assert!(structure(&built, &proof, &nonce, &peer).is_ok());
@@ -1401,19 +1469,6 @@ mod tests {
             "sample {} must be within 3..=5",
             s.len()
         );
-    }
-
-    #[test]
-    fn full_pass_requires_every_sampled_leaf() {
-        // checked must equal the number of sampled leaves on a pass (no leaf is
-        // silently skipped — every sampled, committed key must verify).
-        let nonce = [11u8; 32];
-        let (built, proof, peer) = honest(400, &nonce);
-        let s = sample(&proof, &nonce, built.commitment().key_count);
-        match verify_byte_response(&s, &nonce, &peer, served_honest) {
-            AuditVerdict::Pass { checked } => assert_eq!(checked, s.len()),
-            other @ AuditVerdict::Fail(_) => panic!("expected Pass, got {other:?}"),
-        }
     }
 
     // ---- end-to-end gate composition ----------------------------------------
@@ -1468,16 +1523,12 @@ mod tests {
         let sn = sample(&proof_near, &nonce, built_near.commitment().key_count);
         let v_near = verify_byte_response(&sn, &nonce, &peer_near, served_honest);
 
-        match (&v_far, &v_near) {
-            (AuditVerdict::Pass { checked: cf }, AuditVerdict::Pass { checked: cn }) => {
-                assert!(*cf >= 1 && *cn >= 1);
-            }
-            other => panic!("both honest proofs must Pass regardless of closeness, got {other:?}"),
-        }
-        assert!(
-            !matches!(v_far, AuditVerdict::Fail(_)),
-            "far/padding-shaped honest proof must NEVER fail, got {v_far:?}"
+        assert_eq!(
+            v_far,
+            AuditVerdict::Pass,
+            "far/padding honest proof must Pass"
         );
+        assert_eq!(v_near, AuditVerdict::Pass, "near honest proof must Pass");
     }
 
     // Unused-leaf constructor guard: keep SubtreeLeaf import meaningful.
@@ -1488,5 +1539,109 @@ mod tests {
             bytes_hash: [0u8; 32],
             nonced_hash: [0u8; 32],
         };
+    }
+
+    // ---- byte layer: local possession check for a co-held leaf ---------------
+
+    /// The leaf the honest tree built for `key(0)` under `nonce`, plus that
+    /// key's canonical bytes. The auditor co-holds this key.
+    fn honest_leaf_and_bytes(nonce: &[u8; 32]) -> (SubtreeLeaf, [u8; 32], Vec<u8>) {
+        let (_built, proof, peer) = honest(400, nonce);
+        let leaf = proof.leaves.first().cloned().unwrap();
+        let bytes = chunk_bytes(&leaf.key);
+        (leaf, peer, bytes)
+    }
+
+    #[test]
+    fn local_leaf_matches_honest_co_held_leaf() {
+        // The auditor co-holds the key: recomputing both hashes from its own
+        // canonical bytes reproduces the committed leaf exactly.
+        let nonce = [9u8; 32];
+        let (leaf, peer, bytes) = honest_leaf_and_bytes(&nonce);
+        assert!(local_leaf_matches(&leaf, &nonce, &peer, &bytes));
+    }
+
+    #[test]
+    fn local_leaf_rejects_fabricated_nonced_hash() {
+        // A modified deleter fabricates the freshness hash for a leaf it no
+        // longer holds. A co-holder recomputes the digest from the CANONICAL
+        // bytes and the fabrication does not match.
+        let nonce = [9u8; 32];
+        let (mut leaf, peer, bytes) = honest_leaf_and_bytes(&nonce);
+        leaf.nonced_hash = [0xAB; 32];
+        assert!(!local_leaf_matches(&leaf, &nonce, &peer, &bytes));
+    }
+
+    #[test]
+    fn local_leaf_rejects_stale_nonce_freshness() {
+        // A digest precomputed under an older nonce never satisfies a fresh
+        // challenge: the recompute is bound to THIS audit's nonce.
+        let nonce = [9u8; 32];
+        let stale = [0xEE; 32];
+        let (mut leaf, peer, bytes) = honest_leaf_and_bytes(&nonce);
+        leaf.nonced_hash = nonced_leaf_hash(&stale, &peer, &leaf.key, &bytes);
+        assert!(!local_leaf_matches(&leaf, &nonce, &peer, &bytes));
+    }
+
+    #[test]
+    fn local_leaf_rejects_bytes_hash_disagreeing_with_canonical_bytes() {
+        // The peer committed (key, junk_hash) for a key the auditor co-holds.
+        // The canonical bytes hash to bytes_hash, not junk_hash, so the
+        // substitution is caught against the auditor's own copy — a check the
+        // wire round (which compares the peer's SERVED bytes to the peer's own
+        // commitment) cannot make.
+        let nonce = [9u8; 32];
+        let (mut leaf, peer, bytes) = honest_leaf_and_bytes(&nonce);
+        leaf.bytes_hash = [0x77; 32];
+        assert!(!local_leaf_matches(&leaf, &nonce, &peer, &bytes));
+    }
+
+    #[test]
+    fn local_check_rejects_leaf_committed_over_non_canonical_bytes() {
+        // A leaf committed as `(key, BLAKE3(other))` with `nonced_hash` also
+        // over `other`, where `key` is the CONTENT ADDRESS of the canonical
+        // chunk. Even though the leaf's two committed hashes are internally
+        // consistent with `other`, an honest co-holder stores the CANONICAL
+        // bytes for `key`, and the local check recomputes both hashes from
+        // those — `BLAKE3(canonical) == key != BLAKE3(other) == committed
+        // bytes_hash` — so it rejects the leaf.
+        let nonce = [0x5A; 32];
+        let peer = [0x11; 32];
+        let canonical = b"the canonical chunk for this key".to_vec();
+        let other = b"different bytes committed for the same key".to_vec();
+        let key = *blake3::hash(&canonical).as_bytes();
+        let leaf = SubtreeLeaf {
+            key,
+            bytes_hash: *blake3::hash(&other).as_bytes(),
+            nonced_hash: nonced_leaf_hash(&nonce, &peer, &key, &other),
+        };
+        assert!(
+            !local_leaf_matches(&leaf, &nonce, &peer, &canonical),
+            "a leaf committed over non-canonical bytes must fail the local check"
+        );
+    }
+
+    #[test]
+    fn verify_byte_response_fails_when_only_the_last_sampled_leaf_is_bad() {
+        // No sampled leaf may be silently skipped: a bad LAST leaf must fail
+        // even when every earlier leaf verified (guards against a verifier that
+        // short-circuits to Pass on the first good leaf).
+        let nonce = [7u8; 32];
+        let (built, proof, peer) = honest(400, &nonce);
+        let s = sample(&proof, &nonce, built.commitment().key_count);
+        assert!(s.len() >= 2, "need multiple sampled leaves");
+        let last_key = s.last().unwrap().key;
+        let v = verify_byte_response(&s, &nonce, &peer, |k| {
+            if *k == last_key {
+                Some(Some(b"garbage-for-the-last-leaf".to_vec()))
+            } else {
+                Some(Some(chunk_bytes(k)))
+            }
+        });
+        assert_eq!(
+            v,
+            AuditVerdict::Fail(AuditFailureReason::DigestMismatch),
+            "a bad final sampled leaf must fail the whole verification"
+        );
     }
 }

--- a/tests/e2e/subtree_audit_testnet.rs
+++ b/tests/e2e/subtree_audit_testnet.rs
@@ -43,11 +43,12 @@ async fn wait_for_first_audit_stats(
 }
 
 /// Store the same `n` chunks on both `a` (the audited holder) and `b` (the
-/// auditor — NOT because verification needs them: round 2 demands the bytes
-/// from `a` itself, so `b` could hold nothing; storing them just makes `b` a
-/// realistic co-holder of the keyspace), make `a` commit to them,
-/// then deterministically seed `b`'s cache with `a`'s commitment (simulating
-/// "b received a's gossip" without depending on neighbor-sync timing — that
+/// auditor). `b` verifies leaves it co-holds against its own copy, so `b`
+/// co-holding the chunks is exactly the production topology: commitments only
+/// reach self-close neighbors, which co-hold the shared range. Make `a` commit
+/// to them, then
+/// deterministically seed `b`'s cache with `a`'s commitment (simulating "b
+/// received a's gossip" without depending on neighbor-sync timing — that
 /// propagation is covered by the dedicated neighbor-sync tests). After this,
 /// `b.audit_peer_now(a)` pins `a`'s real commitment and runs the audit over the
 /// live wire against `a`'s real responder.
@@ -119,11 +120,69 @@ async fn honest_node_passes_subtree_audit() {
         .as_ref()
         .expect("b engine");
 
-    // Honest holder: B holds the chunks so it byte-verifies the proof → Passed.
+    // Honest holder: B co-holds the sampled chunks and verifies them against
+    // its own bytes, so the audit passes with no false rejection.
     let result = b_engine.audit_peer_now(&a_peer).await;
     assert!(
         matches!(result, AuditTickResult::Passed { keys_checked, .. } if keys_checked >= 1),
-        "honest node must pass with at least one byte-verified leaf, got {result:?}"
+        "honest node must pass with at least one verified leaf, got {result:?}"
+    );
+
+    harness.teardown().await.expect("teardown");
+}
+
+/// EGRESS SAVING: a co-held sampled leaf is verified against the auditor's OWN
+/// bytes, with NO byte challenge to the responder. `commit_and_seed` makes B
+/// co-hold every chunk A committed, so B's fresh-random sample lands only on
+/// co-held leaves; B verifies them all locally and sends A ZERO round-2 byte
+/// challenges for this commitment. That eliminates the round-2 chunk traffic
+/// (the dominant audit egress) for co-held leaves. A regression that
+/// wire-challenges co-held leaves would record byte challenges here and fail.
+#[tokio::test]
+#[serial]
+async fn coheld_sampled_leaf_is_verified_locally_zero_egress() {
+    let harness = TestHarness::setup_small().await.expect("setup");
+    harness.warmup_dht().await.expect("warmup");
+
+    let (a_idx, b_idx) = (1, 2);
+    commit_and_seed(&harness, a_idx, b_idx, 64).await;
+
+    let a = harness.test_node(a_idx).expect("a");
+    let a_peer = *a.p2p_node.as_ref().expect("a p2p").peer_id();
+    let a_engine = a.replication_engine.as_ref().expect("a engine");
+    // A's freshly-rebuilt commitment (from `commit_and_seed`) was NOT gossiped;
+    // only B was handed it (via `inject_peer_commitment_for_test`). So a byte
+    // challenge pinned to this hash can only come from B's audit below — no
+    // other node holds this commitment to audit it. That makes the observation
+    // deterministically B's, immune to any incidental background audit.
+    let a_pin = a_engine
+        .commitment_state()
+        .current()
+        .expect("A has a current commitment")
+        .hash();
+
+    let b_engine = harness
+        .test_node(b_idx)
+        .expect("b")
+        .replication_engine
+        .as_ref()
+        .expect("b engine");
+    let result = b_engine.audit_peer_now(&a_peer).await;
+    assert!(
+        matches!(result, AuditTickResult::Passed { keys_checked, .. } if keys_checked >= 1),
+        "honest co-held audit must pass, got {result:?}"
+    );
+
+    // B co-holds every sampled key, so it verified them all against its own
+    // bytes: A received NO byte challenge for this commitment. That is the
+    // egress saving — the round-2 chunk transfer is eliminated for co-held
+    // leaves.
+    let challenged = a_engine
+        .commitment_state()
+        .byte_challenge_keys_for_pin(&a_pin);
+    assert!(
+        challenged.is_empty(),
+        "co-held leaves must be verified locally with no byte challenge, got {challenged:?}"
     );
 
     harness.teardown().await.expect("teardown");
@@ -173,7 +232,8 @@ async fn data_deleting_node_fails_subtree_audit() {
     // The adversary can no longer produce the subtree's bytes, so its responder
     // rejects ("missing bytes for committed key") → a confirmed Failed. (It must
     // NOT be Passed; Idle would mean B couldn't reach the audit, also a failure
-    // of the test setup.)
+    // of the test setup.) B co-holds the data, so this also confirms a co-held
+    // audit still catches a deleter (the round-1 proof requires the bytes).
     assert!(
         matches!(result, AuditTickResult::Failed { .. }),
         "a node that deleted its committed data must FAIL the audit, got {result:?}"

--- a/tests/poc_commitment_audit_attacks.rs
+++ b/tests/poc_commitment_audit_attacks.rs
@@ -10,20 +10,17 @@
 //!
 //! ## How the auditor is modelled here
 //!
-//! The production auditor's `verify_subtree_response` (in
-//! `src/replication/storage_commitment_audit.rs`) is private, so this file
-//! reproduces the exact ordered gates it runs — pin, peer-id binding,
-//! signature, structural [`verify_subtree_proof`], then the **round-2 byte
-//! challenge**: the auditor demands the ORIGINAL chunk bytes for a
-//! nonce-selected sample of the just-proven leaves FROM THE RESPONDER and
-//! verifies the served content against each leaf's committed `bytes_hash`
-//! (content address) and `nonced_hash` (freshness). Possession is
-//! non-delegable: the auditor needs to hold NONE of the responder's chunks,
-//! and a committed key the responder cannot serve is a deterministic,
-//! confirmed failure (`DigestMismatch` in production — never inconclusive,
-//! never graced). The helper [`auditor_accepts`] runs these gates in the same
-//! order with the same failure semantics, so a reviewer can see each attack
-//! is caught at the same gate the network code would catch it.
+//! After the shared round-1 gates (pin, peer-id binding, signature, structural
+//! [`verify_subtree_proof`]) the auditor verifies each sampled leaf's bytes. A
+//! sampled leaf the auditor does not itself hold is wire-challenged: it demands
+//! the ORIGINAL content FROM THE RESPONDER and verifies the served content
+//! against `bytes_hash` (content address) and `nonced_hash` (freshness). A
+//! committed key the responder cannot serve is a deterministic confirmed
+//! failure (`DigestMismatch`). The production dispatcher is private, so the
+//! helper [`auditor_accepts`] reproduces its exact ordered gates; the tests
+//! below model this wire path. (A sampled leaf the auditor holds is verified
+//! against its own bytes instead; that local path is unit-tested beside
+//! `local_leaf_matches`.)
 //!
 //! ## What changed from the old per-key audit (and why)
 //!


### PR DESCRIPTION
## Summary

The storage-commitment audit (ADR-0002) round 2 has the responder serve the
sampled chunks' bytes back to the auditor, which is a large share of
steady-state replication traffic. When the auditor already holds a sampled
leaf, it can verify that leaf against its own copy instead of receiving the
bytes over the wire.

This change:

- Verifies a sampled leaf the auditor already holds against the auditor's own
  copy, with no chunk bytes on the wire. A sampled leaf the auditor does not
  hold is wire-challenged for the original bytes exactly as before. The verdict
  is the unchanged pass/fail with whole-slice credit.
- Makes the possession digest a domain-separated keyed BLAKE3 hash so the fresh
  per-audit nonce is bound into the digest over the whole content. The
  replication protocol id advances to v3 for a clean cutover.
- Returns no verdict (Idle) from the responsible-chunk audit when a challenged
  key's own local copy is unreadable, instead of a pass that reflects only the
  readable keys.

## Expected impact

Expected egress for an audit is `(1 - q)` of round 2's chunk traffic, where `q`
is the fraction of the sampled leaves the auditor holds. The first-audit lane,
where the auditor holds nothing, is unchanged.

## Testing

- Adds test-only observability (compiled under `test`/`test-utils` only) so an
  e2e test can confirm co-held leaves are verified locally with no byte
  challenge.
- Full lib suite, the commitment-audit PoC suites, and the real-QUIC
  subtree-audit e2e pass; `cargo fmt` and `clippy` are clean.
