### PR TITLE
fix(replication): stop conscripting peers for local write failures

### DIFF
--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -8244,6 +8244,38 @@ enum FetchResult {
     IntegrityFailed,
     /// Source failed (network error or non-success response) — retryable.
     SourceFailed,
+    /// This node could not write the chunk locally: the capacity pre-check
+    /// refused before the dial, or `put` failed after the bytes arrived.
+    ///
+    /// Distinct from [`Self::SourceFailed`] because nothing about the source
+    /// is implicated, and because the remedy is the opposite one. A source
+    /// failure should move on to the next holder; a local write failure must
+    /// not — every remaining source would send the same chunk into the same
+    /// full disk. The key returns to verification instead, so a later cycle
+    /// retries it once local capacity allows. That is a retry path, not a
+    /// liveness guarantee: `evict_stale` still expires the entry at
+    /// `PENDING_VERIFY_MAX_AGE` measured from when it was first queued, after
+    /// which re-acquisition depends on a fresh hint.
+    LocalWriteFailed,
+    /// This node already holds the key, so there is nothing to fetch —
+    /// terminal, exactly like [`Self::Stored`], because the duty is already
+    /// discharged.
+    ///
+    /// Responsibility is rechecked at download time; possession has to be too.
+    /// The earlier gates already drop held keys out of the fetch pipeline —
+    /// `queue_admitted_hints` skips them, and the promotion-time
+    /// `fetch_allowed_keys` filter and the local-paid probe both terminate
+    /// them. (`is_relevant` is not one of them: possession there makes a key
+    /// *relevant*, which is what keeps us tracking it.) So a held key reaches
+    /// the dial only when it arrived *after* promotion — a fresh-offer push, a
+    /// client PUT, or another source landing first. The nearest-first fetch
+    /// queue is deep enough for that window to be real.
+    ///
+    /// This check must also precede the capacity pre-check below, because
+    /// `LmdbStorage::put` tests `exists` *before* it tests disk space: without
+    /// it, a full node would decline a key it already holds, which `put` would
+    /// have accepted as a duplicate.
+    AlreadyHeld,
     /// Live routing state no longer places this node in the storage-admission
     /// group for the key — terminal, exactly like [`Self::Stored`]. The duty
     /// the fetch was serving has lapsed, so no alternate source is tried and
@@ -8291,7 +8323,7 @@ fn apply_fetch_result(
     verification_retry_after: Duration,
 ) -> FetchFollowUp {
     match result {
-        FetchResult::Stored | FetchResult::NoLongerResponsible => {
+        FetchResult::Stored | FetchResult::NoLongerResponsible | FetchResult::AlreadyHeld => {
             q.complete_fetch(key);
             FetchFollowUp::Terminal
         }
@@ -8299,6 +8331,19 @@ fn apply_fetch_result(
             if let Some(next_peer) = q.retry_fetch(key) {
                 FetchFollowUp::RetryFrom(next_peer)
             } else if q.requeue_fetch_for_verification(key, verification_retry_after) {
+                FetchFollowUp::RequeuedForVerification
+            } else {
+                FetchFollowUp::Terminal
+            }
+        }
+        // No `retry_fetch`: the local write is what failed, so every other
+        // source would be asked to send the same chunk into the same full
+        // disk. Requeueing for verification is what keeps the key from being
+        // stranded — it comes back once capacity allows — and the fallthrough
+        // to `Terminal` when there is no retry metadata is what keeps
+        // bootstrap drain accounting correct, exactly as for a source failure.
+        FetchResult::LocalWriteFailed => {
+            if q.requeue_fetch_for_verification(key, verification_retry_after) {
                 FetchFollowUp::RequeuedForVerification
             } else {
                 FetchFollowUp::Terminal
@@ -8359,6 +8404,48 @@ async fn execute_single_fetch(
         return FetchOutcome {
             key,
             result: FetchResult::NoLongerResponsible,
+        };
+    }
+
+    // Possession, then capacity — both before the dial, and in that order.
+    //
+    // `LmdbStorage::put` tests `exists` before it tests disk space, so a full
+    // node still accepts a key it already holds. Checking possession first is
+    // what keeps this pair of gates from declining work `put` would have
+    // taken.
+    if storage.exists(&key).unwrap_or(false) {
+        debug!(
+            "Skipping fetch for {}: already held locally",
+            hex::encode(key)
+        );
+        return FetchOutcome {
+            key,
+            result: FetchResult::AlreadyHeld,
+        };
+    }
+
+    // Capacity is checked before the dial rather than after the bytes arrive.
+    // `put` runs this same check on every write of a key it does not already
+    // hold, so this reaches the same verdict `put` would reach *at this
+    // instant*. It is not a guarantee about the later write: both answers can
+    // change across the round trip. Space freed in between would have let a
+    // post-download `put` succeed, so a refusal here can cost a fleeting
+    // acquisition and one retry cycle of delay; space lost in between is why
+    // the check inside `put` still has to stay.
+    //
+    // What it buys is that the refusal costs no bandwidth. Without it a
+    // disk-full node pulls the whole chunk over the network first, and the
+    // failure is then classified as the source's — no trust event, but the
+    // worker walks to every remaining holder, and each re-uploads the same
+    // chunk into the same full disk.
+    if let Err(e) = storage.check_capacity() {
+        debug!(
+            "Skipping fetch for {}: local storage cannot accept a write: {e}",
+            hex::encode(key)
+        );
+        return FetchOutcome {
+            key,
+            result: FetchResult::LocalWriteFailed,
         };
     }
 
@@ -8490,13 +8577,19 @@ async fn execute_single_fetch(
                     }
 
                     if let Err(e) = storage.put(&resp_key, &data).await {
+                        // The bytes arrived and passed the content-address
+                        // check, so the source did its job; the failure is
+                        // entirely local (disk-full, or an LMDB error). Any
+                        // valid source must serve identical content, so trying
+                        // the next one cannot cure a local error — it only
+                        // re-downloads the same chunk into the same store.
                         warn!(
                             "Failed to store fetched record {}: {e}",
                             hex::encode(resp_key)
                         );
                         return FetchOutcome {
                             key,
-                            result: FetchResult::SourceFailed,
+                            result: FetchResult::LocalWriteFailed,
                         };
                     }
 
@@ -12830,5 +12923,85 @@ mod tests {
 
         assert_eq!(follow_up, FetchFollowUp::Terminal);
         assert!(!q.contains_key(&key));
+    }
+
+    #[test]
+    fn already_held_key_leaves_the_pipeline_terminally() {
+        const RETRY_AFTER: Duration = Duration::from_secs(60);
+
+        let mut q = ReplicationQueues::new();
+        let key = test_key(0x4C);
+        let source = test_peer(0x0B);
+        drive_key_in_flight(&mut q, key, vec![source, test_peer(0x0C)]);
+
+        let follow_up = apply_fetch_result(&mut q, &key, &FetchResult::AlreadyHeld, RETRY_AFTER);
+
+        assert_eq!(
+            follow_up,
+            FetchFollowUp::Terminal,
+            "holding the key already discharges the duty, so the key must leave \
+             the pipeline exactly as a completed fetch does — requeueing it \
+             would re-verify a key that needs nothing"
+        );
+        assert!(!q.contains_key(&key));
+        assert_eq!(
+            q.retry_reserved_slot_count(),
+            0,
+            "the terminal path must release the retry-slot reservation, or the \
+             owner's verification budget leaks"
+        );
+    }
+
+    #[test]
+    fn local_write_failure_does_not_conscript_the_remaining_sources() {
+        const RETRY_AFTER: Duration = Duration::from_secs(60);
+
+        let mut q = ReplicationQueues::new();
+        let key = test_key(0x2A);
+        let first = test_peer(0x07);
+        let second = test_peer(0x08);
+        let third = test_peer(0x09);
+        drive_key_in_flight(&mut q, key, vec![first, second, third]);
+
+        let follow_up =
+            apply_fetch_result(&mut q, &key, &FetchResult::LocalWriteFailed, RETRY_AFTER);
+
+        assert_eq!(
+            follow_up,
+            FetchFollowUp::RequeuedForVerification,
+            "a local write failure must go straight back to verification: the two \
+             untried sources would each re-upload the same chunk into the same \
+             full disk, and neither of them did anything wrong"
+        );
+        assert_eq!(q.in_flight_count(), 0);
+        assert_eq!(
+            q.pending_count(),
+            1,
+            "the key must come back — capacity frees up, and a stranded key is \
+             a replica this node silently stops owing"
+        );
+        assert_eq!(q.retry_reserved_slot_count(), 0);
+    }
+
+    #[test]
+    fn local_write_failure_without_retry_metadata_is_terminal() {
+        const RETRY_AFTER: Duration = Duration::from_secs(60);
+
+        // No pending entry to restore, so the only way not to strand the key
+        // in `in_flight_fetch` forever — which would also stall bootstrap
+        // drain — is the terminal path.
+        let mut q = ReplicationQueues::new();
+        let key = test_key(0x3B);
+        let source = test_peer(0x0A);
+        assert!(q.enqueue_fetch(key, key, vec![source]));
+        let candidate = q.dequeue_fetch().expect("enqueued key must dequeue");
+        q.start_dequeued_fetch(candidate, source);
+
+        let follow_up =
+            apply_fetch_result(&mut q, &key, &FetchResult::LocalWriteFailed, RETRY_AFTER);
+
+        assert_eq!(follow_up, FetchFollowUp::Terminal);
+        assert!(!q.contains_key(&key));
+        assert_eq!(q.retry_reserved_slot_count(), 0);
     }
 }

--- a/tests/e2e/fetch_local_write_guard.rs
+++ b/tests/e2e/fetch_local_write_guard.rs
@@ -1,0 +1,263 @@
+//! A node that cannot write does not spend anyone else's bandwidth.
+//!
+//! `execute_single_fetch` rechecks storage *responsibility* at download time,
+//! and now rechecks local possession and local capacity there too. The unit
+//! tests on `apply_fetch_result` pin what the queue does with the resulting
+//! `AlreadyHeld` / `LocalWriteFailed` outcomes; what they cannot show is the
+//! part that matters for egress — that a node which cannot use the bytes does
+//! not ask for them in the first place.
+//!
+//! (`LocalWriteFailed` also covers a `put` that fails *after* a round trip, so
+//! the variant does not mean "no bytes moved". What the pre-check adds is that
+//! the refusal happens before any holder is contacted, and what the
+//! classification adds is that no *further* holder is contacted.)
+//!
+//! Both scenarios are observed through the holder's `chunks_retrieved` counter.
+//! Only `LmdbStorage::get` increments it — the replication fetch responder and
+//! the client GET handler; audits read through `get_raw` and leave it alone.
+//! It is not keyed by chunk or requester, so it is an "it served something"
+//! signal rather than an exact per-key one; on a freshly built testnet with no
+//! other traffic to the holder, a delta means it served this fetch.
+//!
+//! Two gaps this file deliberately does not close, because neither is
+//! constructible without adding test-only hooks to `LmdbStorage`:
+//!
+//! - **Ordering.** Possession is checked before capacity so a full node still
+//!   accepts a key it already holds, matching `put`. Proving it needs a node
+//!   that both holds the key and refuses writes, and `disk_reserve` is fixed at
+//!   construction — seeding such a node fails. The ordering rests on inspection
+//!   and on the `FetchResult::AlreadyHeld` doc comment.
+//! - **Post-round-trip classification.** Nothing here forces `put` to fail
+//!   *after* the bytes arrive, so reverting that one arm to `SourceFailed`
+//!   would still pass. The pre-check fires first in every reachable local
+//!   failure mode this harness can build.
+//!
+//! Why this matters in bytes: before the capacity gate, a write-blocked node
+//! pulled the whole chunk first, and the failure was then classified as the
+//! source's, so the worker walked to the next verified holder and every one of
+//! them re-uploaded the same chunk into the same full store.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use super::testnet::TestNetworkConfig;
+use super::verify_storage_gate::find_key_for_target;
+use super::TestHarness;
+use ant_node::replication::config::storage_admission_width;
+use ant_node::ReplicationConfig;
+use serial_test::serial;
+use std::collections::HashMap;
+use std::time::Duration;
+
+/// Above `storage_admission_width` (9), so a key the target is *not*
+/// responsible for can exist — otherwise every node is responsible for
+/// everything and `find_key_for_target` has nothing to choose between.
+const NODE_COUNT: usize = 12;
+/// Production close-group size, so the admission width is the real 9.
+const CLOSE_GROUP_SIZE: usize = 7;
+const TARGET_INDEX: usize = 5;
+const HOLDER_INDEX: usize = 6;
+/// Far above any real free space, so the target's capacity check always
+/// refuses — the same `Insufficient disk space` error a full partition raises,
+/// through the same `check_disk_space_cached` call `put` makes.
+const IMPOSSIBLE_DISK_RESERVE: u64 = u64::MAX / 2;
+const OBSERVATION_WINDOW: Duration = Duration::from_secs(15);
+const OBSERVATION_POLL: Duration = Duration::from_millis(200);
+
+/// A node whose storage cannot accept a write must not dial for the chunk.
+#[tokio::test]
+#[serial]
+async fn write_blocked_node_does_not_dial() {
+    let mut storage_disk_reserve_overrides = HashMap::new();
+    storage_disk_reserve_overrides.insert(TARGET_INDEX, IMPOSSIBLE_DISK_RESERVE);
+    let config = TestNetworkConfig {
+        node_count: NODE_COUNT,
+        storage_disk_reserve_overrides,
+        replication_config: Some(ReplicationConfig {
+            close_group_size: CLOSE_GROUP_SIZE,
+            ..ReplicationConfig::default()
+        }),
+        ..TestNetworkConfig::default()
+    };
+    let harness = TestHarness::setup_with_config(config)
+        .await
+        .expect("setup write-blocked network");
+    harness.warmup_dht().await.expect("warmup");
+
+    let width = storage_admission_width(CLOSE_GROUP_SIZE);
+    let (content, key) = find_key_for_target(&harness, TARGET_INDEX, width, true, "blocked").await;
+
+    let target = harness.test_node(TARGET_INDEX).expect("target");
+    let target_storage = target
+        .ant_protocol
+        .as_ref()
+        .expect("target protocol")
+        .storage();
+    let target_engine = target.replication_engine.as_ref().expect("target engine");
+    let holder = harness.test_node(HOLDER_INDEX).expect("holder");
+    let holder_peer = *holder.p2p_node.as_ref().expect("holder p2p").peer_id();
+    let holder_storage = holder
+        .ant_protocol
+        .as_ref()
+        .expect("holder protocol")
+        .storage();
+
+    // The holder can serve it, so a zero below means the target declined to
+    // ask — not that nobody could answer.
+    holder_storage
+        .put(&key, &content)
+        .await
+        .expect("host the chunk");
+    // Establish the precondition through the public write path, which runs the
+    // same capacity check the fetch pre-check calls.
+    let probe = b"local-write-guard-precondition-probe".to_vec();
+    let probe_address = ant_node::client::compute_address(&probe);
+    assert!(
+        target_storage.put(&probe_address, &probe).await.is_err(),
+        "the target's storage must be refusing writes, or this test proves nothing"
+    );
+
+    let served_before = holder_storage.stats().chunks_retrieved;
+    assert!(
+        target_engine
+            .enqueue_fetch_for_test(key, vec![holder_peer])
+            .await,
+        "candidate must enqueue"
+    );
+
+    let deadline = tokio::time::Instant::now() + OBSERVATION_WINDOW;
+    while target_engine.fetch_pipeline_contains_for_test(&key).await {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "the candidate never resolved; a key stuck in the fetch pipeline \
+             would stall bootstrap drain (key {})",
+            hex::encode(key)
+        );
+        tokio::time::sleep(OBSERVATION_POLL).await;
+    }
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let served = holder_storage.stats().chunks_retrieved - served_before;
+    println!("LOCAL-WRITE-GUARD-RESULT served_by_holder={served}");
+
+    assert_eq!(
+        served, 0,
+        "a node whose storage cannot accept a write pulled {served} chunk(s) \
+         from the holder. The bytes could never have been stored, and the old \
+         classification treated the failure as the source's for retry-selection \
+         purposes, so the worker walked to every remaining holder and each \
+         re-sent the same chunk into the same full store."
+    );
+    assert!(
+        !target_storage.exists(&key).unwrap_or(true),
+        "the target cannot have stored a chunk its storage refuses to write"
+    );
+
+    harness.teardown().await.expect("teardown");
+}
+
+/// A node that already holds the key must not dial for it either.
+#[tokio::test]
+#[serial]
+async fn already_held_key_is_not_fetched_again() {
+    let config = TestNetworkConfig {
+        node_count: NODE_COUNT,
+        replication_config: Some(ReplicationConfig {
+            close_group_size: CLOSE_GROUP_SIZE,
+            ..ReplicationConfig::default()
+        }),
+        ..TestNetworkConfig::default()
+    };
+    let harness = TestHarness::setup_with_config(config)
+        .await
+        .expect("setup possession-recheck network");
+    harness.warmup_dht().await.expect("warmup");
+
+    let width = storage_admission_width(CLOSE_GROUP_SIZE);
+    let (held_content, held_key) =
+        find_key_for_target(&harness, TARGET_INDEX, width, true, "held").await;
+    let (missing_content, missing_key) =
+        find_key_for_target(&harness, TARGET_INDEX, width, true, "missing").await;
+
+    let target = harness.test_node(TARGET_INDEX).expect("target");
+    let target_storage = target
+        .ant_protocol
+        .as_ref()
+        .expect("target protocol")
+        .storage();
+    let target_engine = target.replication_engine.as_ref().expect("target engine");
+    let holder = harness.test_node(HOLDER_INDEX).expect("holder");
+    let holder_peer = *holder.p2p_node.as_ref().expect("holder p2p").peer_id();
+    let holder_storage = holder
+        .ant_protocol
+        .as_ref()
+        .expect("holder protocol")
+        .storage();
+
+    holder_storage
+        .put(&held_key, &held_content)
+        .await
+        .expect("host held key");
+    holder_storage
+        .put(&missing_key, &missing_content)
+        .await
+        .expect("host control key");
+    target_storage
+        .put(&held_key, &held_content)
+        .await
+        .expect("target already holds the key");
+
+    let served_before = holder_storage.stats().chunks_retrieved;
+    assert!(
+        target_engine
+            .enqueue_fetch_for_test(held_key, vec![holder_peer])
+            .await,
+        "held-key candidate must enqueue"
+    );
+    let deadline = tokio::time::Instant::now() + OBSERVATION_WINDOW;
+    while target_engine
+        .fetch_pipeline_contains_for_test(&held_key)
+        .await
+    {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "a candidate for an already-held key must leave the fetch pipeline"
+        );
+        tokio::time::sleep(OBSERVATION_POLL).await;
+    }
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let held_serves = holder_storage.stats().chunks_retrieved - served_before;
+
+    // Positive control: same seam, same holder, a key the target genuinely
+    // lacks. Without this the assertion above could pass on a broken pipeline.
+    let served_before = holder_storage.stats().chunks_retrieved;
+    assert!(
+        target_engine
+            .enqueue_fetch_for_test(missing_key, vec![holder_peer])
+            .await,
+        "control candidate must enqueue"
+    );
+    let deadline = tokio::time::Instant::now() + OBSERVATION_WINDOW;
+    while !target_storage.exists(&missing_key).unwrap_or(false) {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "REGRESSION: a key the target does not hold was not fetched — the \
+             possession recheck must not decline genuine work"
+        );
+        tokio::time::sleep(OBSERVATION_POLL).await;
+    }
+    let control_serves = holder_storage.stats().chunks_retrieved - served_before;
+
+    println!("POSSESSION-RESULT held_serves={held_serves} control_serves={control_serves}");
+
+    assert_eq!(
+        held_serves, 0,
+        "the target pulled {held_serves} chunk(s) for a key it already had"
+    );
+    assert!(
+        control_serves >= 1,
+        "the holder served nothing for a key the target lacks, so the \
+         zero-serve assertion above proves nothing"
+    );
+
+    harness.teardown().await.expect("teardown");
+}

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -67,6 +67,9 @@ mod security_attacks;
 mod subtree_audit_testnet;
 
 #[cfg(test)]
+mod fetch_local_write_guard;
+
+#[cfg(test)]
 mod fetch_responsibility_recheck;
 
 #[cfg(test)]


### PR DESCRIPTION
## Linear issue

V2-963 — https://linear.app/autonominetwork/issue/V2-963/ant-node-local-possession-and-capacity-pre-check-on-the-replication

Sibling to V2-411 (disk-space pre-check in the PUT handler), which explicitly
scoped the replication path out: *"keep the existing check inside
`try_put`/`put` as defence-in-depth (covers … replication-path writes via
`replication/mod.rs`)"*. This closes that path.

## Risk tier

- [ ] T0 — docs / tooling / CI / pure UX-output. Repo CI only.
- [ ] T1 — client-only, no network-facing behavior change. CI + prod compat smoke.
- [x] T2 — node/client logic with behavioral surface, no protocol/format/economics change. Dev testnet + ADR.
- [ ] T3 — protocol / storage format / payments / routing. T2 evidence + adversarial testing.

Node-side replication behaviour changes: a node that already holds a key, or
cannot write, stops dialling for it. No protocol, format, or economics change.

## Compatibility

- Wire: none. `FetchResult` is a private internal enum; no message, field, or
  protocol id changes. Mixed-version fleets interoperate unchanged — an
  upgraded node simply sends fewer fetch requests.
- Storage: none. No schema, key, or on-disk format change.
- API: none. No public API change (`check_capacity` is already `pub(crate)`).

## Semver impact

- [ ] breaking
- [ ] feature
- [x] fix

## Test evidence

**Unit (`cargo test --lib --features test-utils`, 924 passed)** — three new
tests drive the real pending → promotion → dequeue → in-flight path with a live
retry-slot reservation:

- `local_write_failure_does_not_conscript_the_remaining_sources` — with three
  verified sources, `LocalWriteFailed` goes straight back to verification
  instead of walking to sources two and three.
- `local_write_failure_without_retry_metadata_is_terminal` — the no-metadata
  path stays terminal, so bootstrap-drain accounting is not stranded.
- `already_held_key_leaves_the_pipeline_terminally` — `AlreadyHeld` releases the
  retry-slot reservation exactly as a completed fetch does.

**E2E (`cargo test --test e2e --features test-utils -- --test-threads=1`,
96 passed / 0 failed / 3 pre-existing ignores)** — new file
`tests/e2e/fetch_local_write_guard.rs`, observed through the holder's
`chunks_retrieved` counter:

- `write_blocked_node_does_not_dial` — target given an impossible
  `disk_reserve`, precondition established through the public `put` path:
  **holder served 0 chunks**.
- `already_held_key_is_not_fetched_again` — **held_serves=0, control_serves=1**;
  the control proves the seam and worker are live, so the zero is not vacuous.

**Both new tests were confirmed to fail without the change.** With the two
pre-dial gates removed from `execute_single_fetch`, the same run gives
`held_serves=1` and `served_by_holder=1`.

**Local workload measurement** — 40-node testnet (grown to 43 by churn), real
QUIC, real on-chain payment against Anvil, 25 seed + 60 measured paid uploads,
continuous churn, 3 seeds per arm. With 10 of 40 nodes capacity-blocked:

| | baseline | with this change |
|---|---:|---:|
| fetch serves | 4214.0 ± 295.3 | 82.7 ± 14.0 |
| fetch-lane bytes | 1053.5 ± 73.8 MiB | 20.7 ± 3.5 MiB |
| repeat delivery (share of bytes) | 95.7% | 0% |
| **total replication egress** | **1003.17 MB/run** | **60.94 MB/run** (−93.9%) |
| verification lane | 2.46 MB | 2.17 MB (does not grow) |
| holders per key | 6.92 ± 0.37 | 6.84 ± 0.13 |

The verification lane falling rather than growing is the check that this removes
bytes instead of displacing them. Possession gains per run are unchanged
(577 vs 572), so the same data still lands.

Without capacity pressure the fetch lane is already tight — every acquisition
costs exactly one delivery across steady, pruning and restart-storm arms — so
this change is inert on a healthy node.

**Known coverage gaps**, recorded in the test module rather than papered over:

1. Ordering (possession before capacity) is not pinned by a test. Proving it
   needs a node that both holds a key and refuses writes, and `disk_reserve` is
   fixed at construction, so such a node cannot be seeded. It rests on
   inspection and the `AlreadyHeld` doc comment.
2. Nothing forces `put` to fail *after* the round trip, so reverting that one
   arm to `SourceFailed` would still pass. The pre-check fires first in every
   local failure mode this harness can construct.

Closing either needs test-only hooks in `LmdbStorage`, which felt like more
surface than the change warrants.

**Review**: `codex exec --model gpt-5.6-sol` at `xhigh` — *"Safe to ship from a
runtime correctness, security, and compatibility perspective. I found no
blocker, reservation leak, bootstrap-accounting bug, or peer-scoring
regression."* Its doc-accuracy findings are all applied in this branch.

`cargo fmt --all` and `cargo clippy --all-features --all-targets` clean; PoC
suites (19 / 16 / 3) and `--no-default-features` (924) green.

## New dependency

none

## ADR

No new decision — this applies decisions already recorded:

- [**ADR-0003** — full-node detection, penalisation, and eviction](https://github.com/WithAutonomi/ant-node/blob/main/docs/adr/ADR-0003-full-node-detection-and-eviction.md) frames how a
  node that cannot accept writes should behave toward its close group. This is
  that principle applied one layer down: a full node should not consume the
  group's upstream either.
- [**ADR-0005** — replication repair hardening under churn, load, and shutdown](https://github.com/WithAutonomi/ant-node/blob/main/docs/adr/ADR-0005-replication-repair-hardening.md)
  covers the verification-and-fetch pipeline this changes, and its recurring
  shape — "a decision made once against a snapshot, then acted on much later
  against a world that had moved" — is exactly the promotion-then-dial window
  the possession recheck closes.

Both are `Status: Proposed`. Happy to write a dedicated ADR if a reviewer reads
this as a new decision rather than an application of those two.

## Mitigation / rollback

Revert the commit. The change is two added `FetchResult` variants, two local
checks in one function, and one match arm; it touches no persisted
state, no wire format, and no peer scoring, so a revert restores previous
behaviour immediately with no migration. Blast radius is bounded to the
replication fetch path: worst case on a mistaken capacity reading is that a node
defers a fetch by one verification cycle (15 s) instead of performing it, and
the existing check inside `LmdbStorage::put` still backstops the write.

<!-- template check re-run against the current body -->
