### PR TITLE
test(bootstrap): integrate cache hygiene diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4921,7 +4921,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.26.4"
-source = "git+https://github.com/WithAutonomi/saorsa-core.git?rev=22326b5d19280061639742ac78da630b0a03803d#22326b5d19280061639742ac78da630b0a03803d"
+source = "git+https://github.com/WithAutonomi/saorsa-core.git?rev=e74a1bf4085cbd175136b331a0ecfb9c7e423752#e74a1bf4085cbd175136b331a0ecfb9c7e423752"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2433,7 +2433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4334,7 +4334,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.4",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4347,7 +4347,7 @@ dependencies = [
  "libc",
  "socket2 0.6.4",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4777,7 +4777,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4844,7 +4844,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4921,8 +4921,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "454529f8a72b4cf22f7d9c3b009ad9d4ba78520e11f6444ae460795d55c002da"
+source = "git+https://github.com/WithAutonomi/saorsa-core.git?rev=22326b5d19280061639742ac78da630b0a03803d#22326b5d19280061639742ac78da630b0a03803d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5697,7 +5696,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6418,7 +6417,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4921,7 +4921,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.26.4"
-source = "git+https://github.com/WithAutonomi/saorsa-core.git?rev=e74a1bf4085cbd175136b331a0ecfb9c7e423752#e74a1bf4085cbd175136b331a0ecfb9c7e423752"
+source = "git+https://github.com/WithAutonomi/saorsa-core.git?rev=a4faf6f72c1dd4425a2d1f3bdece6789c1f85b83#a4faf6f72c1dd4425a2d1f3bdece6789c1f85b83"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,12 @@ logging = ["tracing", "tracing-subscriber", "tracing-appender"]
 # integration tests and downstream test harnesses.
 test-utils = []
 
+# Testnet integration override for saorsa-core PR #149. Pin the exact reviewed
+# head so ant-protocol and ant-node share one saorsa-core source and type
+# identity; remove this patch once #149 is released on crates.io.
+[patch.crates-io]
+saorsa-core = { git = "https://github.com/WithAutonomi/saorsa-core.git", rev = "22326b5d19280061639742ac78da630b0a03803d" }
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ test-utils = []
 # head so ant-protocol and ant-node share one saorsa-core source and type
 # identity; remove this patch once #149 is released on crates.io.
 [patch.crates-io]
-saorsa-core = { git = "https://github.com/WithAutonomi/saorsa-core.git", rev = "e74a1bf4085cbd175136b331a0ecfb9c7e423752" }
+saorsa-core = { git = "https://github.com/WithAutonomi/saorsa-core.git", rev = "a4faf6f72c1dd4425a2d1f3bdece6789c1f85b83" }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ test-utils = []
 # head so ant-protocol and ant-node share one saorsa-core source and type
 # identity; remove this patch once #149 is released on crates.io.
 [patch.crates-io]
-saorsa-core = { git = "https://github.com/WithAutonomi/saorsa-core.git", rev = "22326b5d19280061639742ac78da630b0a03803d" }
+saorsa-core = { git = "https://github.com/WithAutonomi/saorsa-core.git", rev = "e74a1bf4085cbd175136b331a0ecfb9c7e423752" }
 
 [profile.release]
 lto = true

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -1524,6 +1524,11 @@ const RETENTION_PERSIST_INTERVAL_SECS: u64 = 30;
 /// default that keeps log volume negligible.
 const TRAFFIC_SUMMARY_INTERVAL_SECS: u64 = 300;
 
+/// Cadence of the read-only bootstrap state snapshot used to separate drain
+/// debt from cache and broader connectivity failures in fleet logs.
+#[cfg(feature = "logging")]
+const BOOTSTRAP_STATE_SNAPSHOT_INTERVAL_SECS: u64 = 60;
+
 /// Maximum tolerated auditor↔responder wall-clock skew for the first-audit
 /// in-window screen (ADR-0004 A1 guardrail A). The screen accepts a monetized pin
 /// for first audit only if its SIGNED `quote_ts` lands in
@@ -2176,6 +2181,9 @@ impl ReplicationEngine {
         self.start_first_audit_drainer();
         // V2-623: periodic cumulative per-variant traffic accounting.
         self.start_traffic_summary_loop();
+        // V2-884: read-only bootstrap state for cache/drain/connectivity triage.
+        #[cfg(feature = "logging")]
+        self.start_bootstrap_state_snapshot_loop();
         #[cfg(feature = "logging")]
         self.start_audit_responder_summary_loop();
 
@@ -3408,6 +3416,54 @@ impl ReplicationEngine {
                 }
             }
             debug!("Replication traffic summary loop shut down");
