### PR TITLE
fix(replication): bound total bootstrap stall with a force-drain deadline

### DIFF
--- a/docs/adr/ADR-0010-bound-replication-bootstrap-drain.md
+++ b/docs/adr/ADR-0010-bound-replication-bootstrap-drain.md
@@ -1,0 +1,121 @@
+# ADR-0010: Bound replication bootstrap drain with an overall deadline
+
+- **Status:** Proposed
+- **Date:** 2026-08-06
+- **Decision owners:** @dirvine
+- **Reviewers:** @jacderida, @grumbach
+- **Supersedes:** none
+- **Superseded by:** none
+- **Related:** Linear V2-882 (implementation), V2-864 (production pruning impact), ADR-0005 (replication repair hardening)
+
+## Context
+
+A joining node remains in replication bootstrap until all peer requests,
+bootstrap-discovered keys, and capacity-rejection debt have drained. While
+`is_bootstrapping` is true, audits are paused (Invariant 19), remote prune
+confirmation is gated, and the node continues advertising itself as
+bootstrapping.
+
+ADR-0005 and the changes already on `main` bound one known wedge: each
+capacity-rejected source is first-seen timestamped and eventually expires if it
+never returns for a clean admission cycle. That does not bound every bootstrap
+state. Multiple sources can enter at different times, or a `pending_keys` /
+`pending_peer_requests` path can fail to reach its terminal cleanup after
+storage failure or restart. There is no overall deadline, so a new or
+unanticipated cleanup defect can still keep audits and pruning disabled for the
+lifetime of the process.
+
+Production evidence in V2-864 includes peers claiming bootstrap beyond the
+24-hour grace period and pruning candidates remaining entirely
+`bootstrap_deferred`. The safe fail-closed behaviour prevents unsafe deletion,
+but an unbounded bootstrap stall fills disks and removes the node from effective
+audit participation.
+
+## Decision Drivers
+
+- No peer or stale internal state may disable audits and pruning indefinitely.
+- Honest bootstrap work must retain a meaningful period to complete normally.
+- Missed bootstrap work must remain recoverable through steady-state neighbour
+  sync and the audit/repair pipeline.
+- The change must not alter wire messages, storage format, payments, or trust
+  attribution.
+- Operators need explicit evidence when the safety ceiling fires.
+
+## Considered Options
+
+1. **Rely only on per-source capacity-rejection expiry.** Rejected: it closes the
+   known source-debt wedge but does not cover stalled pending requests, pending
+   keys, or future cleanup defects.
+2. **Restart any node that exceeds the bootstrap grace period.** Rejected: this
+   is an operational workaround, loses causal evidence, and can replay the same
+   stale state or bootstrap path.
+3. **Force replication bootstrap drain after an overall deadline (chosen).**
+   Preserve normal drain checks before the deadline, then transition to steady
+   state with an explicit warning once the ceiling is reached.
+4. **Delete or ignore all bootstrap work immediately under pressure.** Rejected:
+   it weakens normal completeness and makes transient load indistinguishable
+   from a real terminal wedge.
+
+## Decision
+
+We will add a configurable `bootstrap_drain_deadline`, defaulting to 30 minutes,
+and record `bootstrap_started_at` when replication drain tracking begins.
+
+`check_bootstrap_drained` will check this deadline before pending-request,
+capacity-rejection and pending-key gates. Once elapsed, it will mark bootstrap
+drained and emit a WARN containing the configured deadline and the remaining
+source/request/key counts. Before the deadline, existing drain and per-source
+expiry semantics remain unchanged.
+
+The default is aligned with `PENDING_VERIFY_MAX_AGE` (30 minutes). By the time
+the ceiling fires, stale pending-verification entries have already reached their
+normal eviction bound. Any forfeited or late work remains discoverable through
+post-bootstrap periodic neighbour sync and the audit/repair pipeline.
+
+## Consequences
+
+### Positive
+
+- Total replication bootstrap stall is bounded independently of attacker pattern
+  or the exact cleanup defect.
+- Audits and prune confirmation resume instead of remaining disabled for the
+  process lifetime.
+- The forced transition is visible and carries the outstanding-state counts
+  needed for follow-up investigation.
+- No protocol, data-format, payment, or client compatibility change.
+
+### Negative / Trade-offs
+
+- A node can enter steady state with genuine bootstrap work still outstanding.
+  This trades bootstrap completeness for bounded liveness.
+- The 30-minute default is a policy value and may require tuning from fleet
+  evidence.
+- Forced drain does not repair the underlying failed work item; steady-state
+  reconciliation must recover it.
+
+### Neutral / Operational
+
+- The deadline is configurable through `ReplicationConfig` but is not a new CLI
+  surface in this change.
+- A force-drain WARN is an investigation signal, not proof of data loss.
+- Per-source capacity-rejection expiry remains the first-line targeted defence;
+  this deadline is the unconditional backstop.
+
+## Validation
+
+- Unit test: force drain after the deadline despite outstanding requests,
+  rejected sources and pending keys.
+- Unit test: before the deadline, outstanding work still blocks drain.
+- Existing bootstrap capacity-rejection, peer-removal and TTL tests remain
+  green.
+- Run the focused replication/config suites plus `cargo check`, formatting and
+  clippy.
+- Fleet review trigger: monitor force-drain frequency and outstanding counts. If
+  normal healthy nodes hit the ceiling, investigate before increasing it; do not
+  silently normalise repeated forced drains.
+
+## Notes for AI-assisted work
+
+AI tools may help draft this ADR, but **must not mark it Accepted without human
+review**. Accepted ADRs are immutable: create a new superseding ADR rather than
+editing an Accepted ADR.

