### PR TITLE
fix(devnet): bind Anvil to --host so LAN clients can reach the manifest rpc_url

### DIFF
--- a/src/bin/ant-devnet/cli.rs
+++ b/src/bin/ant-devnet/cli.rs
@@ -59,13 +59,17 @@ pub struct Cli {
 
     /// Start a local Anvil blockchain for EVM payment verification.
     /// Starts Anvil, deploys contracts, and configures all nodes to verify
-    /// payments against the local chain.
+    /// payments against the local chain. With `--host`, Anvil binds the same
+    /// LAN IP (unless `ANVIL_IP_ADDR` overrides it) so the manifest's
+    /// `rpc_url` is reachable from other devices — external signers on the
+    /// LAN can pay, not just download.
     #[arg(long)]
     pub enable_evm: bool,
 
     /// Advertise this IPv4 to peers/clients and bind 0.0.0.0, so the devnet is
     /// reachable from other devices on the LAN. When omitted, nodes bind
-    /// loopback (127.0.0.1) as before (single-machine only).
+    /// loopback (127.0.0.1) as before (single-machine only). Also becomes
+    /// Anvil's bind/publish address under `--enable-evm` (see there).
     #[arg(long)]
     pub host: Option<std::net::Ipv4Addr>,
 

--- a/src/bin/ant-devnet/main.rs
+++ b/src/bin/ant-devnet/main.rs
@@ -98,8 +98,13 @@ async fn main() -> color_eyre::Result<()> {
         ));
     }
     config.advertise_ip = cli.host;
-    let evm_info =
-        resolve_evm_info(cli.evm_network.as_deref(), cli.enable_evm, &mut config).await?;
+    let evm_info = resolve_evm_info(
+        cli.evm_network.as_deref(),
+        cli.enable_evm,
+        cli.host,
+        &mut config,
+    )
+    .await?;
 
     let mut devnet = Devnet::new(config).await?;
     devnet.start().await?;
@@ -141,6 +146,7 @@ async fn main() -> color_eyre::Result<()> {
 async fn resolve_evm_info(
     evm_network: Option<&str>,
     enable_evm: bool,
+    host: Option<std::net::Ipv4Addr>,
     config: &mut DevnetConfig,
 ) -> color_eyre::Result<Option<DevnetEvmInfo>> {
     if let Some(net_name) = evm_network {
@@ -166,6 +172,19 @@ async fn resolve_evm_info(
             payment_vault_address: vault_addr,
         }))
     } else if enable_evm {
+        // Anvil binds — and evmlib publishes in the manifest's `rpc_url` —
+        // the address in `ANVIL_IP_ADDR`, defaulting to localhost. A LAN
+        // devnet must expose the chain the way it exposes the nodes, or the
+        // published `rpc_url` is unreachable from every other device —
+        // exactly the audience `--host` serves (external signers can join
+        // and download, but not pay). An explicit `ANVIL_IP_ADDR` wins.
+        if let Some(anvil_ip) = anvil_ip_for_lan(host, std::env::var_os("ANVIL_IP_ADDR")) {
+            ant_node::logging::info!(
+                "Binding Anvil to {anvil_ip} (via ANVIL_IP_ADDR) so LAN clients \
+                 can reach the manifest's rpc_url"
+            );
+            std::env::set_var("ANVIL_IP_ADDR", anvil_ip);
+        }
         ant_node::logging::info!("Starting local Anvil blockchain for EVM payment enforcement...");
         let testnet = evmlib::testnet::Testnet::new()
             .await
@@ -318,4 +337,50 @@ fn spawn_manifest_server(
             let _ = stream.write_all(resp.as_bytes());
         }
     });
+}
+
+/// The Anvil bind/publish address a LAN devnet should use: the `--host` IP,
+/// unless the operator set `ANVIL_IP_ADDR` explicitly (their override wins),
+/// or there is no `--host` (loopback devnet — keep Anvil's localhost
+/// default). Returns the value to write into `ANVIL_IP_ADDR`, or `None` to
+/// leave the environment untouched.
+fn anvil_ip_for_lan(
+    host: Option<std::net::Ipv4Addr>,
+    existing_override: Option<std::ffi::OsString>,
+) -> Option<String> {
+    match (host, existing_override) {
+        (Some(host), None) => Some(host.to_string()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::anvil_ip_for_lan;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn lan_host_becomes_anvil_ip() {
+        assert_eq!(
+            anvil_ip_for_lan(Some(Ipv4Addr::new(192, 168, 0, 61)), None),
+            Some("192.168.0.61".to_string())
+        );
+    }
+
+    #[test]
+    fn explicit_override_wins() {
+        assert_eq!(
+            anvil_ip_for_lan(
+                Some(Ipv4Addr::new(192, 168, 0, 61)),
+                Some("10.0.0.9".into())
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn loopback_devnet_keeps_anvil_default() {
+        assert_eq!(anvil_ip_for_lan(None, None), None);
+        assert_eq!(anvil_ip_for_lan(None, Some("10.0.0.9".into())), None);
+    }
 }


### PR DESCRIPTION
## Linear issue
[V2-950](https://linear.app/autonominetwork/issue/V2-950/ant-devnet-host-enable-evm-publishes-unreachable-loopback-anvil-rpc)

## Risk tier
- [x] T0 — docs / tooling / CI / pure UX-output. Repo CI only.
- [ ] T1 — client-only, no network-facing behavior change. CI + prod compat smoke.
- [ ] T2 — node/client logic with behavioral surface, no protocol/format/economics change. Dev testnet + ADR.
- [ ] T3 — protocol / storage format / payments / routing. T2 evidence + adversarial testing.

## Compatibility
- Wire: none — dev harness binary only (`ant-devnet`); node code untouched.
- Storage: none.
- API: none. Behavioral (harness only): with `--host <ip> --enable-evm` and no explicit `ANVIL_IP_ADDR`, Anvil now binds the host IP and the manifest's `rpc_url` becomes LAN-reachable. An explicit `ANVIL_IP_ADDR` still wins; loopback devnets (no `--host`) keep Anvil's localhost default exactly as before.

## Semver impact
- [ ] breaking
- [ ] feature
- [x] fix

## Test evidence
- Problem + fix verified live on a LAN box before writing the patch: stock behavior publishes `http://localhost:<port>/` (other devices can join/download but not pay — an external-signer LAN validation had to tunnel the RPC over SSH); with the env var set as this patch now does automatically, the manifest published `http://192.168.0.61:37365/` and `eth_chainId` answered from a second machine directly.
- 3 new unit tests on the pure helper (`anvil_ip_for_lan`): host→ip, explicit-override-wins, loopback-devnet-untouched. `cargo test --bin ant-devnet`: 8/8.
- `cargo fmt --check` clean; clippy (panic/unwrap/expect denied) clean on the bin.

## New dependency
none

## ADR
n/a

## Mitigation / rollback
Revert the commit; operators can always set `ANVIL_IP_ADDR` by hand (which this patch never overrides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)