### PR TITLE
feat(payment): enforce the ADR-0004 quote arithmetic check

### DIFF
--- a/docs/adr/ADR-0008-storage-economics-and-payment-protocol.md
+++ b/docs/adr/ADR-0008-storage-economics-and-payment-protocol.md
@@ -306,16 +306,24 @@ address, its ML-DSA-65 signature, and the on-chain settlement — which must be
 at least 3× the median **and recorded for the quote's own rewards address**, so
 a client cannot redirect the money to itself and still be admitted.
 
-Two limits of that check, both current behaviour:
+ADR-0004's `price == calculate_price(committed_key_count)` recheck **is
+enforced**, over every quote in the bundle rather than the paid one alone. A
+quote whose signed price is not exactly the curve value for its own signed
+count is rejected, as is a quote whose binding shape is invalid. The gate is
+reject-only: an off-curve quote produces no trust evidence and schedules no
+audit.
+
+Two limits of that check remain, both current behaviour:
 
 - **Non-paid quotes are not fully re-verified.** They position the median but
   their signatures and content addresses are not checked, so a bad signature on
   an unpaid quote is accepted (`test_legacy_unpaid_quote_bad_signature_accepted`
   pins this). They still influence which quote gets paid.
-- **The on-curve price check is off.** ADR-0004's
-  `price == calculate_price(committed_key_count)` recheck over every quote is
-  rollout-gated by `QUOTE_ARITHMETIC_RECHECK_ENABLED`, which is `false`; today
-  off-curve quotes are only logged.
+- **The signed count is not resolved against the peer's own commitment.** The
+  arithmetic gate forces the price to the count the quoter signed, but a quoter
+  can still sign a count it does not store. Resolving the pin and reporting the
+  contradiction is `QUOTE_COMMITMENT_MISMATCH_TRUST_ENABLED`, which is `false`;
+  today such mismatches are only logged.
 
 Merkle proofs are checked against the pool's on-chain record: every candidate's
 signature, the pool's closeness to the midpoint, the tree proofs, and each paid
@@ -349,7 +357,7 @@ and a node that was actually paid is nominated for a first audit.
 | Client resolve-before-pay quote binding | **enforced** |
 | Node re-verification of the **paid median** quote (signature, content, K-closeness, settlement, payee address) | **enforced** |
 | Node re-verification of **non-paid** quotes in the bundle | not done (bad signature on an unpaid quote is accepted) |
-| Node rejection of off-curve quotes (`QUOTE_ARITHMETIC_RECHECK_ENABLED`) | off (telemetry only) |
+| Node rejection of off-curve quotes (`QUOTE_ARITHMETIC_RECHECK_ENABLED`) | **enforced**, on every quote in the bundle |
 | Quote/commitment mismatch reported to trust | off (telemetry only) |
 | Receiver-side price floor (ADR-0006) | shadow (`ANT_PRICE_FLOOR_ENFORCE`, 50% tolerance) |
 | Payee eligibility gate (ADR-0005) | **not merged**; observe-only on its branch (`ADR5_ENFORCE`) |

--- a/docs/adr/implementation-slices-adr-0004.md
+++ b/docs/adr/implementation-slices-adr-0004.md
@@ -20,9 +20,10 @@ already specifies.
 non-negative integer `n`, by exact recomputation, on every quote in every
 payment bundle (all 7 single-node quotes and all 16 merkle candidates), in
 every `VerificationContext`. Reject-only when enforced; no trust evidence.
-Rollout-gated by `QUOTE_ARITHMETIC_RECHECK_ENABLED` (defaults to `false` —
-observe-only). Telemetry runs only after ML-DSA-65 signature verification has
-passed, so unauthenticated peers cannot poison rollout logs.
+Rollout-gated by `QUOTE_ARITHMETIC_RECHECK_ENABLED`, now `true` after a clean
+observe-only canary on ant-prod-01. Telemetry runs only after ML-DSA-65
+signature verification has passed, so unauthenticated peers cannot poison
+rollout logs.
 
 **Why first:** needs no evmlib change, no new state, no new wire types, no
 new gossip; it is the ADR's "every storer re-runs the