--- a/src/node.rs
+++ b/src/node.rs
@@ -538,7 +538,7 @@ impl RunningNode {
             // Safety: dht_events_for_bootstrap is Some when replication_engine
             // is Some (both arms use the same condition).
             if let Some(dht_events) = dht_events_for_bootstrap {
-                engine.start(dht_events);
+                engine.start(dht_events).await;
             }
             info!("Replication engine started");
         }

--- a/src/replication/bootstrap.rs
+++ b/src/replication/bootstrap.rs
@@ -136,6 +136,14 @@ pub async fn check_bootstrap_drained(
             state.pending_peer_requests,
             state.pending_keys.len(),
         );
+        // The deadline deliberately abandons bootstrap accounting debt. Clear
+        // that debt as one atomic state transition so post-bootstrap
+        // verification and cleanup are not still gated by stale request
+        // counters or bootstrap-only key tracking. Queue contents are left
+        // intact and continue through the normal verification pipeline.
+        state.pending_peer_requests = 0;
+        state.pending_keys.clear();
+        state.capacity_rejected_sources.clear();
         state.drained = true;
         return true;
     }
@@ -183,6 +191,9 @@ pub async fn note_capacity_rejected(
     source: saorsa_core::identity::PeerId,
 ) {
     let mut state = bootstrap_state.write().await;
+    if state.drained {
+        return;
+    }
     if state.note_capacity_rejected(source, Instant::now()) {
         let n = state.capacity_rejected_sources.len();
         debug!(
@@ -254,6 +265,9 @@ pub async fn track_discovered_keys(
     keys: &HashSet<XorName>,
 ) {
     let mut state = bootstrap_state.write().await;
+    if state.drained {
+        return;
+    }
     state.pending_keys.extend(keys);
     debug!(
         "Bootstrap tracking {} total discovered keys",
@@ -267,6 +281,9 @@ pub async fn increment_pending_requests(
     count: usize,
 ) {
     let mut state = bootstrap_state.write().await;
+    if state.drained {
+        return;
+    }
     state.pending_peer_requests += count;
 }
 
@@ -419,6 +436,22 @@ mod tests {
             0,
             "should saturate at zero"
         );
+    }
+
+    #[tokio::test]
+    async fn drained_state_ignores_new_bootstrap_accounting() {
+        let source = saorsa_core::identity::PeerId::from_bytes([7; 32]);
+        let state = Arc::new(RwLock::new(BootstrapState::new()));
+        mark_bootstrap_drained(&state).await;
+
+        increment_pending_requests(&state, 3).await;
+        track_discovered_keys(&state, &HashSet::from([xor_name_from_byte(0x01)])).await;
+        note_capacity_rejected(&state, source).await;
+
+        let state = state.read().await;
+        assert_eq!(state.pending_peer_requests, 0);
+        assert!(state.pending_keys.is_empty());
+        assert!(state.capacity_rejected_sources.is_empty());
     }
 
     /// Round-3 regression: a source that previously had capacity-rejected
@@ -641,7 +674,9 @@ mod tests {
                 m
             },
             // Backdate bootstrap start past the 60s deadline.
-            bootstrap_started_at: Instant::now() - Duration::from_secs(61),
+            bootstrap_started_at: Instant::now()
+                .checked_sub(Duration::from_secs(61))
+                .expect("test duration must fit in Instant"),
             bootstrap_drain_deadline: Duration::from_secs(60),
         }));
         let queues = ReplicationQueues::new();
@@ -654,6 +689,10 @@ mod tests {
             state.read().await.drained,
             "drained flag must be set by force-drain"
         );
+        let state = state.read().await;
+        assert_eq!(state.pending_peer_requests, 0);
+        assert!(state.pending_keys.is_empty());
+        assert!(state.capacity_rejected_sources.is_empty());
     }
 
     /// (d) Within the deadline, outstanding state still blocks drain: the

