### PR TITLE
fix(payment): require an explicit tolerance to enforce the price floor

### DIFF
--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -28,6 +28,7 @@ use saorsa_core::identity::node_identity::peer_id_from_public_key_bytes;
 use saorsa_core::identity::PeerId;
 use saorsa_core::P2PNode;
 use std::collections::HashMap;
+use std::env::VarError;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Instant;
@@ -193,10 +194,18 @@ impl GroupSample {
 /// Absent or any other value means shadow mode: the floor is computed and
 /// logged, never enforced. Per-node so enforcement can roll out canary-first;
 /// unsetting it (and restarting) is the kill switch.
+///
+/// Not sufficient on its own: [`PRICE_FLOOR_TOLERANCE_ENV`] must also name a
+/// valid tolerance, or [`PriceFloorConfig::from_env`] stays in shadow mode.
 pub const PRICE_FLOOR_ENFORCE_ENV: &str = "ANT_PRICE_FLOOR_ENFORCE";
 
-/// Environment variable overriding the price-floor tolerance percentage
-/// (`0..=100`). Invalid or absent values use the default.
+/// Environment variable setting the price-floor tolerance percentage
+/// (`0..=100`).
+///
+/// Required to enforce, optional to measure. In shadow mode an absent or
+/// unreadable value falls back to the default so telemetry still has a number.
+/// Under [`PRICE_FLOOR_ENFORCE_ENV`] there is no fallback: an absent or
+/// unreadable value fails closed to shadow mode.
 pub const PRICE_FLOOR_TOLERANCE_ENV: &str = "ANT_PRICE_FLOOR_TOLERANCE_PERCENT";
 
 /// Receiver-side price floor for single-node store admissions.
@@ -244,46 +253,67 @@ impl PriceFloorConfig {
     /// Build from the environment (see [`PRICE_FLOOR_ENFORCE_ENV`] and
     /// [`PRICE_FLOOR_TOLERANCE_ENV`]). Never panics.
     ///
-    /// An unset tolerance uses the default. A tolerance that is *present but
-    /// invalid* (unparseable or `> 100`) is an operator error: rather than
-    /// silently enforce at the default, this **fails closed to shadow mode**
-    /// (`enforce = false`) and logs a prominent error, so a fat-fingered
-    /// tolerance can never enforce an unintended floor against real payments.
+    /// **Enforcement requires an explicitly specified, valid tolerance.**
+    /// Anything else (unset, unparseable, `> 100`, or not readable as Unicode)
+    /// **fails closed to shadow mode** (`enforce = false`) and logs a prominent
+    /// error. Shadow mode still evaluates, at the default tolerance, because its
+    /// whole job is to produce telemetry.
+    ///
+    /// The tolerance is not a formatting detail, it is the policy: it decides
+    /// which already-settled, unrefundable payments get refused. Its meaning also
+    /// depends on what the floor is priced against, and that reference has
+    /// changed once already, so a node carrying an older enforcement opt-in must
+    /// not silently start enforcing a newer rule at a default nobody chose for
+    /// it. Requiring the operator to name a tolerance is what makes enabling
+    /// enforcement a deliberate act under the rule that is actually in force.
     #[must_use]
     pub fn from_env() -> Self {
         let enforce_requested = std::env::var(PRICE_FLOOR_ENFORCE_ENV)
             .is_ok_and(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "True"));
 
-        let tolerance_raw = std::env::var(PRICE_FLOOR_TOLERANCE_ENV).ok();
+        // `var` separates three cases and only ONE of them means the operator
+        // said nothing. A value that is set but not readable as Unicode is still
+        // a value someone set, so it must not be mistaken for an absent one:
+        // reading it through `.ok()` would collapse it onto "unset" and hand it
+        // the default.
+        let tolerance_raw = std::env::var(PRICE_FLOOR_TOLERANCE_ENV);
+        let tolerance_unset = matches!(tolerance_raw, Err(VarError::NotPresent));
         let valid_tolerance = tolerance_raw
             .as_deref()
+            .ok()
             .map(str::trim)
             .and_then(|s| s.parse::<u64>().ok())
             .filter(|percent| *percent <= 100);
-        // A tolerance that is set but does not parse to `0..=100` is an operator
-        // error. Fail CLOSED: never enforce a tolerance the operator did not
-        // actually specify.
-        let tolerance_present_but_invalid = tolerance_raw.is_some() && valid_tolerance.is_none();
 
-        if tolerance_present_but_invalid {
+        // Name WHICH unusable state the tolerance is in, as a value rather than
+        // as duplicated log arms. The two states take different fixes (set it
+        // versus correct it), and telling an operator it is unset when they did
+        // set it, to something this process cannot read, sends them to the wrong
+        // one.
+        let tolerance_problem = match (valid_tolerance.is_some(), tolerance_unset) {
+            (true, _) => None,
+            (false, true) => Some("is unset"),
+            (false, false) => Some("is not readable as an integer in 0..=100"),
+        };
+
+        if let Some(problem) = tolerance_problem {
             if enforce_requested {
                 crate::logging::error!(
-                    "{PRICE_FLOOR_TOLERANCE_ENV}={tolerance_raw:?} is not an integer in 0..=100; \
-                     refusing to enforce the price floor with an unspecified tolerance. \
-                     Price-floor enforcement DISABLED (shadow mode). Fix the value and restart \
-                     to enable enforcement."
+                    "Price-floor enforcement was requested but {PRICE_FLOOR_TOLERANCE_ENV} \
+                     {problem}; refusing to enforce a tolerance nobody specified. Price-floor \
+                     enforcement DISABLED (shadow mode). Set {PRICE_FLOOR_TOLERANCE_ENV} to an \
+                     integer in 0..=100 and restart to enable enforcement."
                 );
-            } else {
+            } else if !tolerance_unset {
                 crate::logging::warn!(
-                    "{PRICE_FLOOR_TOLERANCE_ENV}={tolerance_raw:?} is not an integer in 0..=100; \
-                     using the default {PRICE_FLOOR_DEFAULT_TOLERANCE_PERCENT}% for shadow-mode \
-                     telemetry."
+                    "{PRICE_FLOOR_TOLERANCE_ENV} {problem}; using the default \
+                     {PRICE_FLOOR_DEFAULT_TOLERANCE_PERCENT}% for shadow-mode telemetry."
                 );
             }
         }
 
         Self {
-            enforce: enforce_requested && !tolerance_present_but_invalid,
+            enforce: enforce_requested && valid_tolerance.is_some(),
             tolerance_percent: valid_tolerance.unwrap_or(PRICE_FLOOR_DEFAULT_TOLERANCE_PERCENT),
         }
     }
@@ -5139,6 +5169,59 @@ mod tests {
         std::env::set_var(PRICE_FLOOR_TOLERANCE_ENV, "loose");
         let cfg = PriceFloorConfig::from_env();
         assert!(!cfg.enforce);
+
+        // Enforce on, tolerance UNSET: disabled too. This is the upgrade case —
+        // a node carrying an enforcement opt-in from an older release, where the
+        // floor was priced against a different reference, must not resume
+        // enforcing under the current rule at a default it never chose.
+        std::env::remove_var(PRICE_FLOOR_TOLERANCE_ENV);
+        let cfg = PriceFloorConfig::from_env();
+        assert!(
+            !cfg.enforce,
+            "enforcement must require an explicitly specified tolerance, not inherit a default"
+        );
+        assert_eq!(
+            cfg.tolerance_percent, PRICE_FLOOR_DEFAULT_TOLERANCE_PERCENT,
+            "shadow mode still needs a number to measure with"
+        );
+
+        // Enforce on, tolerance set but NOT READABLE as Unicode: disabled too.
+        //
+        // Stated precisely, because the stronger claim is tempting and wrong:
+        // requiring a valid tolerance ALREADY covers this, since an unreadable
+        // value cannot parse and so is not valid. This case is not what makes
+        // enforcement safe here; it pins that the unreadable path stays on the
+        // fail-closed side if the "explicitly specified" rule is ever relaxed
+        // back toward a default, which is when `NotUnicode` collapsing onto
+        // `NotPresent` would start deciding the outcome again. The value of
+        // separating them TODAY is the operator-facing message: telling someone
+        // the tolerance is unset when they did set it, to something this process
+        // cannot read, sends them to the wrong fix.
+        //
+        // Kept inside this test rather than beside it: this test owns the
+        // `PRICE_FLOOR_*` variables, and a sibling test setting them would race
+        // its cleanup rather than measure anything.
+        #[cfg(unix)]
+        {
+            use std::ffi::OsStr;
+            use std::os::unix::ffi::OsStrExt;
+
+            // Lone continuation byte: a real value, and not valid UTF-8.
+            std::env::set_var(PRICE_FLOOR_TOLERANCE_ENV, OsStr::from_bytes(&[0x80]));
+            assert!(
+                std::env::var_os(PRICE_FLOOR_TOLERANCE_ENV).is_some(),
+                "the value must really be set for this case to discriminate"
+            );
+            assert!(
+                std::env::var(PRICE_FLOOR_TOLERANCE_ENV).is_err(),
+                "and it must really be unreadable as Unicode"
+            );
+            let cfg = PriceFloorConfig::from_env();
+            assert!(
+                !cfg.enforce,
+                "an unreadable tolerance is a SET value, not an absent one, and must fail closed"
+            );
+        }
 
         std::env::remove_var(PRICE_FLOOR_ENFORCE_ENV);
         std::env::remove_var(PRICE_FLOOR_TOLERANCE_ENV);


### PR DESCRIPTION
## Linear issue

- https://linear.app/autonominetwork/issue/V2-696

## Risk tier

- [ ] T0 — docs / tooling / CI / pure UX-output. Repo CI only.
- [ ] T1 — client-only, no network-facing behavior change. CI + prod compat smoke.
- [x] T2 — node/client logic with behavioral surface, no protocol/format/economics change. Dev testnet + ADR.
- [ ] T3 — protocol / storage format / payments / routing. T2 evidence + adversarial testing.

T2, and worth stating why it is not T3 given the file. This changes no pricing, no
quote, no settlement arithmetic and nothing on the wire. It changes one startup
decision: whether an operator's enforcement opt-in is honoured. The only behaviour
that can differ is on a node that sets `ANT_PRICE_FLOOR_ENFORCE=1` without a
tolerance, and that node now stays in shadow mode instead of enforcing.

Not T1, because a node could in principle be enforcing today and stop.
**No node is.** The measurement in #193 covers 912 of 913 production instances
over 2026-07-29..08-04, all shadow.

## Compatibility

- Wire: none.
- Storage: none.
- API: none. `PriceFloorConfig` keeps its shape and its `Default`.
- Operational: `ANT_PRICE_FLOOR_ENFORCE=1` alone no longer enforces.
  `ANT_PRICE_FLOOR_TOLERANCE_PERCENT` must also be set to `0..=100`. A node that
  sets only the first stays in shadow mode and logs an error saying so.

## Semver impact

- [ ] breaking
- [ ] feature
- [x] fix

No API change; a defect in how an opt-in was interpreted.

## Test evidence

- `cfd` clean: clippy `-D warnings` across all targets and features, fmt,
  `cargo doc --deny=warnings`.
- `--no-default-features` clippy holds at the **13-warning baseline** `main`
  already carries. The first draft of this change added a 14th
  (`match` arms that become identical once the log macros compile out); it was
  restructured to state the diagnostic as a value instead.
- 919 lib tests, including the extended environment test.

**Verified to fail without the change.** The production expression was reverted
to the previous semantics and the test observed to break on
`enforcement must require an explicitly specified tolerance, not inherit a
default`, then restored.

The new cases live inside `price_floor_from_env_fails_closed_on_invalid_tolerance`
rather than in a sibling test. That test already declares it owns the
`PRICE_FLOOR_*` variables; a sibling setting them raced its cleanup, which is how
the first attempt failed, on the setup assertion rather than the assertion under
test.

## New dependency

None.

## ADR

https://github.com/WithAutonomi/ant-node/blob/main/docs/adr/ADR-0006-receiver-side-revenue-floor.md

No decision changes. ADR-0006 already records that enforcement is a deliberate
per-node opt-in and that the floor is not safe to enforce yet; this makes the
opt-in behave the way the ADR describes. Not amended, because nothing it decided
moved.

## Mitigation / rollback

Revert the commit. No stored data, no migration, no wire effect. An operator who
genuinely wants enforcement sets the tolerance explicitly, which is the
documented path either way.

---

## Why

Found while reviewing #193's own production-safety claim ("ships shadow-only, not
safe to enforce") against the code that shipped. The shadow-only claim holds. This
is about what happens the moment someone acts on the opt-in it documents.

`ANT_PRICE_FLOOR_ENFORCE=1` was sufficient by itself, and the tolerance fell back
to a compiled-in default. Two problems with that, one general and one specific to
where this code has been:

1. **The tolerance is the policy.** It decides which already-settled,
   unrefundable payments get refused. #193 measured the previous floor firing on
   0.377% of honest stores at production scale. A default is the wrong thing to
   supply silently for the one variable that decides who is rejected.

2. **Its meaning already changed once.** The floor used to be priced against the
   receiver's own commitment-bound price and is now priced against the
   close-group median, so the same percentage does not mean the same thing before
   and after #193. A node carrying an enforcement opt-in across that upgrade
   would silently start enforcing a different rule at a percentage nobody picked
   for it.

The function's own comment already said it should "never enforce a tolerance the
operator did not actually specify". Two of the three unusable states were exempt
from that rule: unset, and set-but-not-readable-as-Unicode (`std::env::var`
returns `NotUnicode` there, and reading it through `.ok()` collapses it onto
`NotPresent`, so it looked absent and took the default).

**One thing I want to be precise about, because the tidier claim is wrong.**
Requiring a valid tolerance already covers the non-Unicode case, since an
unreadable value cannot parse. So separating `NotUnicode` from `NotPresent` is
**not** a second safety fix here. Its value today is the operator-facing message:
telling someone their tolerance is unset, when they did set it to something the
process cannot read, sends them to the wrong fix. I checked this by reverting
each half separately rather than assuming.

Shadow mode is deliberately untouched and still evaluates at the default
tolerance. Producing telemetry is its whole purpose, and it is what the entire
fleet runs.

## Not in scope

The review also surfaced two things that are **not** fixed here, because neither
is a small fix:

- Gossiped commitments carry no generation counter, so a peer can replay an older
  signed high-count commitment and ingest refreshes it as current for the
  answerability TTL. That compounds the roughly-4-of-15 manipulation bound
  ADR-0006 and #193 already document.
- The "at most 19 neighbours" ceiling in the sample is the normal case rather than
  a guarantee: the upstream K-closest helper appends self and truncates to K, so
  self is not guaranteed to survive. Production gossip never caches self, so this
  is unreached today.

Both matter before anyone enables enforcement, and neither belongs in a change
this size.