--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -3373,13 +3373,30 @@ mod tests {
         let (public_key, secret_key) = ml_dsa.generate_keypair().expect("keygen");
         let pub_key_bytes = public_key.as_bytes().to_vec();
         let peer_id = encoded_peer_id_for_pub_key(&pub_key_bytes);
+        // Derive the ADR-0004 binding from the price rather than hardcoding
+        // `(0, None)`: a quote priced at `calculate_price(n)` must also claim
+        // `committed_key_count = n`, or it charges as though it stored `n` keys
+        // while committing to nothing and is rejected by the arithmetic gate
+        // before the test's own assertion is reached. Prices that are not on
+        // the curve at all (`ZERO`, small literals) keep the baseline shape and
+        // stay off-curve, which is what the tests exercising bad prices want.
+        let (committed_key_count, commitment_pin) =
+            match PaymentVerifier::price_off_curve_diagnostics(&price) {
+                None => {
+                    let records = derive_records_stored_from_price(price);
+                    let count = u32::try_from(records).unwrap_or(u32::MAX);
+                    let pin = if count == 0 { None } else { Some([0xA5u8; 32]) };
+                    (count, pin)
+                }
+                Some(_) => (0, None),
+            };
         let mut quote = PaymentQuote {
             content: xor_name::XorName(xorname),
             timestamp: SystemTime::now(),
             price,
             rewards_address: RewardsAddress::new([rewards_seed; 20]),
-            committed_key_count: 0,
-            commitment_pin: None,
+            committed_key_count,
+            commitment_pin,
             pub_key: pub_key_bytes,
             signature: Vec::new(),
         };
@@ -4151,6 +4168,16 @@ mod tests {
         );
     }
 