--- a/src/replication/bootstrap.rs
+++ b/src/replication/bootstrap.rs
@@ -118,6 +118,28 @@ pub async fn check_bootstrap_drained(
         return true;
     }
 
+    // (d) Overall force-drain backstop — unconditional ceiling. Placed first
+    // so it fires regardless of pending peer requests, capacity-rejected
+    // sources, or undiscovered keys. Bounds total bootstrap stall even when
+    // per-source expiry alone would not resolve the wedge (e.g. multiple
+    // coordinated over-cap sources, or a `pending_keys` path that never
+    // empties after a disk-full restart). Aligned with `PENDING_VERIFY_MAX_AGE`
+    // so by the deadline stale `pending_verify` entries have already been
+    // evicted, leaving minimal genuine residual work.
+    let now = Instant::now();
+    if now.duration_since(state.bootstrap_started_at) >= state.bootstrap_drain_deadline {
+        warn!(
+            "Bootstrap force-drain: {:?} stall ceiling reached, draining with \
+             possibly-outstanding work (rejects={}, pending_peer_requests={}, pending_keys={})",
+            state.bootstrap_drain_deadline,
+            state.capacity_rejected_sources.len(),
+            state.pending_peer_requests,
+            state.pending_keys.len(),
+        );
+        state.drained = true;
+        return true;
+    }
+
     if state.pending_peer_requests > 0 {
         return false;
     }
@@ -277,6 +299,8 @@ mod tests {
             pending_peer_requests: 5,
             pending_keys: HashSet::new(),
             capacity_rejected_sources: std::collections::HashMap::new(),
+            bootstrap_started_at: Instant::now(),
+            bootstrap_drain_deadline: Duration::from_secs(1800),
         }));
         let queues = ReplicationQueues::new();
 
@@ -293,6 +317,8 @@ mod tests {
             pending_peer_requests: 2,
             pending_keys: HashSet::new(),
             capacity_rejected_sources: std::collections::HashMap::new(),
+            bootstrap_started_at: Instant::now(),
+            bootstrap_drain_deadline: Duration::from_secs(1800),
         }));
         let queues = ReplicationQueues::new();
 
@@ -309,6 +335,8 @@ mod tests {
             pending_peer_requests: 0,
             pending_keys: std::iter::once(xor_name_from_byte(0x01)).collect(),
             capacity_rejected_sources: std::collections::HashMap::new(),
+            bootstrap_started_at: Instant::now(),
+            bootstrap_drain_deadline: Duration::from_secs(1800),
         }));
         let queues = ReplicationQueues::new();
 
@@ -324,6 +352,8 @@ mod tests {
             pending_peer_requests: 0,
             pending_keys: std::iter::once(xor_name_from_byte(0x01)).collect(),
             capacity_rejected_sources: std::collections::HashMap::new(),
+            bootstrap_started_at: Instant::now(),
+            bootstrap_drain_deadline: Duration::from_secs(1800),
         }));
         let mut queues = ReplicationQueues::new();
 