+        });
+        self.task_handles.push(handle);
+    }
+
+    /// Periodically expose the state that gates bootstrap completion and prune
+    /// admission. The state counts are copied before reading `is_bootstrapping`
+    /// so this diagnostic path never nests async locks.
+    #[cfg(feature = "logging")]
+    fn start_bootstrap_state_snapshot_loop(&mut self) {
+        let shutdown = self.shutdown.clone();
+        let bootstrap_state = Arc::clone(&self.bootstrap_state);
+        let is_bootstrapping = Arc::clone(&self.is_bootstrapping);
+        let started_at = Instant::now();
+        let handle = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    () = shutdown.cancelled() => break,
+                    () = tokio::time::sleep(Duration::from_secs(
+                        BOOTSTRAP_STATE_SNAPSHOT_INTERVAL_SECS,
+                    )) => {
+                        let (
+                            drained,
+                            pending_peer_requests,
+                            pending_keys,
+                            capacity_rejected_sources,
+                        ) = {
+                            let state = bootstrap_state.read().await;
+                            (
+                                state.drained,
+                                state.pending_peer_requests,
+                                state.pending_keys.len(),
+                                state.capacity_rejected_sources.len(),
+                            )
+                        };
+                        let bootstrapping = *is_bootstrapping.read().await;
+                        info!(
+                            drained,
+                            pending_peer_requests,
+                            pending_keys,
+                            capacity_rejected_sources,
+                            is_bootstrapping = bootstrapping,
+                            uptime_secs = started_at.elapsed().as_secs(),
+                            "Replication bootstrap state snapshot"
+                        );
+                    }
+                }
+            }
+            debug!("Bootstrap state snapshot loop shut down");
         });
         self.task_handles.push(handle);
     }

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -3451,15 +3451,29 @@ impl ReplicationEngine {
                             )
                         };
                         let bootstrapping = *is_bootstrapping.read().await;
+                        let snapshot_state = if drained && !bootstrapping {
+                            "healthy"
+                        } else if drained {
+                            "drained_waiting_for_bootstrap_flag"
+                        } else {
+                            "pending"
+                        };
                         info!(
                             drained,
                             pending_peer_requests,
                             pending_keys,
                             capacity_rejected_sources,
                             is_bootstrapping = bootstrapping,
+                            snapshot_state,
                             uptime_secs = started_at.elapsed().as_secs(),
                             "Replication bootstrap state snapshot"
                         );
+                        if drained && !bootstrapping {
+                            info!(
+                                "Replication bootstrap diagnostics reached healthy state; stopping periodic snapshots"
+                            );
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Linear issue

[V2-884 — Age-bound and refresh the saorsa-core close-group bootstrap cache](https://linear.app/autonominetwork/issue/V2-884/age-bound-and-refresh-the-saorsa-core-close-group-bootstrap-cache)

## Risk tier

- [ ] T0 — docs / tooling / CI / pure UX-output. Repo CI only.
- [ ] T1 — client-only, no network-facing behavior change. CI + prod compat smoke.
- [x] T2 — node/client logic with behavioral surface, no protocol/format/economics change. Dev testnet + ADR.
- [ ] T3 — protocol / storage format / payments / routing. T2 evidence + adversarial testing.

This is a draft integration/testnet PR. It pins the exact saorsa-core #149 head so an ant-node binary can exercise that change, and adds logging-only ant-node bootstrap-state diagnostics.

## Compatibility

- Wire: none.
- Storage: none; saorsa-core #149 retains the existing close-group cache format.
- API: none in ant-node. The patched saorsa-core API/semver impact remains documented on #149.

## Semver impact

- [ ] breaking
- [ ] feature
- [x] fix

## Test evidence

- Cargo resolves exactly one `saorsa-core`, shared by ant-node and ant-protocol, at saorsa-core #149 head `e74a1bf4085cbd175136b331a0ecfb9c7e423752`.
- `cargo check --all-targets --all-features` — passed.
- `cargo check --no-default-features` — passed.
- `cargo check --no-default-features --features logging` — passed.
- `cargo test --lib replication::` — 565 passed, 0 failed.
- Strict clippy (`panic`, `unwrap_used`, `expect_used` denied) — passed.
- `cargo fmt --all -- --check` and `git diff --check` — passed.
- `cargo build --release --no-default-features --features logging --bin ant-node` — passed on macOS arm64. Local binary SHA-256: `f09c794988f3abf0485703e0460761c79cdb7778c63282f03a18e1edbf6566ff`.

A Linux GNU release build and dev-testnet run remain required before rollout. Detailed matrix: [V2-894](https://linear.app/autonominetwork/issue/V2-894/testnet-run-bootstrap-cache-hygiene-and-drain-diagnostics-149198197).

### Testnet evidence map

The patched saorsa-core emits:

- fresh cache age and saved timestamp;
- explicit stale-cache rejection;
- periodic cache-save results during normal running;
- INFO dial outcomes tagged `bootstrap_source=cache|configured` and `outcome`;
- reason-labelled cache saves (`periodic|post_bootstrap|shutdown`);
- an INFO `Bootstrap reachability summary` with cache/configured candidate and success counts.

This PR additionally emits `Replication bootstrap state snapshot` every 60 seconds in logging builds with:

- `drained`;
- `pending_peer_requests`;
- `pending_keys`;
- `capacity_rejected_sources`;
- `is_bootstrapping`;
- `snapshot_state=pending|drained_waiting_for_bootstrap_flag|healthy`;
- `uptime_secs`.

Snapshots stop after the first healthy sample to avoid permanent fleet log volume.

The saorsa-core fields directly verify #149. The ant-node fields do not prove cache refresh themselves; they separate a remaining replication-drain wedge from stale-cache or general connectivity failures.

## New dependency

none. A temporary `[patch.crates-io]` source override pins the existing saorsa-core dependency to #149’s exact Git revision.

## ADR

[saorsa-core ADR-016 — Age-Bounded, Periodically Refreshed Close-Group Cache](https://github.com/WithAutonomi/saorsa-core/blob/fix/close-group-cache-hygiene/docs/adr/ADR-016-close-group-cache-validity.md) — Proposed; human acceptance pending.

## Mitigation / rollback

Revert this integration commit or remove the crates.io patch and logging loop; no stored or wire data migration is required.