+    /// A zero-priced median must never be admitted.
+    ///
+    /// Which check rejects it depends on the ADR-0004 rollout gate. `Amount::ZERO`
+    /// is not a point on the pricing curve (the curve's minimum is
+    /// `calculate_price(0)`), so with
+    /// [`crate::replication::config::QUOTE_ARITHMETIC_RECHECK_ENABLED`] on, the
+    /// arithmetic gate rejects the bundle before median selection runs and the
+    /// dedicated zero-price check is no longer reachable for single-node quotes.
+    /// The gate subsumes it rather than replacing it, so both messages are
+    /// accepted here and the invariant under test stays "this is rejected".
     #[tokio::test]
     async fn test_legacy_zero_price_median_rejected() {
         let verifier = create_test_verifier();
@@ -4174,9 +4201,11 @@ mod tests {
             .await
             .expect_err("zero median must be rejected");
 
+        let msg = format!("{err}");
         assert!(
-            format!("{err}").contains("zero price"),
-            "Error should mention zero price: {err}"
+            msg.contains("zero price") || msg.contains("off-curve quote rejected"),
+            "Error must reject the zero-priced median, by either the zero-price \
+             check or the ADR-0004 arithmetic gate: {msg}"
         );
     }
 
@@ -4504,7 +4533,10 @@ mod tests {
         let quote = PaymentQuote {
             content: xor_name::XorName(wrong_xorname),
             timestamp: SystemTime::now(),
-            price: Amount::from(1u64),
+            // Baseline-priced so the quote is on-curve: this test is about the
+            // content binding, and an off-curve price would be rejected by the
+            // ADR-0004 arithmetic gate first, never reaching that check.
+            price: crate::payment::pricing::calculate_price(0),
             rewards_address: RewardsAddress::new([1u8; 20]),
             committed_key_count: 0,
             commitment_pin: None,
@@ -4553,7 +4585,13 @@ mod tests {
         PaymentQuote {
             content: xor_name::XorName(xorname),
             timestamp,
-            price: Amount::from(1u64),
+            // Baseline quote: `(committed_key_count = 0, commitment_pin = None)`
+            // must be priced at `calculate_price(0)` to satisfy the ADR-0004
+            // binding rule. An arbitrary placeholder price here is off-curve and
+            // is rejected outright once
+            // [`crate::replication::config::QUOTE_ARITHMETIC_RECHECK_ENABLED`] is
+            // on, which would mask whatever a test actually means to assert.
+            price: crate::payment::pricing::calculate_price(0),
             rewards_address,
             committed_key_count: 0,
             commitment_pin: None,
@@ -4565,6 +4603,12 @@ mod tests {
     /// Helper: create a fake quote priced on-curve at `records` stored records
     /// (price = `calculate_price(records)`), reusing [`make_fake_quote`] for the
     /// remaining fields. Used by the ADR-0004 arithmetic-gate tests.
+    ///
+    /// Sets the whole binding, not just the price: ADR-0004 requires `price ==
+    /// calculate_price(committed_key_count)` AND the `(n > 0, Some(pin))` /
+    /// `(0, None)` shape, so pricing at `records` while leaving the count at `0`
+    /// produces a quote that claims to store nothing yet charges as though it
+    /// stored `records` keys. That is exactly what the gate rejects.
     fn make_fake_quote_at_records(
         xorname: [u8; 32],
         timestamp: SystemTime,
@@ -4573,6 +4617,14 @@ mod tests {
     ) -> evmlib::PaymentQuote {
         let mut quote = make_fake_quote(xorname, timestamp, rewards_address);
         quote.price = crate::payment::pricing::calculate_price(records);
+        quote.committed_key_count = u32::try_from(records).unwrap_or(u32::MAX);
+        quote.commitment_pin = if records == 0 {
+            None
+        } else {
+            // Any stable non-zero pin: these fixtures never resolve it to a real
+            // commitment, they only need the binding shape to be coherent.
+            Some([0xA5u8; 32])
+        };
         quote
     }
 
@@ -5188,7 +5240,11 @@ mod tests {
         std::array::from_fn::<_, CANDIDATES_PER_POOL, _>(|i| {
             let ml_dsa = MlDsa65::new();
             let (pub_key, secret_key) = ml_dsa.generate_keypair().expect("keygen");
-            let price = evmlib::common::Amount::from(1024u64);
+            // Baseline candidate: `(committed_key_count = 0, commitment_pin =
+            // None)` below, so the price must be `calculate_price(0)` to satisfy
+            // the ADR-0004 binding rule. A placeholder price is off-curve and is
+            // rejected before the check each test actually exercises.
+            let price = crate::payment::pricing::calculate_price(0);
             #[allow(clippy::cast_possible_truncation)]
             let reward_address = RewardsAddress::new([i as u8; 20]);
             let msg = MerklePaymentCandidateNode::bytes_to_sign(
@@ -5401,12 +5457,21 @@ mod tests {
         verifier
     }
 
-    /// Per-node amount a depth-2 pool of 1024-priced candidates must settle
-    /// under parity: `median(1024) * 2^2 * 3 / 2`.
-    const MERKLE_PARITY_PER_NODE_DEPTH2: u64 = 6144;
+    /// Per-node amount a depth-2 pool of baseline-priced candidates must settle
+    /// under parity: `median * 2^2 * 3 / 2`, i.e. six times the candidate price.
+    ///
+    /// Derived from the curve rather than hardcoded: the candidates are priced
+    /// at `calculate_price(0)` so they satisfy the ADR-0004 binding rule, and a
+    /// literal would silently stop matching the formula if the curve moves.
+    fn merkle_parity_per_node_depth2() -> Amount {
+        crate::payment::pricing::calculate_price(0) * Amount::from(6u64)
+    }
 
-    /// The same pool's historic pre-parity amount: `median(1024) * 2^2 / 2`.
-    const MERKLE_LEGACY_PER_NODE_DEPTH2: u64 = 2048;
+    /// The same pool's historic pre-parity amount: `median * 2^2 / 2`, i.e.
+    /// twice the candidate price.
+    fn merkle_legacy_per_node_depth2() -> Amount {
+        crate::payment::pricing::calculate_price(0) * Amount::from(2u64)
+    }
 
     fn make_valid_merkle_proof_bytes() -> (
         [u8; 32],
@@ -5697,13 +5762,13 @@ mod tests {
                     (
                         RewardsAddress::new([0u8; 20]),
                         0,
-                        Amount::from(MERKLE_PARITY_PER_NODE_DEPTH2),
+                        merkle_parity_per_node_depth2(),
                     ),
                     // Second paid node: index 999 is way beyond CANDIDATES_PER_POOL (16)
                     (
                         RewardsAddress::new([1u8; 20]),
                         999,
-                        Amount::from(MERKLE_PARITY_PER_NODE_DEPTH2),
+                        merkle_parity_per_node_depth2(),
                     ),
                 ],
             };
@@ -5746,13 +5811,13 @@ mod tests {
                     (
                         RewardsAddress::new([0u8; 20]),
                         0,
-                        Amount::from(MERKLE_PARITY_PER_NODE_DEPTH2),
+                        merkle_parity_per_node_depth2(),
                     ),
                     // Index 1 with WRONG address — candidate 1's address is [0x01; 20]
                     (
                         RewardsAddress::new([0xFF; 20]),
                         1,
-                        Amount::from(MERKLE_PARITY_PER_NODE_DEPTH2),
+                        merkle_parity_per_node_depth2(),
                     ),
                 ],
             };
@@ -5870,12 +5935,12 @@ mod tests {
                     (
                         RewardsAddress::new([0u8; 20]),
                         0,
-                        Amount::from(MERKLE_LEGACY_PER_NODE_DEPTH2),
+                        merkle_legacy_per_node_depth2(),
                     ),
                     (
                         RewardsAddress::new([1u8; 20]),
                         1,
-                        Amount::from(MERKLE_LEGACY_PER_NODE_DEPTH2),
+                        merkle_legacy_per_node_depth2(),
                     ),
                 ],
             };
@@ -5917,12 +5982,12 @@ mod tests {
                     (
                         RewardsAddress::new([0u8; 20]),
                         0,
-                        Amount::from(MERKLE_LEGACY_PER_NODE_DEPTH2),
+                        merkle_legacy_per_node_depth2(),
                     ),
                     (
                         RewardsAddress::new([1u8; 20]),
                         1,
-                        Amount::from(MERKLE_LEGACY_PER_NODE_DEPTH2),
+                        merkle_legacy_per_node_depth2(),
                     ),
                 ],
             };
@@ -5961,12 +6026,12 @@ mod tests {
                         (
                             RewardsAddress::new([0u8; 20]),
                             0,
-                            Amount::from(MERKLE_PARITY_PER_NODE_DEPTH2),
+                            merkle_parity_per_node_depth2(),
                         ),
                         (
                             RewardsAddress::new([1u8; 20]),
                             1,
-                            Amount::from(MERKLE_PARITY_PER_NODE_DEPTH2),
+                            merkle_parity_per_node_depth2(),
                         ),
                     ],
                 };
@@ -6059,12 +6124,12 @@ mod tests {
                 (
                     RewardsAddress::new([0u8; 20]),
                     0,
-                    Amount::from(MERKLE_PARITY_PER_NODE_DEPTH2),
+                    merkle_parity_per_node_depth2(),
                 ),
                 (
                     RewardsAddress::new([1u8; 20]),
                     1,
-                    Amount::from(MERKLE_PARITY_PER_NODE_DEPTH2),
+                    merkle_parity_per_node_depth2(),
                 ),
             ],
         }
@@ -6739,13 +6804,13 @@ mod tests {
     }
 
     /// Off-curve quote behaviour follows the rollout gate
-    /// [`QUOTE_ARITHMETIC_RECHECK_ENABLED`]. We assert the gate's current
-    /// observe-only stance: an off-curve quote is accepted with no error.
-    /// The enforcement-branch behaviour is exercised separately by
-    /// `adr0004_off_curve_diagnostics_yields_reject_payload` so both branches
-    /// of the const-gated split are covered in CI.
+    /// [`QUOTE_ARITHMETIC_RECHECK_ENABLED`]. The gate now ships enforcing, so
+    /// an off-curve quote must be rejected; the observe-only branch is kept so
+    /// the test still documents the semantics if the gate is ever rolled back.
+    /// The rejection payload itself is exercised separately by
+    /// `adr0004_off_curve_diagnostics_yields_reject_payload`.
     #[test]
-    fn adr0004_observe_only_does_not_reject_off_curve_quote() {
+    fn adr0004_off_curve_quote_follows_rollout_gate() {
         use evmlib::{EncodedPeerId, RewardsAddress};
 
         let mut quote = make_fake_quote_at_records(
@@ -6762,11 +6827,15 @@ mod tests {
             peer_quotes: vec![(EncodedPeerId::new(id), quote)],
         };
 
-        // This test is only meaningful in the observe-only configuration
-        // (which is the default at slice ship). If a future change flips the
-        // const, the assertion documents the regression instead of silently
-        // changing semantics.
-        if !crate::replication::config::QUOTE_ARITHMETIC_RECHECK_ENABLED {
+        // Both branches of the const-gated split are asserted, so the test
+        // keeps its meaning whichever way the gate is set rather than going
+        // silently vacuous when it flips.
+        if crate::replication::config::QUOTE_ARITHMETIC_RECHECK_ENABLED {
+            assert!(
+                PaymentVerifier::validate_quote_arithmetic(&payment).is_err(),
+                "enforcing rollout must reject off-curve quotes"
+            );
+        } else {
             assert!(
                 PaymentVerifier::validate_quote_arithmetic(&payment).is_ok(),
                 "observe-only rollout must not reject off-curve quotes"
@@ -6864,10 +6933,15 @@ mod tests {
         let mut candidates = make_candidate_nodes(timestamp);
 
         // Set every candidate price to calculate_price(500) so the pool is
-        // honestly on-curve to start.
+        // honestly on-curve to start. The binding must move with the price:
+        // ADR-0004 requires `price == calculate_price(committed_key_count)`, so
+        // repricing at 500 records while leaving the count at 0 would make the
+        // pool dishonest rather than honest.
         let on_curve = crate::payment::pricing::calculate_price(500);
         for c in &mut candidates {
             c.price = on_curve;
+            c.committed_key_count = 500;
+            c.commitment_pin = Some([0xA5u8; 32]);
         }
         let pool = MerklePaymentCandidatePool {
             midpoint_proof: fake_midpoint_proof(),

--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -1589,25 +1589,23 @@ impl PaymentVerifier {
     /// ADR-0004: enforce that every quoted price lies exactly on the public
     /// pricing curve.
     ///
-    /// **Scope** (this slice): canonicality only. The gate proves the price is
-    /// some `calculate_price(n)` for a non-negative integer `n`; it does NOT
-    /// yet prove `n` matches a signed commitment, because `PaymentQuote` lives
-    /// in evmlib (crates.io) and has no `claimed_key_count` / `commitment_pin`
-    /// fields yet. A future slice will bind `n` to a signed commitment once
-    /// the evmlib quote payload is extended. Until then, an attacker can still
-    /// quote `calculate_price(fake_n)` for any fake count and pass this gate;
-    /// what dies here is the strictly weaker attack of picking a price *off*
-    /// the curve altogether.
+    /// **Scope**: the price is forced by the quote's own signed
+    /// `committed_key_count`, not merely required to be *somewhere* on the
+    /// curve. `PaymentQuote` now carries `committed_key_count` and
+    /// `commitment_pin`, both covered by the quote signature and the quote
+    /// hash, so [`Self::binding_violation`] can hold the price to the count the
+    /// quoter committed to. What this gate does not do is resolve the pin
+    /// against the commitment the peer actually gossiped — a quoter can still
+    /// commit to a count it does not store and price consistently with it.
+    /// That cross-check is [`Self::cross_check_quotes`], gated separately by
+    /// [`crate::replication::config::QUOTE_COMMITMENT_MISMATCH_TRUST_ENABLED`]
+    /// because it carries a trust penalty rather than being reject-only.
     ///
-    /// **Check**: exact recomputation, never price-inversion. We derive the
-    /// candidate `n` for which `quote.price` would be the curve value (using
-    /// the existing inverse `derive_records_stored_from_price`, which floors),
-    /// then recompute `calculate_price(n)` and require strict equality.
-    /// On-curve prices round-trip exactly; off-curve prices floor to a smaller
-    /// `n` whose recomputed value is strictly less than `quote.price` and so
-    /// are rejected. Floor-then-equality is the canonicality test the ADR
-    /// specifies; price inversion alone would silently accept any value
-    /// between two curve points.
+    /// **Check**: exact recomputation, never price-inversion. The price is
+    /// compared against `calculate_price(committed_key_count)` recomputed from
+    /// the signed count. Inverting the price to a count would silently accept
+    /// any value between two curve points, and would also let a quote price
+    /// itself off one count while committing to another.
     ///
     /// **Where it runs**: in every [`VerificationContext`] over **every**
     /// quote in **both** quote types — all 7 single-node quotes

--- a/src/replication/config.rs
+++ b/src/replication/config.rs
@@ -494,7 +494,14 @@ const _: () = assert!(
 /// [`QUOTE_COMMITMENT_MISMATCH_TRUST_ENABLED`] for that, kept separate because
 /// the two have different ADR-0004 contracts (this one rejects with no trust
 /// action; that one reports a deterministic contradiction to the trust engine).
-pub const QUOTE_ARITHMETIC_RECHECK_ENABLED: bool = false;
+///
+/// Enabled after the observe-only canary came back clean on ant-prod-01. Over
+/// the 2026-07-29 to 2026-08-04 window the check ran against every quote in
+/// more than 70,000 verified bundles across 912 of 913 node instances and
+/// flagged nothing: no off-curve price, no invalid binding shape, no
+/// price/count mismatch. Honest traffic therefore sits exactly on the curve, so
+/// enforcing rejects nothing that is accepted today.
+pub const QUOTE_ARITHMETIC_RECHECK_ENABLED: bool = true;
 
 /// Rollout gate for ADR-0004 quote/commitment **mismatch** trust reporting.
 ///

--- a/tests/e2e/merkle_payment.rs
+++ b/tests/e2e/merkle_payment.rs
@@ -205,12 +205,22 @@ fn build_valid_merkle_proof() -> ValidMerkleProof {
     }
 }
 
+/// The price every fabricated candidate carries.
+///
+/// It must be a real point on the pricing curve for the binding these
+/// candidates declare below (`committed_key_count: 0`, `commitment_pin: None`),
+/// or the ADR-0004 arithmetic gate rejects the pool outright and the attack
+/// tests never reach the check they are actually asserting.
+fn candidate_price() -> Amount {
+    ant_node::payment::pricing::calculate_price(0)
+}
+
 /// Build 16 validly-signed ML-DSA-65 candidate nodes for a merkle proof.
 fn build_candidate_nodes(timestamp: u64) -> [MerklePaymentCandidateNode; CANDIDATES_PER_POOL] {
     std::array::from_fn(|i| {
         let ml_dsa = MlDsa65::new();
         let (pub_key, secret_key) = ml_dsa.generate_keypair().expect("keygen");
-        let price = Amount::from(1024u64);
+        let price = candidate_price();
         #[allow(clippy::cast_possible_truncation)]
         let reward_address = RewardsAddress::new([i as u8; 20]);
         let msg =
@@ -574,10 +584,12 @@ async fn test_attack_merkle_pay_yourself_fabricated_pool() -> Result<(), Box<dyn
         .first()
         .expect("pool has candidates")
         .merkle_payment_timestamp;
-    // 4-leaf tree → depth 2 (log2(4)). Prices are all 1024 in
-    // build_candidate_nodes, so per-node payment = 1024 * 2^2 / 2 = 2048.
+    // 4-leaf tree → depth 2 (log2(4)). Every candidate carries
+    // `candidate_price()`, so per-node payment = price * 2^2. Derived from the
+    // price rather than hardcoded: a literal silently stops matching the
+    // formula the moment the pricing curve moves.
     let depth: u8 = 2;
-    let per_node = Amount::from(4096u64);
+    let per_node = candidate_price() * Amount::from(4u64);
     let paid_node_addresses = vec![
         (RewardsAddress::new([0u8; 20]), 0usize, per_node),
         (RewardsAddress::new([1u8; 20]), 1usize, per_node),

--- a/tests/e2e/merkle_payment.rs
+++ b/tests/e2e/merkle_payment.rs
@@ -215,6 +215,60 @@ fn candidate_price() -> Amount {
     ant_node::payment::pricing::calculate_price(0)
 }
 
+/// Per-node settlement the verifier requires for a merkle proof of `depth`.
+///
+/// Mirrors the contract formula the verifier applies, including both terms:
+/// `multiplier * median16(candidate prices) * 2^depth / depth`. Every
+/// fabricated candidate carries `candidate_price()`, so the median is that
+/// price. The trailing `/ depth` split is the part a bare `price * 2^depth`
+/// misses.
+///
+/// The multiplier is the ADR-0008 parity `3x` that a receipt stamped at or
+/// after `MERKLE_PARITY_ENFORCED_FROM_UNIX` must settle at. Fixtures stamp
+/// their receipts at `now`, so they land on that side of the boundary. The
+/// verifier only rejects *under*payment, so the parity amount also clears the
+/// legacy `1x` expectation, and a fixture funded here is correct on both sides
+/// of the boundary without the test having to pin it.
+///
+/// Derived from the price rather than hardcoded: a literal silently stops
+/// matching the formula the moment the pricing curve moves.
+fn parity_per_node_payment(depth: u8) -> Amount {
+    /// Mirrors the verifier's private `PAID_QUOTE_PAYMENT_MULTIPLIER`.
+    const PARITY_MULTIPLIER: u64 = 3;
+
+    let Some(leaves) = 1u64.checked_shl(u32::from(depth)) else {
+        return Amount::ZERO;
+    };
+    let Some(nodes_paid) = std::num::NonZeroU64::new(u64::from(depth)) else {
+        // Depth 0 pays nobody, matching the verifier's own short-circuit.
+        return Amount::ZERO;
+    };
+    let total = candidate_price()
+        .saturating_mul(Amount::from(PARITY_MULTIPLIER))
+        .saturating_mul(Amount::from(leaves));
+    total / Amount::from(nodes_paid.get())
+}
+
+/// Pin the depth-2 settlement the attack fixtures fund at.
+///
+/// The previous fixture paid `price * 2^depth` and dropped the `/ depth` term,
+/// which happened to be neither the legacy `1x` nor the parity `3x` amount. It
+/// stayed green only because candidate closeness is checked before settlement,
+/// so the fixture had quietly stopped isolating the check it claims to isolate.
+/// This restates the depth-2 case as literals so an error in the general helper
+/// fails here rather than silently re-arming that trap.
+#[test]
+fn parity_per_node_payment_matches_the_contract_formula_at_depth_two() {
+    let price = candidate_price();
+    // 3 * price * 2^2 / 2 == 6 * price.
+    assert_eq!(parity_per_node_payment(2), price * Amount::from(6u64));
+    // And it clears the legacy 1x expectation (price * 2^2 / 2), which the
+    // verifier still applies to receipts stamped before the parity boundary.
+    assert!(parity_per_node_payment(2) >= price * Amount::from(2u64));
+    // Depth 0 pays nobody, matching the verifier's short-circuit.
+    assert_eq!(parity_per_node_payment(0), Amount::ZERO);
+}
+
 /// Build 16 validly-signed ML-DSA-65 candidate nodes for a merkle proof.
 fn build_candidate_nodes(timestamp: u64) -> [MerklePaymentCandidateNode; CANDIDATES_PER_POOL] {
     std::array::from_fn(|i| {
@@ -584,12 +638,14 @@ async fn test_attack_merkle_pay_yourself_fabricated_pool() -> Result<(), Box<dyn
         .first()
         .expect("pool has candidates")
         .merkle_payment_timestamp;
-    // 4-leaf tree → depth 2 (log2(4)). Every candidate carries
-    // `candidate_price()`, so per-node payment = price * 2^2. Derived from the
-    // price rather than hardcoded: a literal silently stops matching the
-    // formula the moment the pricing curve moves.
+    // 4-leaf tree → depth 2 (log2(4)). The verifier settles
+    // `multiplier * median16(price) * 2^depth / depth`, so at depth 2 the
+    // parity multiplier makes this `3 * price * 4 / 2` = `6 * price`. Funding
+    // at the parity amount keeps the fixture's isolation invariant intact on
+    // both sides of the parity boundary: settlement can never be the reason
+    // this proof is rejected, so closeness stays the only check that can fire.
     let depth: u8 = 2;
-    let per_node = candidate_price() * Amount::from(4u64);
+    let per_node = parity_per_node_payment(depth);
     let paid_node_addresses = vec![
         (RewardsAddress::new([0u8; 20]), 0usize, per_node),
         (RewardsAddress::new([1u8; 20]), 1usize, per_node),


### PR DESCRIPTION
## Linear issue
https://linear.app/autonominetwork/issue/V2-817/turn-on-the-two-quote-enforcement-gates-once-the-fleet-has

This PR is the first of the two gates that issue covers. The second
(`QUOTE_COMMITMENT_MISMATCH_TRUST_ENABLED`) stays off here, deliberately: it carries
a trust penalty rather than being reject-only, so it gets its own read of the
observe-only logs before flipping.

## Risk tier
- [ ] T0 — docs / tooling / CI / pure UX-output. Repo CI only.
- [ ] T1 — client-only, no network-facing behavior change. CI + prod compat smoke.
- [ ] T2 — node/client logic with behavioral surface, no protocol/format/economics change. Dev testnet + ADR.
- [x] T3 — protocol / storage format / payments / routing. T2 evidence + adversarial testing.

Payment admission behavior changes: a quote whose signed price is not exactly on
the public pricing curve is now rejected instead of logged.

## Compatibility
- Wire: none. `committed_key_count` and `commitment_pin` have shipped in the quote
  since ADR-0004 and are already covered by the signature and quote hash. No new
  field, no new message, no size change.
- Storage: none.
- API: none. The gate is a private crate constant.

## Semver impact
- [ ] breaking
- [x] feature
- [ ] fix

No public API changes; this enables node-side enforcement that was previously
observe-only. Flagged as a feature rather than a fix because it changes what a
node accepts, not because anything was incorrect before.

## Test evidence

**Production canary, ant-prod-01, 2026-07-29 to 2026-08-04.** The check has been
running observe-only against every quote in every verified bundle. Over the window
it flagged nothing:

| signal | count |
| --- | --- |
| verified bundles evaluated | 70,078 |
| node instances reporting | 912 of 913 (99.9%) |
| off-curve prices observed | 0 |
| invalid binding shapes observed | 0 |
| price/count mismatches observed | 0 |

Measured by querying the `ant_node::payment::verifier` log target for the
`log_off_curve_single_node` warnings. WARN-level records from payment modules do
reach the log store (451 under `ant_node::payment::verify` on the busiest day), so
the zero is a genuine absence rather than a collection gap.

Honest traffic therefore sits exactly on the curve, and enforcing rejects nothing
that is accepted today. What the production data does *not* establish is detection
power: prod contained no off-curve quotes, so the rejection path was never
exercised there. That side is covered by unit tests.

**Unit tests.** 768 pass, 0 fail. Getting there took more than the flag flip, and
the reason is worth a reviewer's attention.

Flipping the gate initially broke **30 tests**, none of them a product problem: the
payment test fixtures build quotes whose `committed_key_count` does not match their
`price`, so they were never valid under the ADR-0004 binding rule and only passed
because the gate was off. Specifically:

- `make_fake_quote` priced every quote at a placeholder `1` while claiming
  `committed_key_count: 0`, whose curve price is `3906250000000000`.
- `make_fake_quote_at_records(n)` set `price = calculate_price(n)` but left the
  count at `0`, i.e. a quote charging as though it stored `n` keys while committing
  to storing nothing. That is exactly what the gate is meant to reject, so the
  fixture named "honest bundle" was not honest.
- `make_signed_quote` had the same split, so it now derives the binding from the
  price.
- The merkle candidate fixture priced at a placeholder `1024`, and the depth-2
  settlement constants (`6144`, `2048`) were scaled to that placeholder. Both are
  now derived from the curve so they track it instead of drifting.

Product code is unchanged apart from the const. Every edit above is test-only.

Two tests changed meaning rather than just fixtures, flagged explicitly:

- `adr0004_observe_only_does_not_reject_off_curve_quote` was gated on the const
  being `false`, so after the flip its body would never execute. It now asserts
  both branches and is renamed `adr0004_off_curve_quote_follows_rollout_gate`.
- `test_legacy_zero_price_median_rejected`: `Amount::ZERO` is not on the curve, so
  the arithmetic gate now rejects the bundle before median selection and the
  dedicated zero-price check is unreachable for single-node quotes. The gate
  subsumes it. The test accepts either rejection and the docstring says why.

**Follow-up from review: the pay-yourself fixture's settlement was wrong.**
`test_attack_merkle_pay_yourself_fabricated_pool` funded its fabricated
`OnChainPaymentInfo` at `price * 2^depth`, dropping the `/ depth` term from the
formula the verifier applies (`multiplier * median16(price) * 2^depth / depth`).
At depth 2 that is `2 * price` under the legacy rule and `6 * price` from
`MERKLE_PARITY_ENFORCED_FROM_UNIX` onward, so the fixture's `4 * price` was
neither and underpaid on the parity side.

The test stayed green because candidate closeness is checked before cached
settlement, but the fixture had stopped satisfying its stated invariant: it
claims to be funded so closeness is the only check that can reject the proof,
and an unrelated underpayment rejection sat behind it. Had closeness been
bypassed or regressed, the test would have passed for the wrong reason.

It now funds at the parity amount, derived from the curve rather than a literal.
Since the verifier only rejects underpayment, the parity amount also clears the
legacy expectation, so the fixture is correct on both sides of the boundary
without pinning it, and a unit test restates the depth-2 case as literals so a
future drift fails loudly.

## New dependency
none

## ADR
https://github.com/WithAutonomi/ant-node/blob/main/docs/adr/ADR-0004-commitment-bound-quote-pricing.md

This is the rollout gate ADR-0004 specifies, moving from its observe-only stage to
enforcement. See also
[the implementation slices](https://github.com/WithAutonomi/ant-node/blob/main/docs/adr/implementation-slices-adr-0004.md).

## Mitigation / rollback
Flip `QUOTE_ARITHMETIC_RECHECK_ENABLED` back to `false` and ship.

In source terms that is as cheap as a rollback gets: a single crate constant, no
persisted state, no wire effect, so it is a one-line revert with no migration and
nothing to undo on disk or on the network. It is worth being plain that the
*source* change is the cheap part. There is no runtime switch here, so getting
the revert into the field means a rebuild, a release and a fleet restart, on the
same timeline as any other node release. Plan for release latency, not for a
flag flip.

What limits the blast radius in the meantime is the gate's shape rather than the
speed of the rollback. It is reject-only per ADR-0004: an off-curve quote
produces no trust evidence and schedules no audit, so a misbehaving gate cannot
feed the trust engine or evict peers. The worst case is refused stores on the
affected quotes until the release lands, not accumulated trust damage that
outlives it.

## Note for reviewers

This is deliberately only the quote-arithmetic half. It does **not** address a
client shopping the closest group for the cheapest quote, which is a separate
economic question. The receiver-side price floor from #176 is **not** enabled here
and, on the same production data, should not be: honest stores already fall below
it 0.377% of the time because node prices legitimately vary about 4x across the
fleet.