@@ -589,6 +619,65 @@ mod tests {
         assert!(
             check_bootstrap_drained(&state, &queues).await,
             "bootstrap must drain once the expired debt is forfeited"
+        );
+    }
+
+    /// (d) Force-drain backstop: past the overall drain deadline, drain is
+    /// forced even with outstanding peer requests, capacity-rejected sources,
+    /// and pending keys. This is the unconditional ceiling that bounds total
+    /// bootstrap stall regardless of any per-source or per-key state.
+    #[tokio::test]
+    async fn force_drain_after_overall_deadline() {
+        let state = Arc::new(RwLock::new(BootstrapState {
+            drained: false,
+            pending_peer_requests: 3,
+            pending_keys: std::iter::once(xor_name_from_byte(0x01)).collect(),
+            capacity_rejected_sources: {
+                let mut m = std::collections::HashMap::new();
+                m.insert(
+                    saorsa_core::identity::PeerId::from_bytes([0xAA; 32]),
+                    Instant::now(),
+                );
+                m
+            },
+            // Backdate bootstrap start past the 60s deadline.
+            bootstrap_started_at: Instant::now() - Duration::from_secs(61),
+            bootstrap_drain_deadline: Duration::from_secs(60),
+        }));
+        let queues = ReplicationQueues::new();
+
+        assert!(
+            check_bootstrap_drained(&state, &queues).await,
+            "force-drain must fire after the overall deadline despite all outstanding work"
+        );
+        assert!(
+            state.read().await.drained,
+            "drained flag must be set by force-drain"
+        );
+    }
+
+    /// (d) Within the deadline, outstanding state still blocks drain: the
+    /// force-drain ceiling must NOT fire early and mask genuine in-progress
+    /// bootstrap work.
+    #[tokio::test]
+    async fn force_drain_does_not_fire_within_deadline() {
+        let state = Arc::new(RwLock::new(BootstrapState {
+            drained: false,
+            pending_peer_requests: 1,
+            pending_keys: HashSet::new(),
+            capacity_rejected_sources: std::collections::HashMap::new(),
+            bootstrap_started_at: Instant::now(),
+            bootstrap_drain_deadline: Duration::from_secs(1800),
+        }));
+        let queues = ReplicationQueues::new();
+
+        assert!(
+            !check_bootstrap_drained(&state, &queues).await,
+            "within the deadline, pending peer requests must still block drain"
+        );
+        assert!(
+            !state.read().await.drained,
+            "force-drain must not fire before the deadline"
         );
     }
 }

