### PR TITLE
ci(release): build release candidates with the release profile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,20 +116,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Determine build profile
-        id: profile
-        shell: bash
-        run: |
-          if [[ "${{ needs.validate.outputs.is_prerelease }}" == "true" ]]; then
-            echo "build_flags=" >> $GITHUB_OUTPUT
-            echo "profile_dir=debug" >> $GITHUB_OUTPUT
-            echo "Building DEBUG (RC pre-release: logging enabled)"
-          else
-            echo "build_flags=--release --no-default-features --features logging" >> $GITHUB_OUTPUT
-            echo "profile_dir=release" >> $GITHUB_OUTPUT
-            echo "Building RELEASE (logging enabled, other defaults stripped)"
-          fi
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -143,19 +129,22 @@ jobs:
         if: matrix.cross
         run: cargo install cross --git https://github.com/cross-rs/cross
 
+      # Pre-releases are built exactly like the release they are a candidate for.
+      # Logging is in the default feature set, so `--release` carries it; there is
+      # no reason for an RC to differ from the artifact that ships.
       - name: Build (cross)
         if: matrix.cross
-        run: cross build ${{ steps.profile.outputs.build_flags }} --target ${{ matrix.target }}
+        run: cross build --release --target ${{ matrix.target }}
 
       - name: Build (native)
         if: ${{ !matrix.cross }}
-        run: cargo build ${{ steps.profile.outputs.build_flags }} --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Create archive (Unix)
         if: matrix.archive == 'tar.gz'
         run: |
-          cp config/bootstrap_peers.toml target/${{ matrix.target }}/${{ steps.profile.outputs.profile_dir }}/
-          cd target/${{ matrix.target }}/${{ steps.profile.outputs.profile_dir }}
+          cp config/bootstrap_peers.toml target/${{ matrix.target }}/release/
+          cd target/${{ matrix.target }}/release
           tar -czvf ../../../ant-node-cli-${{ matrix.friendly_name }}.tar.gz ${{ matrix.binary }} bootstrap_peers.toml
           cd ../../..
 
@@ -163,8 +152,8 @@ jobs:
         if: matrix.archive == 'zip'
         shell: pwsh
         run: |
-          Copy-Item "config/bootstrap_peers.toml" "target/${{ matrix.target }}/${{ steps.profile.outputs.profile_dir }}/bootstrap_peers.toml"
-          Push-Location "target/${{ matrix.target }}/${{ steps.profile.outputs.profile_dir }}"
+          Copy-Item "config/bootstrap_peers.toml" "target/${{ matrix.target }}/release/bootstrap_peers.toml"
+          Push-Location "target/${{ matrix.target }}/release"
           Compress-Archive -Path "${{ matrix.binary }}", "bootstrap_peers.toml" -DestinationPath "../../../ant-node-cli-${{ matrix.friendly_name }}.zip"
           Pop-Location
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,9 +177,9 @@ required-features = ["test-utils"]
 [features]
 default = ["logging"]
 # Enable tracing/logging infrastructure.
-# Included in `default` so dev builds (`cargo build`, `cargo test`) get logging
-# automatically. Release builds strip it:
-#   cargo build --release --no-default-features
+# Included in `default`, so every build we ship — dev, release candidate and
+# release alike — has logging. Opt out only for a bespoke build that needs it
+# gone: `cargo build --release --no-default-features`.
 logging = ["tracing", "tracing-subscriber", "tracing-appender"]
 # Expose test helpers (cache_insert, payment_verifier accessor) for
 # integration tests and downstream test harnesses.


### PR DESCRIPTION
## Linear issue
V2-868 — https://linear.app/autonominetwork/issue/V2-868/stop-using-debug-builds-for-the-release-candidate

## Risk tier
- [x] T0 — docs / tooling / CI / pure UX-output. Repo CI only.
- [ ] T1 — client-only, no network-facing behavior change. CI + prod compat smoke.
- [ ] T2 — node/client logic with behavioral surface, no protocol/format/economics change. Dev testnet + ADR.
- [ ] T3 — protocol / storage format / payments / routing. T2 evidence + adversarial testing.

<!-- Proposed T0: this is a CI-only change with no source-behaviour, protocol,
     format or economics change. Worth a reviewer's eye on one nuance: it does
     change the characteristics of the RC *artifact* (optimisation level,
     panic=abort, stripped symbols). That is the entire point of the issue — the
     RC becomes identical to the release — but if the reviewer counts "what the
     RC binary does at runtime" as behavioural surface, bump to T1/T2. -->

## Compatibility
- Wire: none — no source changes, no protocol surface touched.
- Storage: none.
- API: none — the crate's public API is unchanged; only CI build flags and a comment.

## Semver impact
- [ ] breaking
- [ ] feature
- [x] fix

## Test evidence
Per T0, repo CI plus local verification of the build the workflow now performs:

- `.github/workflows/release.yml` parses as valid YAML.
- `cargo build --release` succeeds (5m43s). Output is `ELF 64-bit LSB pie executable, stripped`, 19M — a genuine release artifact.
- `cargo fmt --all -- --check` clean.
- **Logging confirmed present in a release-profile binary.** Ran the built binary with `--enable-logging --log-level debug`; it emitted INFO and DEBUG records normally. This is the crux of the issue — the debug build was never what enabled logging.
- No `profile_dir` / `build_flags` / `debug` references remain in the release workflow.
- `is_prerelease` retains both of its other uses: gating the crates.io publish job and setting the GitHub pre-release flag.
- Archive asset names (`ant-node-cli-<friendly_name>.tar.gz|zip`) unchanged across all five matrix targets, so downstream consumers — testnet deployment, auto-upgrade, canaries — are unaffected.

### Why the original reasoning is obsolete
Two independent reasons:

1. `default = ["logging"]`, so the production flag set `--release --no-default-features --features logging` resolved to **exactly the default feature set**. Logging was never actually stripped from production builds.
2. Logging is gated at **runtime** by `--enable-logging` / `ANT_ENABLE_LOGGING`, not by the build profile. Whether an RC logs was never a build-time decision.

Issue step 2 ("find a route that does not require a debug build") therefore needs no work — that route already exists and is the one operators use.

## New dependency
none

## ADR
n/a — Tier 0.

## Mitigation / rollback
Single-commit revert of a CI workflow change; it affects nothing until the next release run. If an RC built this way proves problematic, revert and the following RC is a debug build again. Note the intended consequence: RC binaries are now stripped, so panic backtraces lose function names — exactly as production behaves today.
