### PR TITLE
chore(release): promote rc-2026.7.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.15.0"
+version = "0.16.0-rc.1"
 dependencies = [
  "alloy",
  "ant-protocol",
@@ -861,9 +861,8 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b665880152b4e124094acc1faaff5f20a275594e6364b8a729b50f3bc326674"
+version = "2.3.1-rc.1"
+source = "git+https://github.com/WithAutonomi/ant-protocol?branch=rc-2026.7.4#36a5c5ef76f458a6a63eac1a8e87aacc44a1b454"
 dependencies = [
  "blake3",
  "bytes",
@@ -4909,9 +4908,8 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0930cfdffe87a9ff747d901dc540e2e9b89c9a29e1cbb55a26e26d151e2b916d"
+version = "0.26.4-rc.1"
+source = "git+https://github.com/saorsa-labs/saorsa-core?branch=rc-2026.7.4#9ce30a69ccdbc9e4f0746c1c4e9b4d37331b9f8e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5024,9 +5022,8 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.35.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dbc31faa4bd1f51807dd3815950212005613e512f6b400715067b78c2fb9603"
+version = "0.35.3-rc.1"
+source = "git+https://github.com/saorsa-labs/saorsa-transport?branch=rc-2026.7.4#613a55326d735632aa203d1438d84ed48e32e934"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.16.0-rc.1"
+version = "0.16.0"
 dependencies = [
  "alloy",
  "ant-protocol",
@@ -861,8 +861,9 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "2.3.1-rc.1"
-source = "git+https://github.com/WithAutonomi/ant-protocol?branch=rc-2026.7.4#36a5c5ef76f458a6a63eac1a8e87aacc44a1b454"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3081ee130dd45e8166bc8ac4d789aac17d143e2e7f54f1c3006503dc63cf3edb"
 dependencies = [
  "blake3",
  "bytes",
@@ -4908,8 +4909,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.26.4-rc.1"
-source = "git+https://github.com/saorsa-labs/saorsa-core?branch=rc-2026.7.4#9ce30a69ccdbc9e4f0746c1c4e9b4d37331b9f8e"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "454529f8a72b4cf22f7d9c3b009ad9d4ba78520e11f6444ae460795d55c002da"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5022,8 +5024,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.35.3-rc.1"
-source = "git+https://github.com/saorsa-labs/saorsa-transport?branch=rc-2026.7.4#613a55326d735632aa203d1438d84ed48e32e934"
+version = "0.35.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3284026c300f642077315b782462b22558e24d621265a8deeae23287b1c5542"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.15.0"
+version = "0.16.0-rc.1"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"
@@ -39,10 +39,10 @@ mimalloc = "0.1"
 # Until then, the git pin tracks the matching saorsa-core lineage
 # (the rc-2026.4.2 branch) so Cargo can unify the wire types here
 # with ant-protocol's re-exports.
-ant-protocol = "2.3.0"
+ant-protocol = { git = "https://github.com/WithAutonomi/ant-protocol", branch = "rc-2026.7.4" }
 
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
-saorsa-core = "0.26.3"
+saorsa-core = { git = "https://github.com/saorsa-labs/saorsa-core", branch = "rc-2026.7.4" }
 saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.16.0-rc.1"
+version = "0.16.0"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"
@@ -39,10 +39,10 @@ mimalloc = "0.1"
 # Until then, the git pin tracks the matching saorsa-core lineage
 # (the rc-2026.4.2 branch) so Cargo can unify the wire types here
 # with ant-protocol's re-exports.
-ant-protocol = { git = "https://github.com/WithAutonomi/ant-protocol", branch = "rc-2026.7.4" }
+ant-protocol = "2.3.1"
 
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
-saorsa-core = { git = "https://github.com/saorsa-labs/saorsa-core", branch = "rc-2026.7.4" }
+saorsa-core = "0.26.4"
 saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment


### PR DESCRIPTION
Promotes `rc-2026.7.4` to release version(s): 0.16.0.

- strips `-rc.*` from `[package].version`
- rewrites internal git+branch deps to crates.io version pins
- regenerates `Cargo.lock`

Once merged, the release tag will be pushed to fire the publish workflow.