--- a/src/replication/config.rs
+++ b/src/replication/config.rs
@@ -635,7 +635,7 @@ pub const PENDING_VERIFY_MAX_AGE: Duration = Duration::from_secs(PENDING_VERIFY_
 /// paths. Aligned with `PENDING_VERIFY_MAX_AGE` so by the deadline stale
 /// `pending_verify` entries have already been evicted.
 const BOOTSTRAP_DRAIN_DEADLINE_SECS: u64 = 30 * 60;
-/// Hard ceiling on total bootstrap stall (see [`BOOTSTRAP_DRAIN_DEADLINE_SECS`]).
+/// Hard ceiling on total bootstrap stall (30 minutes).
 pub const BOOTSTRAP_DRAIN_DEADLINE: Duration = Duration::from_secs(BOOTSTRAP_DRAIN_DEADLINE_SECS);
 
 /// Trust event weight for confirmed audit failures.

--- a/src/replication/config.rs
+++ b/src/replication/config.rs
@@ -626,6 +626,18 @@ const PENDING_VERIFY_MAX_AGE_SECS: u64 = 30 * 60;
 /// Maximum age for pending-verification entries before stale eviction.
 pub const PENDING_VERIFY_MAX_AGE: Duration = Duration::from_secs(PENDING_VERIFY_MAX_AGE_SECS);
 
+/// Hard ceiling on total bootstrap stall. If bootstrap has not drained within
+/// this duration of the moment bootstrap drain tracking began, drain is forced
+/// with a `warn!` log regardless of any outstanding state. Defence-in-depth
+/// backstop behind the per-source capacity-rejection expiry
+/// (`capacity_rejected_max_age`): it covers multiple coordinated over-cap
+/// sources and any future wedge in the `pending_keys` / `pending_peer_requests`
+/// paths. Aligned with `PENDING_VERIFY_MAX_AGE` so by the deadline stale
+/// `pending_verify` entries have already been evicted.
+const BOOTSTRAP_DRAIN_DEADLINE_SECS: u64 = 30 * 60;
+/// Hard ceiling on total bootstrap stall (see [`BOOTSTRAP_DRAIN_DEADLINE_SECS`]).
+pub const BOOTSTRAP_DRAIN_DEADLINE: Duration = Duration::from_secs(BOOTSTRAP_DRAIN_DEADLINE_SECS);
+
 /// Trust event weight for confirmed audit failures.
 pub const AUDIT_FAILURE_TRUST_WEIGHT: f64 = 5.0;
 
@@ -833,6 +845,11 @@ pub struct ReplicationConfig {
     /// Seconds to wait for `DhtNetworkEvent::BootstrapComplete` before
     /// proceeding with bootstrap sync (covers bootstrap nodes with no peers).
     pub bootstrap_complete_timeout_secs: u64,
+    /// Hard ceiling on total bootstrap stall. If bootstrap has not drained
+    /// within this duration of the moment drain tracking began, drain is
+    /// forced with a `warn!` log regardless of outstanding state.
+    /// Defaults to [`BOOTSTRAP_DRAIN_DEADLINE`].
+    pub bootstrap_drain_deadline: Duration,
     /// Lower bound of the delay before a fresh-replication possession check
     /// runs (ADR-0003). Defaults to [`POSSESSION_CHECK_DELAY_MIN`]; tests
     /// shorten it so the scheduled check fires quickly.
@@ -883,6 +900,7 @@ impl Default for ReplicationConfig {
             verification_request_timeout: VERIFICATION_REQUEST_TIMEOUT,
             fetch_request_timeout: FETCH_REQUEST_TIMEOUT,
             bootstrap_complete_timeout_secs: BOOTSTRAP_COMPLETE_TIMEOUT_SECS,
+            bootstrap_drain_deadline: BOOTSTRAP_DRAIN_DEADLINE,
             possession_check_delay_min: POSSESSION_CHECK_DELAY_MIN,
             possession_check_delay_max: POSSESSION_CHECK_DELAY_MAX,
             subtree_round1_responder_cooldown: SUBTREE_ROUND1_RESPONDER_COOLDOWN,

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -2153,12 +2153,18 @@ impl ReplicationEngine {
     /// `dht_events` must be subscribed **before** `P2PNode::start()` so that
     /// the `BootstrapComplete` event emitted during DHT bootstrap is not
     /// missed by the bootstrap-sync gate.
-    pub fn start(&mut self, dht_events: tokio::sync::broadcast::Receiver<DhtNetworkEvent>) {
+    pub async fn start(&mut self, dht_events: tokio::sync::broadcast::Receiver<DhtNetworkEvent>) {
         if !self.task_handles.is_empty() {
             error!("ReplicationEngine::start() called while already running — ignoring");
             return;
         }
         info!("Starting replication engine");
+
+        // Construction can happen well before P2P startup and bootstrap.
+        // Start the hard drain ceiling here, when replication bootstrap and
+        // its workers actually begin, rather than charging network startup
+        // time against the drain budget.
+        self.bootstrap_state.write().await.bootstrap_started_at = Instant::now();
 
         self.start_message_handler();
         self.start_neighbor_sync_loop();
@@ -3738,6 +3744,10 @@ impl ReplicationEngine {
             // Process neighbors in batches of NEIGHBOR_SYNC_PEER_COUNT.
             for batch in neighbors.chunks(config.neighbor_sync_peer_count) {
                 if shutdown.is_cancelled() {
+                    break;
+                }
+                if bootstrap_state.read().await.drained {
+                    info!("Bootstrap sync: drain already completed, stopping remaining batches");
                     break;
                 }
 
@@ -7646,9 +7656,15 @@ async fn run_verification_cycle(ctx: VerificationCycleContext<'_>) {
 
     // Bootstrap admits one concurrent neighbor batch as an atomic source
     // aggregation unit. Do not select newly queued keys until that batch's
-    // hints and drain accounting have both been published.
-    if bootstrap_state.read().await.pending_peer_requests > 0 {
-        return;
+    // hints and drain accounting have both been published. The barrier only
+    // applies while bootstrap is still active: once force-drained the
+    // deadline has abandoned outstanding request debt, so a counter
+    // resurrected by a late/in-flight batch must not wedge verification.
+    {
+        let state = bootstrap_state.read().await;
+        if !state.drained && state.pending_peer_requests > 0 {
+            return;
+        }
     }
 
     // Evict stale entries that have been pending too long (e.g. unreachable
@@ -7674,9 +7690,14 @@ async fn run_verification_cycle(ctx: VerificationCycleContext<'_>) {
         // This closes the race
         // where a bootstrap batch starts after the early check: the batch
         // cannot publish its hints under the queue write lock until this
-        // selection either returns or declines to run.
-        if bootstrap_state.read().await.pending_peer_requests > 0 {
-            return;
+        // selection either returns or declines to run. As above, the barrier
+        // is lifted once bootstrap is force-drained so a resurrected request
+        // counter cannot wedge verification after the deadline.
+        {
+            let state = bootstrap_state.read().await;
+            if !state.drained && state.pending_peer_requests > 0 {
+                return;
+            }
         }
         q.select_ready_pending_keys(Instant::now(), MAX_VERIFICATION_KEYS_PER_CYCLE)
     };

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -1894,7 +1894,11 @@ impl ReplicationEngine {
             gossip_lottery_attempts: Arc::new(RwLock::new(HashMap::new())),
             sync_cycle_epoch: Arc::new(RwLock::new(0)),
             repair_proofs: Arc::new(RwLock::new(RepairProofs::new())),
-            bootstrap_state: Arc::new(RwLock::new(BootstrapState::new())),
+            bootstrap_state: {
+                let mut bs = BootstrapState::new();
+                bs.bootstrap_drain_deadline = config.bootstrap_drain_deadline;
+                Arc::new(RwLock::new(bs))
+            },
             is_bootstrapping: Arc::new(RwLock::new(true)),
             sync_trigger: Arc::new(Notify::new()),
             bootstrap_complete_notify: Arc::new(Notify::new()),

--- a/src/replication/types.rs
+++ b/src/replication/types.rs
@@ -793,7 +793,8 @@ pub struct BootstrapState {
     /// a third party block our drain through an unrelated honest peer. The
     /// displaced key is forfeited to the same post-bootstrap recovery path.
     pub capacity_rejected_sources: HashMap<PeerId, Instant>,
-    /// Wall-clock moment bootstrap drain tracking began. Set in [`Self::new`].
+    /// Wall-clock moment bootstrap drain tracking began. Reset by
+    /// `ReplicationEngine::start`, when replication bootstrap actually begins.
     /// `check_bootstrap_drained` force-drains after `bootstrap_drain_deadline`
     /// has elapsed since this moment, bounding total bootstrap stall even if
     /// per-source expiry alone would not resolve the wedge.

--- a/src/replication/types.rs
+++ b/src/replication/types.rs
@@ -793,6 +793,16 @@ pub struct BootstrapState {
     /// a third party block our drain through an unrelated honest peer. The
     /// displaced key is forfeited to the same post-bootstrap recovery path.
     pub capacity_rejected_sources: HashMap<PeerId, Instant>,
+    /// Wall-clock moment bootstrap drain tracking began. Set in [`Self::new`].
+    /// `check_bootstrap_drained` force-drains after `bootstrap_drain_deadline`
+    /// has elapsed since this moment, bounding total bootstrap stall even if
+    /// per-source expiry alone would not resolve the wedge.
+    pub bootstrap_started_at: Instant,
+    /// Hard ceiling on total bootstrap stall. Once `bootstrap_started_at` is
+    /// older than this, `check_bootstrap_drained` forces drain with a `warn!`
+    /// log. Wired from `ReplicationConfig::bootstrap_drain_deadline` by the
+    /// replication engine; defaults to the 30-minute ceiling.
+    pub bootstrap_drain_deadline: Duration,
 }
 
 impl BootstrapState {
@@ -804,6 +814,8 @@ impl BootstrapState {
             pending_peer_requests: 0,
             pending_keys: HashSet::new(),
             capacity_rejected_sources: HashMap::new(),
+            bootstrap_started_at: Instant::now(),
+            bootstrap_drain_deadline: Duration::from_secs(30 * 60),
         }
     }
 

--- a/tests/e2e/testnet.rs
+++ b/tests/e2e/testnet.rs
@@ -1349,7 +1349,7 @@ impl TestNetwork {
             {
                 Ok(mut engine) => {
                     let dht_events = p2p.dht_manager().subscribe_events();
-                    engine.start(dht_events);
+                    engine.start(dht_events).await;
                     node.replication_engine = Some(engine);
                     node.replication_shutdown = Some(shutdown);
                     debug!("Node {} replication engine started", node.index);

--- a/tests/poc_shutdown_lmdb_drain.rs
+++ b/tests/poc_shutdown_lmdb_drain.rs
@@ -130,7 +130,7 @@ async fn shutdown_waits_for_detached_lmdb_op_and_envs_reopen() {
     )
     .await
     .expect("create engine");
-    engine.start(p2p.dht_manager().subscribe_events());
+    engine.start(p2p.dht_manager().subscribe_events()).await;
 
     // Park a put's blocking closure on the test gate, then drop its awaiter
     // mid-flight — the exact shape of a select! losing to the shutdown token


### PR DESCRIPTION
## Linear issue

[V2-882 — Bound replication bootstrap stall with an overall force-drain deadline](https://linear.app/autonominetwork/issue/V2-882/bound-replication-bootstrap-stall-with-an-overall-force-drain-deadline)

Parent production issue: [V2-864 — Pruning defers 100% of candidates in production](https://linear.app/autonominetwork/issue/V2-864/pruning-defers-100percent-of-candidates-in-production-no-disk-space-is)

## Risk tier

- [ ] T0 — docs / tooling / CI / pure UX-output. Repo CI only.
- [ ] T1 — client-only, no network-facing behavior change. CI + prod compat smoke.
- [x] T2 — node/client logic with behavioral surface, no protocol/format/economics change. Dev testnet + ADR.
- [ ] T3 — protocol / storage format / payments / routing. T2 evidence + adversarial testing.

## Compatibility

- Wire: none; no message or protocol changes.
- Storage: none; no persisted format or migration changes.
- API: additive internal `ReplicationConfig` field; no public client API or CLI change.

## Semver impact

- [ ] breaking
- [ ] feature
- [x] fix

## Test evidence

Local exact-head evidence:

- `cargo check --lib` — passed.
- `cargo test --lib replication::bootstrap` — 16 passed, 0 failed.
- `cargo test --lib replication::` — 567 passed, 0 failed.
- `cargo test --lib replication::config` — 35 passed, 0 failed.
- `cargo test --test poc_bootstrap_stall --features test-utils` — 3 passed, 0 failed.
- `cargo fmt --all -- --check` — passed.
- `cargo clippy --lib -- -D warnings` — passed.
- `python3 scripts/adr-governance.py check` — passed (10 ADRs).

A dev-testnet acceptance run remains required for Tier 2 before merge. In particular, verify normal nodes drain before the ceiling and that a deliberately wedged node emits the force-drain warning, transitions out of bootstrap, resumes audit activity, and no longer leaves pruning indefinitely `bootstrap_deferred`.

## New dependency

none

## ADR

[ADR-0010: Bound replication bootstrap drain with an overall deadline](https://github.com/WithAutonomi/ant-node/blob/fix/bootstrap-drain-wedge/docs/adr/ADR-0010-bound-replication-bootstrap-drain.md)

Status remains **Proposed** pending human review; this PR does not mark it Accepted.

## Mitigation / rollback

Revert the single implementation commit, or raise/disable the internal deadline through `ReplicationConfig` while retaining the existing per-source capacity-rejection expiry path.
