### PR TITLE
fix(replication): tolerate new KClosestPeersChanged fields from saorsa-core

### DIFF
--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -3006,7 +3006,7 @@ impl ReplicationEngine {
                             }
                         };
                         match dht_event {
-                            DhtNetworkEvent::KClosestPeersChanged { old, new } => {
+                            DhtNetworkEvent::KClosestPeersChanged { old, new, .. } => {
                                 let old_peers = old
                                     .iter()
                                     .take(config.neighbor_sync_scope)


### PR DESCRIPTION
## Linear issue
V2-959 — https://linear.app/autonominetwork/issue/V2-959/ant-node-adapt-to-dhtnetworkeventkclosestpeerschanged-gaining

Blocks the 2026-08-11 release train cut (V2-906).

## Risk tier
- [ ] T0 — docs / tooling / CI / pure UX-output. Repo CI only.
- [x] T1 — client-only, no network-facing behavior change. CI + prod compat smoke.
- [ ] T2 — node/client logic with behavioral surface, no protocol/format/economics change. Dev testnet + ADR.
- [ ] T3 — protocol / storage format / payments / routing. T2 evidence + adversarial testing.

<!-- Proposed T1 on the gating axis that matters — no network-facing behaviour
     change — but flagging that the ladder has no clean slot for this. It is a
     compile-compatibility no-op inside node code: "client-only" is not literally
     true, yet T2's "behavioral surface" is absent, since `..` ignores the new
     fields and the call site behaves exactly as before. Re-tier at review if you
     read it differently. -->

## Compatibility
- Wire: none.
- Storage: none.
- API: none. Pattern-match change in a private call site; no public item changes.

## Semver impact
- [ ] breaking
- [ ] feature
- [x] fix

## Test evidence
- `cargo check --all-targets --all-features` against **current `main` pins** (saorsa-core 0.26.4 + the `[patch.crates-io]` rev `a4faf6f`) — passes. `..` is valid whether or not the extra fields exist, so this does not depend on which saorsa-core is resolved.
- `cargo check --all-targets --all-features` against the **rc-2026.8.2 saorsa-core lineage** (0.27.0-rc.1, which contains #136) — passes. Without this change the same check fails with `error[E0027]: pattern does not mention fields added, removed` at `src/replication/mod.rs:3009`.
- `src/replication/mod.rs:3009` is ant-node's only match on this variant, confirmed by grep across `src/`.

## New dependency
none

## ADR
n/a — no decision changes. The event shape is saorsa-core's; this only makes ant-node's pattern tolerant of it.

## Mitigation / rollback
Single-line revert. Reverting restores the E0027 build failure against saorsa-core ≥ 0.27.0, so it should only be reverted alongside pinning saorsa-core back below #136.

## Why this was not caught earlier
ant-node `main` pins `saorsa-core 0.26.4` from crates.io plus a `[patch.crates-io]` override on rev `a4faf6f` — #149's branch head, which predates #136. ant-node has therefore never compiled against a saorsa-core containing #136, and the break stayed latent until the rc cut forced both `main` branches together.

Separately: saorsa-core #136 declared its semver impact as `feature`; adding fields to a non-`#[non_exhaustive]` enum variant is `breaking`. The train's saorsa-core version is unaffected (#149 independently declared breaking, so it was already going to 0.27.0), but the declaration was wrong and the PR body's Compatibility section did not mention the enum, which is why manifest verification passed it.

## Not in scope
Adopting `added`/`removed`. #136 added them so consumers can track K-closest entrants directly rather than recomputing them from `old`/`new`, which is plausibly what this call site should do. That is a design change for the replication owners and is tracked separately rather than decided while unblocking a cut.
