### PR TITLE
feat(quote): refuse quotes to clients that cannot settle correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,8 +862,8 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "2.3.2"
-source = "git+https://github.com/grumbach/ant-protocol?branch=reapply/pr-23-settlement-version#f2bf6e42547ef06bf6ab46acbc4941a5d3a1014d"
+version = "2.3.3"
+source = "git+https://github.com/grumbach/ant-protocol?branch=reapply/pr-23-settlement-version#a22897d7a3048c41f8c419975274151c9ac9a843"
 dependencies = [
  "blake3",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,8 +862,8 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "2.4.0"
-source = "git+https://github.com/grumbach/ant-protocol?branch=settlement-version-quote-gate#439ed83d70ab3bbd14c1031c2e319f793141ea5a"
+version = "2.3.2"
+source = "git+https://github.com/grumbach/ant-protocol?branch=settlement-version-quote-gate#83160b044bdd3f035b9a78ba214d9510ab3ca753"
 dependencies = [
  "blake3",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,7 +863,7 @@ dependencies = [
 [[package]]
 name = "ant-protocol"
 version = "2.4.0"
-source = "git+https://github.com/grumbach/ant-protocol?branch=settlement-version-quote-gate#19845c8c20e1a3505cfbfc446b7e2c26bf5b0726"
+source = "git+https://github.com/grumbach/ant-protocol?branch=settlement-version-quote-gate#620bb9971ba5669bdb23a38568f8d3a597987db1"
 dependencies = [
  "blake3",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,9 +862,8 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a8d4262f20934f579f1f37e7855718d75156e24b3441eabf089e3049d4c831"
+version = "2.4.0"
+source = "git+https://github.com/grumbach/ant-protocol?branch=settlement-version-quote-gate#19845c8c20e1a3505cfbfc446b7e2c26bf5b0726"
 dependencies = [
  "blake3",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,7 +863,7 @@ dependencies = [
 [[package]]
 name = "ant-protocol"
 version = "2.3.2"
-source = "git+https://github.com/grumbach/ant-protocol?branch=settlement-version-quote-gate#83160b044bdd3f035b9a78ba214d9510ab3ca753"
+source = "git+https://github.com/grumbach/ant-protocol?branch=settlement-version-quote-gate#e97901694cba5cad84da0b99ee8af02a791df2cf"
 dependencies = [
  "blake3",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,7 +863,7 @@ dependencies = [
 [[package]]
 name = "ant-protocol"
 version = "2.3.2"
-source = "git+https://github.com/grumbach/ant-protocol?branch=settlement-version-quote-gate#e97901694cba5cad84da0b99ee8af02a791df2cf"
+source = "git+https://github.com/grumbach/ant-protocol?branch=reapply/pr-23-settlement-version#f2bf6e42547ef06bf6ab46acbc4941a5d3a1014d"
 dependencies = [
  "blake3",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,7 +863,7 @@ dependencies = [
 [[package]]
 name = "ant-protocol"
 version = "2.4.0"
-source = "git+https://github.com/grumbach/ant-protocol?branch=settlement-version-quote-gate#620bb9971ba5669bdb23a38568f8d3a597987db1"
+source = "git+https://github.com/grumbach/ant-protocol?branch=settlement-version-quote-gate#439ed83d70ab3bbd14c1031c2e319f793141ea5a"
 dependencies = [
  "blake3",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ mimalloc = "0.1"
 # Branch pin while the settlement-version wire types are in review
 # (WithAutonomi/ant-protocol#25). Swap back to a published `ant-protocol`
 # version pin once that PR merges and the release train publishes it.
-ant-protocol = { git = "https://github.com/grumbach/ant-protocol", branch = "settlement-version-quote-gate" }
+ant-protocol = { git = "https://github.com/grumbach/ant-protocol", branch = "reapply/pr-23-settlement-version" }
 
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
 saorsa-core = "0.27.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,8 @@ mimalloc = "0.1"
 # (the rc-2026.4.2 branch) so Cargo can unify the wire types here
 # with ant-protocol's re-exports.
 # Branch pin while the settlement-version wire types are in review
-# (WithAutonomi/ant-protocol#23). Swap back to `ant-protocol = "2.4.0"` once
-# that PR merges and 2.4.0 is published.
+# (WithAutonomi/ant-protocol#23). Swap back to a published `ant-protocol`
+# version pin once that PR merges and the release train publishes it.
 ant-protocol = { git = "https://github.com/grumbach/ant-protocol", branch = "settlement-version-quote-gate" }
 
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ mimalloc = "0.1"
 # (the rc-2026.4.2 branch) so Cargo can unify the wire types here
 # with ant-protocol's re-exports.
 # Branch pin while the settlement-version wire types are in review
-# (WithAutonomi/ant-protocol#23). Swap back to a published `ant-protocol`
+# (WithAutonomi/ant-protocol#25). Swap back to a published `ant-protocol`
 # version pin once that PR merges and the release train publishes it.
 ant-protocol = { git = "https://github.com/grumbach/ant-protocol", branch = "settlement-version-quote-gate" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,10 @@ mimalloc = "0.1"
 # Until then, the git pin tracks the matching saorsa-core lineage
 # (the rc-2026.4.2 branch) so Cargo can unify the wire types here
 # with ant-protocol's re-exports.
-ant-protocol = "2.3.3"
+# Branch pin while the settlement-version wire types are in review
+# (WithAutonomi/ant-protocol#23). Swap back to `ant-protocol = "2.4.0"` once
+# that PR merges and 2.4.0 is published.
+ant-protocol = { git = "https://github.com/grumbach/ant-protocol", branch = "settlement-version-quote-gate" }
 
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
 saorsa-core = "0.27.1"

--- a/docs/adr/ADR-0010-settlement-version-and-pre-payment-compatibility.md
+++ b/docs/adr/ADR-0010-settlement-version-and-pre-payment-compatibility.md
@@ -103,7 +103,7 @@ Flipping that to a refusal is a **follow-up**, gated on that count decaying, and
 
 - **It does not fix the current burn.** A client too old to settle correctly is also too old to declare a version, so the gate cannot see the population causing today's rejections. Only the reworded error reaches them. Driving client adoption remains the cheaper and faster remedy for the incident that prompted this.
 - **Merkle storers are not exactly the quoted peers.** The gate covers the 16 candidates a client quotes, but the chunk is stored by each chunk's close group, which may include a peer that never quoted. A storer outside the candidate set can still refuse at PUT time. This narrows the exposure substantially without closing it, and only option 3 closes it fully.
-- The fallback costs one extra timeout per silent peer during rollout. Requests run concurrently, so the worst case is 2x the quote timeout overall.
+- The fallback costs one probe per silent peer, bounded by `VERSIONED_QUOTE_PROBE_CEILING` and paid once per peer rather than once per request. Before those two bounds it was one full quote timeout on **every** request, which took the merkle E2E suite from ~24 minutes past the 60-minute CI cap. See the validation section.
 - Clients declaring a version are refused by nodes that have not upgraded. Harmless today because no node has a lower `CURRENT`, but it makes node rollout a prerequisite for the next settlement bump.
 
 ### Neutral / Operational
@@ -120,7 +120,27 @@ Flipping that to a refusal is a **follow-up**, gated on that count decaying, and
 - **Terminality.** `a_refusal_aborts_quote_collection_instead_of_counting_as_one_bad_peer` pins that a refusal stops collection rather than joining the failure list, which is what would otherwise let the remaining peers form a quorum and pay anyway.
 - **Order independence.** `a_refusal_is_recorded_where_the_collection_timeout_cannot_discard_it` and `meeting_the_target_stops_launching_without_stopping_collection` pin that the verdict does not depend on which peers answered first, and `a_lagging_storer_does_not_populate_the_refusal_slot` pins that a behind-the-times peer is not mistaken for one.
 - **Downgrade bound.** The shared compile-time constant referenced from both fallback sites, plus `only_silence_triggers_the_legacy_retry`.
-- **Still outstanding at the time of writing:** a mixed-version dev testnet exercising legacy node, upgraded node, structured refusal, lost refusal, and send failure against real peers. The unit tests pin the decisions; they do not prove the behaviour end to end.
+### Mixed-version validation, and what it found
+
+The new-client-against-old-fleet case has been exercised for real, not simulated. `ant-client`'s merkle E2E suite spawns a 35-node testnet from the **published** `ant-node`, which predates the versioned requests, so the suite is a live mixed-version run: every node logs `Failed to decode message: deserialization failed` for each versioned probe and answers only the unversioned retry.
+
+It passed functionally and **failed on cost**, which is exactly what a unit test could not have shown:
+
+| | Merkle E2E, ubuntu |
+|---|---|
+| Baseline on `main` | 24–38 min |
+| First implementation | exceeded the 60-min CI cap with 4 of 7 tests done |
+
+The cause was that a peer which cannot decode the versioned request never answers, so the client waited the **full** quote timeout before falling back, and paid that on every request rather than once per peer. The suite runs `quote_timeout_secs = 120`, and a merkle pool asks sixteen candidates.
+
+Two changes came out of it, both in the client:
+
+- **Remember the answer.** A peer that fails to answer a versioned request is asked in the legacy shape from then on, so the probe is paid once per peer instead of once per request.
+- **Cap the probe.** A capability probe does not need the patience of a real quote, so the versioned attempt is bounded by `VERSIONED_QUOTE_PROBE_CEILING`. Production's 10s timeout is already below it; the ceiling only binds in test configurations.
+
+Cutting a probe short can misjudge a slow but upgraded peer as legacy. The only consequence is a lost version declaration to that peer, because the fallback still obtains a quote, and it cannot matter while no client can be refused on version grounds. By the time it could, the fallback must already be deleted.
+
+**Still outstanding:** the reverse direction, old client against an upgraded node, and a fleet with both. Those need a testnet built from this branch's `ant-node` rather than the published one, which is not available until the coordinated set lands. Also unproven end to end: structured refusal, lost refusal, and send failure against real peers, which are pinned at unit level only.
 
 ### Re-open triggers
 

--- a/docs/adr/ADR-0010-settlement-version-and-pre-payment-compatibility.md
+++ b/docs/adr/ADR-0010-settlement-version-and-pre-payment-compatibility.md
@@ -159,6 +159,23 @@ The cost of that is roughly two minutes per merkle E2E test for as long as the s
 
 **Still outstanding:** the reverse direction, old client against an upgraded node, and a fleet with both. Those need a testnet built from this branch's `ant-node` rather than the published one, which is not available until the coordinated set lands. Also unproven end to end: structured refusal, lost refusal, and send failure against real peers, which are pinned at unit level only.
 
+### Release gates
+
+Merging puts this in the next release, so the bar is fleet-ready, not code-complete. Green CI covers the code gate and nothing else. **The set is not production ready while any of these is open:**
+
+| Gate | Status |
+|---|---|
+| Code / CI | Proven across all three repos |
+| Dependency | Open: both downstream crates pin a mutable protocol branch |
+| Mixed-version | Partial: new-client against an old fleet is proven by the client suite; the gate itself has never run over a real connection, because the devnet speaks the pre-versioned dialect |
+| Deployment ordering | Open, and **not inert**: against a fleet that cannot answer a versioned request every first contact costs a probe wait, so releasing the client ahead of the nodes adds real latency to cold uploads |
+| Observability | Open: the unversioned-quote counter is the signal that retires the legacy path and has never been read in production |
+| NAT / canary | Open: no canary; relayed and NAT'd peers are the paths this adds work to |
+| Rollback | Argued, not rehearsed |
+| Fleet safety | Open: the corroboration quorum and the client-wide latch have never met a real fleet |
+
+The refusal machinery is inert on arrival, since `MIN` and `CURRENT` are both the first declarable version, so nothing can be refused yet. That lowers the risk. It does not close a gate, and the client-side cost above is live regardless.
+
 ### Re-open triggers
 
 - The unversioned-quote count failing to decay, which would mean a long tail of clients the gate can never protect and would raise the priority of option 3.

--- a/docs/adr/ADR-0010-settlement-version-and-pre-payment-compatibility.md
+++ b/docs/adr/ADR-0010-settlement-version-and-pre-payment-compatibility.md
@@ -149,9 +149,13 @@ The cause was that a peer which cannot decode the versioned request never answer
 Two changes came out of it, both in the client:
 
 - **Remember the answer.** A peer that fails to answer a versioned request is asked in the legacy shape from then on, so the probe is paid once per peer instead of once per request.
-- **Cap the probe.** A capability probe does not need the patience of a real quote, so the versioned attempt is bounded by `VERSIONED_QUOTE_PROBE_CEILING`. Production's 10s timeout is already below it; the ceiling only binds in test configurations.
+- **Cap the probe**, with `VERSIONED_QUOTE_PROBE_CEILING`, but only far enough to bound a pathological timeout. Production's 10s sits below it, so **the ceiling never binds on a production client**.
 
-Cutting a probe short can misjudge a slow but upgraded peer as legacy. The only consequence is a lost version declaration to that peer, because the fallback still obtains a quote, and it cannot matter while no client can be refused on version grounds. By the time it could, the fallback must already be deleted.
+That last point is a safety property, not a tuning choice, and it was nearly got wrong. A shorter ceiling was tried to bring the slower CI runner under its job cap. It would have been a defect: the probe wait is the only window in which a peer can refuse, and the fallback re-asks under a *new* request id, so a refusal arriving after the ceiling answers a request nobody is listening to. It would never count toward corroboration, never set the latch, and the racing unversioned request could return a quote the client then pays against. Neither the never-demote rule nor the compile-time guard covers this: the first only stops a peer being *cached* as legacy, and the second binds future builds while the clients at risk are the ones already released.
+
+Cutting a probe short therefore does more than misjudge a slow peer. The rule is: **keep the ceiling at or above the largest production quote timeout.**
+
+The cost of that is roughly two minutes per merkle E2E test for as long as the suite's devnet speaks the pre-versioned dialect. That is an artifact of the temporary fork-branch protocol pin rather than of the design; when the fleet under test can answer a versioned request there are no probes to pay for and the suite returns to baseline.
 
 **Still outstanding:** the reverse direction, old client against an upgraded node, and a fleet with both. Those need a testnet built from this branch's `ant-node` rather than the published one, which is not available until the coordinated set lands. Also unproven end to end: structured refusal, lost refusal, and send failure against real peers, which are pinned at unit level only.
 

--- a/docs/adr/ADR-0010-settlement-version-and-pre-payment-compatibility.md
+++ b/docs/adr/ADR-0010-settlement-version-and-pre-payment-compatibility.md
@@ -21,7 +21,7 @@ The general problem is that **`PROTOCOL_VERSION` describes what a peer can parse
 ## Decision Drivers
 
 - A refusal must land **before** payment. Merkle settlement is irreversible, so after-the-fact verification cannot be the only check.
-- A client-first rollout must stay possible. ADR-0008 chose client-first deliberately, because a client paying more is accepted by an old node for free. Any policy that makes old nodes refuse new clients breaks that ordering.
+- A client-first rollout must stay **usable**, though this decision does narrow it. ADR-0008 chose client-first because a client paying more was accepted by an old node for free. Bounding the upper end ends that: an old node now refuses a newer client rather than quoting a payment it cannot promise to honour. The refusal is deliberately not a client fault, so a newer client routes to peers that can serve it and its user sees nothing, but **node rollout becomes a prerequisite for the next settlement bump** rather than merely desirable. That is the price of not paying before compatibility is established, and it is paid knowingly.
 - Old peers must not be misread. `ChunkMessage` is postcard-encoded and non-self-describing, so a new field silently changes how existing peers parse every message.
 - The user must be told what to do. The failure is only expensive because it is silent.
 
@@ -69,11 +69,21 @@ A storer built before the versioned requests cannot decode them and simply never
 
 It is safe **only while no client can be refused on version grounds**, which holds exactly while `MIN_SUPPORTED_SETTLEMENT_VERSION` is the first declarable version. The rule is therefore:
 
-> The unversioned retry must be deleted **before** `MIN_SUPPORTED_SETTLEMENT_VERSION` is ever raised.
+> The unversioned retry must be deleted **before either `MIN_SUPPORTED_SETTLEMENT_VERSION` or `CURRENT_SETTLEMENT_VERSION` is raised.**
+
+Both, not just the minimum. Raising `MIN` creates the too-old refusal; raising `CURRENT` creates the node-behind refusal as soon as any node lags, and the retry routes around that one just as readily.
 
 This is enforced by a compile-time assertion in the client, not by review discipline: raising the minimum while a fallback exists fails the build.
 
 There are **two** independent fallbacks, single-node and merkle. The guard is therefore a single shared constant that each site references, so deleting one path cannot orphan the check for the other. An earlier revision put the assertion beside the merkle path only, which left the single-node retry unguarded while this document claimed otherwise.
+
+### A refusal is a verdict about the client, and needs corroboration
+
+Nothing authenticates a refusal. Acting on one peer's word would let a single hostile or misconfigured storer answer `ClientUpdateRequired` to everything and deny every upload the client attempts, converting an over-query design that tolerates many bad peers into one that tolerates none. So a refusal is believed only once `SETTLEMENT_REFUSAL_QUORUM` distinct peers agree, and a refusal that does not describe this client (wrong echoed version, or a stated minimum this client already meets) is discarded as a bad peer rather than counted.
+
+A genuine incompatibility reaches the threshold immediately, because every peer enforcing the newer rule refuses and a client queries far more than two.
+
+The corroborated verdict is then held **client-wide and sticky**, not in one collector's local state. It concerns this build rather than this upload, so an upload that begins after another has already established it must not proceed to pay, and every payment entry point checks it first.
 
 ### A refusal must not depend on who answered first
 
@@ -104,7 +114,8 @@ Flipping that to a refusal is a **follow-up**, gated on that count decaying, and
 - **It does not fix the current burn.** A client too old to settle correctly is also too old to declare a version, so the gate cannot see the population causing today's rejections. Only the reworded error reaches them. Driving client adoption remains the cheaper and faster remedy for the incident that prompted this.
 - **Merkle storers are not exactly the quoted peers.** The gate covers the 16 candidates a client quotes, but the chunk is stored by each chunk's close group, which may include a peer that never quoted, and routing can move that group between quoting and storing. A storer outside the candidate set can still refuse at PUT time, after payment. This narrows the exposure substantially without closing it, and only option 3 closes it fully.
 - **A client binary already in the field cannot be reached.** The cutover guard bounds what future builds may do; it does nothing about a released client that still carries the fallback when nodes later raise their minimum. That is inherent to shipping software, and it is the same reason the storer verifies every payment it is actually offered rather than trusting the declared version.
-- **A refusal in a later merkle sub-batch arrives after earlier sub-batches have paid.** Batches above `MAX_LEAVES` settle sequentially, so the gate cannot be consulted for sub-batch two before sub-batch one's money is spent. The refusal is surfaced rather than folded into a partial success, but the earlier spend has already happened.
+- **A refusal in a later merkle sub-batch arrives after earlier sub-batches have paid.** Batches above `MAX_LEAVES` settle sequentially, so the gate cannot be consulted for sub-batch two before sub-batch one's money is spent. That call still returns its earlier proofs rather than failing: the caller writes the receipt cache only on the success path, so failing would strand a spend that has already settled on-chain, which is the destruction this work exists to prevent. Nothing is lost by returning them, because the verdict is latched client-wide and stops the *next* payment instead.
+- **A single upload can still be denied by two colluding peers.** The corroboration threshold trades a lone-peer denial-of-service for a two-peer one. Two is chosen because a genuine incompatibility clears it instantly while a lone attacker cannot; raising it would blunt the real signal, and the failure mode is availability rather than lost funds.
 - The fallback costs one probe per silent peer, bounded by `VERSIONED_QUOTE_PROBE_CEILING` and paid once per peer rather than once per request. Before those two bounds it was one full quote timeout on **every** request, which took the merkle E2E suite from ~24 minutes past the 60-minute CI cap. See the validation section.
 - Clients declaring a version are refused by nodes that have not upgraded. Harmless today because no node has a lower `CURRENT`, but it makes node rollout a prerequisite for the next settlement bump.
 

--- a/docs/adr/ADR-0010-settlement-version-and-pre-payment-compatibility.md
+++ b/docs/adr/ADR-0010-settlement-version-and-pre-payment-compatibility.md
@@ -190,13 +190,37 @@ Merging puts this in the next release, so the bar is fleet-ready, not code-compl
 | Code / CI | Proven across all three repos |
 | Dependency | Open: both downstream crates pin a mutable protocol branch |
 | Mixed-version | Partial: new-client against an old fleet is proven by the client suite, and both refusal directions plus the unversioned path now run over a real connection on a devnet built from this branch. A fleet running both node versions at once still needs a deployment |
-| Deployment ordering | Open, and **not inert**: against a fleet that cannot answer a versioned request every first contact costs a probe wait, so releasing the client ahead of the nodes adds real latency to cold uploads |
+| Deployment ordering | Planned, not rehearsed: the order and the watch items are stated below. Still **not inert** — against a fleet that cannot answer a versioned request every first contact costs a probe wait, so releasing the client ahead of the nodes adds real latency to cold uploads |
 | Observability | Open: the refusal lines are now observed emitting on a running node, but the unversioned-quote counter is the signal that retires the legacy path, and its log line has never fired outside production volumes, let alone been read there |
 | NAT / canary | Open: no canary; relayed and NAT'd peers are the paths this adds work to |
-| Rollback | Argued, not rehearsed |
+| Rollback | Planned, not rehearsed: revert order stated below, and it is not the reverse of the deploy order for the reason given there |
 | Fleet safety | Open: the corroboration quorum and the client-wide latch have never met a real fleet |
 
 The refusal machinery is inert on arrival, since `MIN` and `CURRENT` are both the first declarable version, so nothing can be refused yet. That lowers the risk. It does not close a gate, and the client-side cost above is live regardless.
+
+### Rollout order, and what to watch
+
+**Nodes first, then clients.** The asymmetry is one-directional and it is a cost, not a correctness problem: a node built before the versioned request cannot decode one, so it never answers, and the client pays a probe wait before falling back. Ship the client first and every cold upload pays that on first contact with each peer it has not yet cached. Ship the nodes first and there is nothing to pay, because the versioned request is answered on the first try.
+
+Neither order can lose a client money. The gate refuses before a quote exists, and the two constants are equal on arrival, so no refusal is reachable in either direction until a future settlement bump.
+
+Three steps, each with the signal that says the previous one worked:
+
+1. **Publish the protocol crate.** Nothing observable; it only unblocks the pin.
+2. **Roll the nodes.** Watch `ant_node::quote::settlement`. The expected count of refusal lines is **zero** — a `ClientUpdateRequired` or `StorerUpdateRequired` on this release means one of the two constants moved when it should not have. The unversioned-quote line is the one that should appear, and its arrival is also the first confirmation the counter works at all.
+3. **Release the client**, once the node roll has reached enough of the fleet that a client's first few peers can answer. Watch quote latency on cold uploads: a rise is the probe wait, and it says the node roll has not reached far enough, not that anything is broken.
+
+A canary should sit between steps 2 and 3, on relayed and NAT'd peers specifically, since those are the paths a probe wait lengthens most.
+
+### Revert order
+
+**Clients first, then nodes** — deliberately *not* the reverse of the rollout, because the two directions are not symmetric.
+
+Reverting the client first is free: it goes back to sending unversioned requests, which an upgraded node still serves, at no probe cost. Reverting the nodes first while clients still declare versions is the expensive direction, and it recreates exactly the condition step 1 of the rollout exists to avoid — every client pays a probe wait against every reverted node.
+
+Reverting only the nodes is safe but pointless while the client is unchanged. Reverting only the client is both safe and free, and is the right first move for any problem that is not clearly node-side.
+
+What a revert costs, at either end: the unversioned-quote counter, which is the evidence that would eventually retire the legacy path. It costs no client money and breaks no upload, because there is no state on either side of this change — no stored format, no on-chain field, no cached verdict that outlives a process. That holds only while the two constants are equal; once a settlement bump makes `MIN` load-bearing, reverting a node re-opens the underpayment it was raised to refuse, and the revert decision stops being free.
 
 ### Re-open triggers
 

--- a/docs/adr/ADR-0010-settlement-version-and-pre-payment-compatibility.md
+++ b/docs/adr/ADR-0010-settlement-version-and-pre-payment-compatibility.md
@@ -71,7 +71,18 @@ It is safe **only while no client can be refused on version grounds**, which hol
 
 > The unversioned retry must be deleted **before** `MIN_SUPPORTED_SETTLEMENT_VERSION` is ever raised.
 
-This is enforced by a compile-time assertion in the client, not by review discipline: raising the minimum while the fallback exists fails the build.
+This is enforced by a compile-time assertion in the client, not by review discipline: raising the minimum while a fallback exists fails the build.
+
+There are **two** independent fallbacks, single-node and merkle. The guard is therefore a single shared constant that each site references, so deleting one path cannot orphan the check for the other. An earlier revision put the assertion beside the merkle path only, which left the single-node retry unguarded while this document claimed otherwise.
+
+### A refusal must not depend on who answered first
+
+A refusal is a verdict about the client, not about one peer, so it cannot be treated as one failed response among many. Two things follow, and both were wrong in the first implementation:
+
+- The collector stops **launching** new peers once it has enough quotes, but keeps **draining** those already launched. Otherwise a refusal still in flight is discarded because faster peers filled the quota, and the upload pays.
+- The verdict is recorded outside the collection timeout. The elapsed arm deliberately falls through so quotes from fast peers stay usable, and would otherwise throw away a refusal observed just before the clock ran out.
+
+`StorerUpdateRequired` deliberately does **not** get this treatment. It is not a verdict about the client, so one lagging peer must not abort an upload the rest of the close group can serve.
 
 ### Unversioned requests are still served
 
@@ -107,7 +118,8 @@ Flipping that to a refusal is a **follow-up**, gated on that count decaying, and
 - **Range policy.** `a_newer_settlement_version_is_refused_rather_than_assumed_compatible` pins the upper bound, which is the specific error this ADR corrects.
 - **Refusal direction.** `a_newer_settlement_version_is_refused_as_this_nodes_fault` and `the_two_refusals_do_not_blame_the_same_party` pin that a lagging node never reports a client fault.
 - **Terminality.** `a_refusal_aborts_quote_collection_instead_of_counting_as_one_bad_peer` pins that a refusal stops collection rather than joining the failure list, which is what would otherwise let the remaining peers form a quorum and pay anyway.
-- **Downgrade bound.** The compile-time assertion in the client, plus `only_silence_triggers_the_legacy_retry`.
+- **Order independence.** `a_refusal_is_recorded_where_the_collection_timeout_cannot_discard_it` and `meeting_the_target_stops_launching_without_stopping_collection` pin that the verdict does not depend on which peers answered first, and `a_lagging_storer_does_not_populate_the_refusal_slot` pins that a behind-the-times peer is not mistaken for one.
+- **Downgrade bound.** The shared compile-time constant referenced from both fallback sites, plus `only_silence_triggers_the_legacy_retry`.
 - **Still outstanding at the time of writing:** a mixed-version dev testnet exercising legacy node, upgraded node, structured refusal, lost refusal, and send failure against real peers. The unit tests pin the decisions; they do not prove the behaviour end to end.
 
 ### Re-open triggers

--- a/docs/adr/ADR-0010-settlement-version-and-pre-payment-compatibility.md
+++ b/docs/adr/ADR-0010-settlement-version-and-pre-payment-compatibility.md
@@ -1,0 +1,122 @@
+# ADR-0010: Settlement version and pre-payment compatibility
+
+- **Status:** Proposed
+- **Date:** 2026-08-13
+- **Decision owners:** Anselme Grumbach
+- **Reviewers:** David Irvine
+- **Supersedes:** none
+- **Superseded by:** none
+- **Related:** ADR-0008 (storage economics and payment protocol); ant-protocol#23; ant-node#204; ant-client#171
+
+## Context
+
+ADR-0008 raised the merkle settlement multiplier to 3x. It changed client code and node code and **changed no wire type**, so nothing tied the two together. A client built before the change could still collect quotes, still pay, and only then discover that every storer refused the upload.
+
+That ordering is what makes it expensive. A merkle batch settles on-chain **before any storer sees a PUT**, and merkle receipts are not refundable. So the check that mattered ran after the money was gone. Production has been rejecting a slow trickle of such uploads at an exact 3x shortfall, each one a user's payment destroyed, reported to them as two integers to compare.
+
+ADR-0008 anticipated this and listed it as a re-open trigger: *"a rise in refused batch uploads after the boundary, indicating clients that never upgraded."* This ADR is that trigger being answered.
+
+The general problem is that **`PROTOCOL_VERSION` describes what a peer can parse, and nothing described how a peer settles**. Those two move independently. Every future change to settlement arithmetic reproduces this failure unless something carries the second fact.
+
+## Decision Drivers
+
+- A refusal must land **before** payment. Merkle settlement is irreversible, so after-the-fact verification cannot be the only check.
+- A client-first rollout must stay possible. ADR-0008 chose client-first deliberately, because a client paying more is accepted by an old node for free. Any policy that makes old nodes refuse new clients breaks that ordering.
+- Old peers must not be misread. `ChunkMessage` is postcard-encoded and non-self-describing, so a new field silently changes how existing peers parse every message.
+- The user must be told what to do. The failure is only expensive because it is silent.
+
+## Considered Options
+
+1. **Bump `CHUNK_PROTOCOL_ID` to v3.** The established mechanism for wire changes here (ADR-0004, ADR-0005). Clean end state, but a hard cutover: old peers cannot negotiate a stream at all, so they get a handshake failure rather than a diagnosis, and the whole fleet plus all clients must move together.
+2. **Append versioned request variants.** No cutover. Existing discriminants are untouched, unknown variants are rejected cleanly, and nodes and clients can move independently.
+3. **Move the multiplier into the contract.** Client submits the 1x price, the contract applies the multiplier. This removes the payer's ability to get it wrong at all, and is the only option that protects clients which never upgrade. Requires a contract upgrade.
+4. **Do nothing; drive client adoption.** Cheapest, and closes the *current* burn faster than any of the above. Does nothing for the next settlement change.
+
+## Decision
+
+We will adopt **option 2**, and treat **option 3 as the eventual structural fix** rather than a competing one.
+
+A `settlement_version` travels in the quote request. It is a separate constant from `PROTOCOL_VERSION` and is bumped whenever a change makes an older client pay an amount storers will refuse.
+
+### The compatibility rule
+
+A storer quotes only when the client's version falls inside its own inclusive range:
+
+```
+MIN_SUPPORTED_SETTLEMENT_VERSION <= client_version <= CURRENT_SETTLEMENT_VERSION
+```
+
+**Both ends are bounded, and the upper bound is the part that is easy to get wrong.** An earlier revision of this work accepted everything at or above the minimum, reasoning that a storer verifies whatever payment actually arrives, so letting a newer client through weakens nothing. That is true only when a settlement change *raises* what is paid. ADR-0008's 3x cleared an old node's 1x minimum, so old nodes accepted new clients for free, and that special case was mistaken for the general rule. A change that redefines the median rule, or which field the contract pays from, produces a payment an older verifier rejects, after the client has already settled.
+
+### Two refusals, not one
+
+The two out-of-range directions need opposite handling and are therefore separate wire variants.
+
+| Condition | Wire error | Whose problem | Client behaviour |
+|---|---|---|---|
+| `client_version < MIN` | `ClientUpdateRequired` | the client | **Terminal.** Abort before payment, show the upgrade instruction. |
+| `client_version > CURRENT` | `StorerUpdateRequired` | this node | **Skip the peer.** Say nothing to the user; use other storers. |
+
+Collapsing them would either tell up-to-date users to upgrade, or strand new clients whenever the node fleet lags. A lagging fleet is the *normal* state during the client-first rollout ADR-0008 prescribes, so this distinction is what keeps the two ADRs compatible.
+
+If too few peers remain after skipping, the operation fails for lack of quotes. That is the correct outcome: it fails before payment rather than after.
+
+### The legacy fallback, and the rule that retires it
+
+A storer built before the versioned requests cannot decode them and simply never answers. Clients therefore retry each silent peer once in the legacy shape, or nothing would work until the whole fleet had upgraded.
+
+**This is a downgrade path.** Silence is not proof a peer cannot parse the request: a dropped response, packet loss, an overloaded peer, and one deliberately discarding versioned requests are indistinguishable from the client side. So the retry can be provoked, and a provoked retry bypasses the gate.
+
+It is safe **only while no client can be refused on version grounds**, which holds exactly while `MIN_SUPPORTED_SETTLEMENT_VERSION` is the first declarable version. The rule is therefore:
+
+> The unversioned retry must be deleted **before** `MIN_SUPPORTED_SETTLEMENT_VERSION` is ever raised.
+
+This is enforced by a compile-time assertion in the client, not by review discipline: raising the minimum while the fallback exists fails the build.
+
+### Unversioned requests are still served
+
+A storer cannot distinguish a client that settles correctly but predates the version field (ant-core 0.5.1 through 0.6.0) from one that does not. Refusing both would break clients that are behaving, so unversioned requests are served and counted. Nodes log a running total per path under `ant_node::quote::settlement`.
+
+Flipping that to a refusal is a **follow-up**, gated on that count decaying, and should use a dated self-retiring boundary in the style of `MERKLE_PARITY_ENFORCED_FROM_UNIX`.
+
+## Consequences
+
+### Positive
+
+- A settlement change can no longer burn an outdated client's money. The refusal lands at quote time, where it costs nothing.
+- The user is told what happened and what to do, in both the quote refusal and the PUT-time underpayment message.
+- No protocol cutover. Nodes and clients roll independently.
+- The wire discriminants of every pre-existing message and error are pinned by a regression test, so the append-only property this rests on is enforced rather than assumed.
+
+### Negative / Trade-offs
+
+- **It does not fix the current burn.** A client too old to settle correctly is also too old to declare a version, so the gate cannot see the population causing today's rejections. Only the reworded error reaches them. Driving client adoption remains the cheaper and faster remedy for the incident that prompted this.
+- **Merkle storers are not exactly the quoted peers.** The gate covers the 16 candidates a client quotes, but the chunk is stored by each chunk's close group, which may include a peer that never quoted. A storer outside the candidate set can still refuse at PUT time. This narrows the exposure substantially without closing it, and only option 3 closes it fully.
+- The fallback costs one extra timeout per silent peer during rollout. Requests run concurrently, so the worst case is 2x the quote timeout overall.
+- Clients declaring a version are refused by nodes that have not upgraded. Harmless today because no node has a lower `CURRENT`, but it makes node rollout a prerequisite for the next settlement bump.
+
+### Neutral / Operational
+
+- Deploy order is **nodes before clients**, since a node on `ant-protocol` 2.3.x cannot decode versioned requests. The fallback makes this a preference rather than a hard gate.
+- The unversioned-quote counter is the input to the follow-up decision above.
+- `ant-protocol` moves 2.3.2 -> 2.4.0. Additive, minor.
+
+## Validation
+
+- **Wire safety.** `appending_v2_variants_leaves_existing_discriminants_untouched` and `client_update_required_is_appended_to_protocol_error` pin the discriminant of every pre-existing variant. If either fails, older peers are misreading current traffic.
+- **Range policy.** `a_newer_settlement_version_is_refused_rather_than_assumed_compatible` pins the upper bound, which is the specific error this ADR corrects.
+- **Refusal direction.** `a_newer_settlement_version_is_refused_as_this_nodes_fault` and `the_two_refusals_do_not_blame_the_same_party` pin that a lagging node never reports a client fault.
+- **Terminality.** `a_refusal_aborts_quote_collection_instead_of_counting_as_one_bad_peer` pins that a refusal stops collection rather than joining the failure list, which is what would otherwise let the remaining peers form a quorum and pay anyway.
+- **Downgrade bound.** The compile-time assertion in the client, plus `only_silence_triggers_the_legacy_retry`.
+- **Still outstanding at the time of writing:** a mixed-version dev testnet exercising legacy node, upgraded node, structured refusal, lost refusal, and send failure against real peers. The unit tests pin the decisions; they do not prove the behaviour end to end.
+
+### Re-open triggers
+
+- The unversioned-quote count failing to decay, which would mean a long tail of clients the gate can never protect and would raise the priority of option 3.
+- Any settlement change that is **not** a monotonic increase, which makes the upper bound load-bearing for the first time.
+- Evidence of peers selectively dropping versioned requests, which would mean the downgrade path is being probed and the fallback should be retired early.
+- A decision to move the multiplier on-chain, which would supersede most of this.
+
+## Notes for AI-assisted work
+
+AI tools may help draft this ADR, but **must not mark it Accepted without human review**. Accepted ADRs are immutable: create a new superseding ADR rather than editing an Accepted ADR.

--- a/docs/adr/ADR-0010-settlement-version-and-pre-payment-compatibility.md
+++ b/docs/adr/ADR-0010-settlement-version-and-pre-payment-compatibility.md
@@ -94,7 +94,7 @@ Flipping that to a refusal is a **follow-up**, gated on that count decaying, and
 
 ### Positive
 
-- A settlement change can no longer burn an outdated client's money. The refusal lands at quote time, where it costs nothing.
+- A settlement change no longer burns an outdated client's money **on the path the gate covers**: the refusal lands at quote time, where it costs nothing. It is a large reduction rather than an elimination, and the two holes are named under trade-offs below. Read this bullet with those.
 - The user is told what happened and what to do, in both the quote refusal and the PUT-time underpayment message.
 - No protocol cutover. Nodes and clients roll independently.
 - The wire discriminants of every pre-existing message and error are pinned by a regression test, so the append-only property this rests on is enforced rather than assumed.
@@ -102,7 +102,9 @@ Flipping that to a refusal is a **follow-up**, gated on that count decaying, and
 ### Negative / Trade-offs
 
 - **It does not fix the current burn.** A client too old to settle correctly is also too old to declare a version, so the gate cannot see the population causing today's rejections. Only the reworded error reaches them. Driving client adoption remains the cheaper and faster remedy for the incident that prompted this.
-- **Merkle storers are not exactly the quoted peers.** The gate covers the 16 candidates a client quotes, but the chunk is stored by each chunk's close group, which may include a peer that never quoted. A storer outside the candidate set can still refuse at PUT time. This narrows the exposure substantially without closing it, and only option 3 closes it fully.
+- **Merkle storers are not exactly the quoted peers.** The gate covers the 16 candidates a client quotes, but the chunk is stored by each chunk's close group, which may include a peer that never quoted, and routing can move that group between quoting and storing. A storer outside the candidate set can still refuse at PUT time, after payment. This narrows the exposure substantially without closing it, and only option 3 closes it fully.
+- **A client binary already in the field cannot be reached.** The cutover guard bounds what future builds may do; it does nothing about a released client that still carries the fallback when nodes later raise their minimum. That is inherent to shipping software, and it is the same reason the storer verifies every payment it is actually offered rather than trusting the declared version.
+- **A refusal in a later merkle sub-batch arrives after earlier sub-batches have paid.** Batches above `MAX_LEAVES` settle sequentially, so the gate cannot be consulted for sub-batch two before sub-batch one's money is spent. The refusal is surfaced rather than folded into a partial success, but the earlier spend has already happened.
 - The fallback costs one probe per silent peer, bounded by `VERSIONED_QUOTE_PROBE_CEILING` and paid once per peer rather than once per request. Before those two bounds it was one full quote timeout on **every** request, which took the merkle E2E suite from ~24 minutes past the 60-minute CI cap. See the validation section.
 - Clients declaring a version are refused by nodes that have not upgraded. Harmless today because no node has a lower `CURRENT`, but it makes node rollout a prerequisite for the next settlement bump.
 
@@ -114,12 +116,12 @@ Flipping that to a refusal is a **follow-up**, gated on that count decaying, and
 
 ## Validation
 
-- **Wire safety.** `appending_v2_variants_leaves_existing_discriminants_untouched` and `client_update_required_is_appended_to_protocol_error` pin the discriminant of every pre-existing variant. If either fails, older peers are misreading current traffic.
+- **Wire safety.** `appending_v2_variants_leaves_existing_discriminants_untouched` and `client_update_required_is_appended_to_protocol_error` pin the discriminant of every pre-existing message body **and** every pre-existing `ProtocolError`, responses included. An earlier revision pinned only the request half and the endpoints of the error enum, so a reordered response variant would have passed while breaking old peers.
 - **Range policy.** `a_newer_settlement_version_is_refused_rather_than_assumed_compatible` pins the upper bound, which is the specific error this ADR corrects.
 - **Refusal direction.** `a_newer_settlement_version_is_refused_as_this_nodes_fault` and `the_two_refusals_do_not_blame_the_same_party` pin that a lagging node never reports a client fault.
 - **Terminality.** `a_refusal_aborts_quote_collection_instead_of_counting_as_one_bad_peer` pins that a refusal stops collection rather than joining the failure list, which is what would otherwise let the remaining peers form a quorum and pay anyway.
-- **Order independence.** `a_refusal_is_recorded_where_the_collection_timeout_cannot_discard_it` and `meeting_the_target_stops_launching_without_stopping_collection` pin that the verdict does not depend on which peers answered first, and `a_lagging_storer_does_not_populate_the_refusal_slot` pins that a behind-the-times peer is not mistaken for one.
-- **Downgrade bound.** The shared compile-time constant referenced from both fallback sites, plus `only_silence_triggers_the_legacy_retry`.
+- **Order independence.** `a_refusal_is_recorded_where_the_collection_timeout_cannot_discard_it` and `meeting_the_target_stops_launching_without_stopping_collection`, plus `a_lagging_storer_does_not_populate_the_refusal_slot`. Stated precisely, because it is easy to overclaim: these pin the *mechanism* — that the verdict is stored where the elapsed arm cannot reach it, and that the launch budget stops recruiting at the target. **No test drives a real collection to timeout**, so the end-to-end ordering behaviour is argued from those two pieces rather than observed.
+- **Downgrade bound.** The shared compile-time constant referenced from both fallback sites, plus `only_silence_triggers_the_legacy_retry` and `only_silence_is_evidence_worth_caching`. The constant now bounds `CURRENT` as well as `MIN`: raising either opens a refusal the unversioned retry could route around, and an earlier revision guarded only `MIN`.
 ### Mixed-version validation, and what it found
 
 The new-client-against-old-fleet case has been exercised for real, not simulated. `ant-client`'s merkle E2E suite spawns a 35-node testnet from the **published** `ant-node`, which predates the versioned requests, so the suite is a live mixed-version run: every node logs `Failed to decode message: deserialization failed` for each versioned probe and answers only the unversioned retry.

--- a/docs/adr/ADR-0010-settlement-version-and-pre-payment-compatibility.md
+++ b/docs/adr/ADR-0010-settlement-version-and-pre-payment-compatibility.md
@@ -157,7 +157,29 @@ Cutting a probe short therefore does more than misjudge a slow peer. The rule is
 
 The cost of that is roughly two minutes per merkle E2E test for as long as the suite's devnet speaks the pre-versioned dialect. That is an artifact of the temporary fork-branch protocol pin rather than of the design; when the fleet under test can answer a versioned request there are no probes to pay for and the suite returns to baseline.
 
-**Still outstanding:** the reverse direction, old client against an upgraded node, and a fleet with both. Those need a testnet built from this branch's `ant-node` rather than the published one, which is not available until the coordinated set lands. Also unproven end to end: structured refusal, lost refusal, and send failure against real peers, which are pinned at unit level only.
+### The gate itself, over a real connection
+
+`settlement_version_gate_observed_on_live_network` (`tests/e2e/settlement_version_gate.rs`) closes the half of the mixed-version gate that does not need the coordinated set to land. It spawns a devnet from **this branch's** node and puts all four cases on a real QUIC connection between two nodes, on both quote paths:
+
+| Request | Result |
+|---|---|
+| Unversioned, the shape every released client sends | Served |
+| Declaring `CURRENT` | Served |
+| Declaring below `MIN` | `ClientUpdateRequired`, no quote issued |
+| Declaring above `CURRENT` | `StorerUpdateRequired`, no quote issued |
+
+That covers **old client against an upgraded node**, which this ADR previously recorded as unit-level only, and the **structured refusal against a real peer** in both directions. Both refusals are unreachable in production today, since `MIN` and `CURRENT` are both the first declarable version, so the driver crafts the versions a future settlement bump will make real.
+
+Run with `RUST_LOG=ant_node::quote::settlement=warn`, it also prints the four refusal lines as a running node emits them, which is the first observation of that log target outside a unit test:
+
+```text
+WARN ant_node::quote::settlement: Refusing single_node quote: client settlement version 0
+  is below the minimum 1. No quote issued, so the client has not been charged.
+WARN ant_node::quote::settlement: Refusing merkle quote: client settles under version 2,
+  newer than this node's 1. This node needs upgrading; the client has not been charged.
+```
+
+**Still outstanding:** a genuinely mixed fleet, with old and new nodes answering the same client, which needs a deployment rather than a devnet. Also unproven end to end: lost refusal and send failure against real peers, which are pinned at unit level only, and the unversioned-quote counter, which needs production traffic volumes to cross its log interval at all.
 
 ### Release gates
 
@@ -167,9 +189,9 @@ Merging puts this in the next release, so the bar is fleet-ready, not code-compl
 |---|---|
 | Code / CI | Proven across all three repos |
 | Dependency | Open: both downstream crates pin a mutable protocol branch |
-| Mixed-version | Partial: new-client against an old fleet is proven by the client suite; the gate itself has never run over a real connection, because the devnet speaks the pre-versioned dialect |
+| Mixed-version | Partial: new-client against an old fleet is proven by the client suite, and both refusal directions plus the unversioned path now run over a real connection on a devnet built from this branch. A fleet running both node versions at once still needs a deployment |
 | Deployment ordering | Open, and **not inert**: against a fleet that cannot answer a versioned request every first contact costs a probe wait, so releasing the client ahead of the nodes adds real latency to cold uploads |
-| Observability | Open: the unversioned-quote counter is the signal that retires the legacy path and has never been read in production |
+| Observability | Open: the refusal lines are now observed emitting on a running node, but the unversioned-quote counter is the signal that retires the legacy path, and its log line has never fired outside production volumes, let alone been read there |
 | NAT / canary | Open: no canary; relayed and NAT'd peers are the paths this adds work to |
 | Rollback | Argued, not rehearsed |
 | Fleet safety | Open: the corroboration quorum and the client-wide latch have never met a real fleet |

--- a/docs/adr/ADR-0010-settlement-version-and-pre-payment-compatibility.md
+++ b/docs/adr/ADR-0010-settlement-version-and-pre-payment-compatibility.md
@@ -99,7 +99,7 @@ Flipping that to a refusal is a **follow-up**, gated on that count decaying, and
 
 - Deploy order is **nodes before clients**, since a node on `ant-protocol` 2.3.x cannot decode versioned requests. The fallback makes this a preference rather than a hard gate.
 - The unversioned-quote counter is the input to the follow-up decision above.
-- `ant-protocol` moves 2.3.2 -> 2.4.0. Additive, minor.
+- The `ant-protocol` change is additive, so it carries a minor semver impact. The version bump itself is left to the release train, not taken in the PR.
 
 ## Validation
 

--- a/docs/adr/ADR-0013-settlement-version-and-pre-payment-compatibility.md
+++ b/docs/adr/ADR-0013-settlement-version-and-pre-payment-compatibility.md
@@ -96,7 +96,7 @@ A refusal is a verdict about the client, not about one peer, so it cannot be tre
 
 ### Unversioned requests are still served
 
-A storer cannot distinguish a client that settles correctly but predates the version field (ant-core 0.5.1 through 0.6.0) from one that does not. Refusing both would break clients that are behaving, so unversioned requests are served and counted. Nodes log a running total per path under `ant_node::quote::settlement`.
+A storer cannot distinguish a client that settles correctly but predates the version field (ant-core 0.5.1 through 0.6.0) from one that does not. Refusing both would break clients that are behaving, so unversioned requests are served and counted. Nodes log a running total per path under `ant_node::quote::settlement`. The count is taken on arrival rather than on a quote being returned: a request this node refuses for an unrelated reason still came from a client that cannot declare a version, and would still break if the unversioned path were retired.
 
 Flipping that to a refusal is a **follow-up**, gated on that count decaying, and should use a dated self-retiring boundary in the style of `MERKLE_PARITY_ENFORCED_FROM_UNIX`.
 

--- a/docs/adr/ADR-0013-settlement-version-and-pre-payment-compatibility.md
+++ b/docs/adr/ADR-0013-settlement-version-and-pre-payment-compatibility.md
@@ -1,4 +1,4 @@
-# ADR-0010: Settlement version and pre-payment compatibility
+# ADR-0013: Settlement version and pre-payment compatibility
 
 - **Status:** Proposed
 - **Date:** 2026-08-13
@@ -6,7 +6,7 @@
 - **Reviewers:** David Irvine
 - **Supersedes:** none
 - **Superseded by:** none
-- **Related:** ADR-0008 (storage economics and payment protocol); ant-protocol#23; ant-node#204; ant-client#171
+- **Related:** ADR-0008 (storage economics and payment protocol); ant-protocol#25; ant-node#204; ant-client#171
 
 ## Context
 

--- a/src/ant_protocol/mod.rs
+++ b/src/ant_protocol/mod.rs
@@ -17,10 +17,10 @@
 pub use ::ant_protocol::chunk;
 
 pub use ::ant_protocol::chunk::{
-    settlement_version_is_supported, ChunkGetRequest, ChunkGetResponse, ChunkMessage,
-    ChunkMessageBody, ChunkPutRequest, ChunkPutResponse, ChunkQuoteRequest, ChunkQuoteRequestV2,
-    ChunkQuoteResponse, MerkleCandidateQuoteRequest, MerkleCandidateQuoteRequestV2,
-    MerkleCandidateQuoteResponse, ProtocolError, XorName, CHUNK_PROTOCOL_ID, CLOSE_GROUP_MAJORITY,
+    settlement_compatibility, ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkMessageBody,
+    ChunkPutRequest, ChunkPutResponse, ChunkQuoteRequest, ChunkQuoteRequestV2, ChunkQuoteResponse,
+    MerkleCandidateQuoteRequest, MerkleCandidateQuoteRequestV2, MerkleCandidateQuoteResponse,
+    ProtocolError, SettlementCompatibility, XorName, CHUNK_PROTOCOL_ID, CLOSE_GROUP_MAJORITY,
     CLOSE_GROUP_SIZE, CURRENT_SETTLEMENT_VERSION, DATA_TYPE_CHUNK, MAX_CHUNK_SIZE,
     MAX_WIRE_MESSAGE_SIZE, MIN_SUPPORTED_SETTLEMENT_VERSION, PROOF_TAG_MERKLE,
     PROOF_TAG_SINGLE_NODE, PROTOCOL_VERSION, XORNAME_LEN,

--- a/src/ant_protocol/mod.rs
+++ b/src/ant_protocol/mod.rs
@@ -17,9 +17,11 @@
 pub use ::ant_protocol::chunk;
 
 pub use ::ant_protocol::chunk::{
-    ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkMessageBody, ChunkPutRequest,
-    ChunkPutResponse, ChunkQuoteRequest, ChunkQuoteResponse, MerkleCandidateQuoteRequest,
+    settlement_version_is_supported, ChunkGetRequest, ChunkGetResponse, ChunkMessage,
+    ChunkMessageBody, ChunkPutRequest, ChunkPutResponse, ChunkQuoteRequest, ChunkQuoteRequestV2,
+    ChunkQuoteResponse, MerkleCandidateQuoteRequest, MerkleCandidateQuoteRequestV2,
     MerkleCandidateQuoteResponse, ProtocolError, XorName, CHUNK_PROTOCOL_ID, CLOSE_GROUP_MAJORITY,
-    CLOSE_GROUP_SIZE, DATA_TYPE_CHUNK, MAX_CHUNK_SIZE, MAX_WIRE_MESSAGE_SIZE, PROOF_TAG_MERKLE,
+    CLOSE_GROUP_SIZE, CURRENT_SETTLEMENT_VERSION, DATA_TYPE_CHUNK, MAX_CHUNK_SIZE,
+    MAX_WIRE_MESSAGE_SIZE, MIN_SUPPORTED_SETTLEMENT_VERSION, PROOF_TAG_MERKLE,
     PROOF_TAG_SINGLE_NODE, PROTOCOL_VERSION, XORNAME_LEN,
 };

--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -3363,11 +3363,33 @@ impl PaymentVerifier {
                 )));
             }
             if *paid_amount < expected_per_node {
+                // An exact `required_multiplier`x shortfall is the signature of
+                // a client that settles under the superseded rule: it applied
+                // no multiplier at all. That is not a pricing dispute, it is an
+                // outdated client, and the person reading this has already paid
+                // and cannot get it back. Say so, and say what to do about it,
+                // rather than leaving them with two integers to compare.
+                //
+                // This message is the only thing that reaches such a client.
+                // The settlement-version gate refuses these uploads before they
+                // pay, but only for clients new enough to declare a version,
+                // which by construction excludes every client this branch
+                // catches.
+                let looks_like_stale_client = expected_per_node
+                    == paid_amount.saturating_mul(Amount::from(required_multiplier));
+                let advice = if looks_like_stale_client {
+                    " This is exactly the pre-parity settlement amount, so the paying client is \
+                     too old to settle correctly. Run `ant update` to upgrade, or reinstall from \
+                     https://github.com/WithAutonomi/ant-client/releases/latest. Note the payment \
+                     that was already made cannot be recovered."
+                } else {
+                    ""
+                };
                 return Err(Error::Payment(format!(
                     "Underpayment for node at index {idx}: paid {paid_amount}, \
                      expected at least {expected_per_node} \
                      (median16 formula, depth={}, {required_multiplier}x required for a \
-                     receipt stamped {} vs parity boundary {parity_from})",
+                     receipt stamped {} vs parity boundary {parity_from}).{advice}",
                     payment_info.depth, payment_info.merkle_payment_timestamp
                 )));
             }
@@ -7039,6 +7061,59 @@ mod tests {
         assert!(
             err_msg.contains("Underpayment") && err_msg.contains("3x required"),
             "Error should name the required multiplier: {err_msg}"
+        );
+        // An exact 1x settlement is an outdated client, not a pricing dispute.
+        // The payer has already spent money they cannot recover, so the
+        // rejection has to tell them what to do rather than hand them two
+        // integers. This is the only message that reaches a client too old to
+        // declare a settlement version at quote time.
+        assert!(
+            err_msg.contains("too old to settle correctly") && err_msg.contains("ant update"),
+            "Error should tell the user to upgrade: {err_msg}"
+        );
+    }
+
+    /// The upgrade advice is keyed on an EXACT multiplier shortfall, which is
+    /// what an unmultiplied settlement looks like. A merely-cheap payment is a
+    /// different fault and must not be blamed on the client's version, or the
+    /// advice stops meaning anything.
+    #[tokio::test]
+    async fn a_partial_shortfall_is_not_blamed_on_an_outdated_client() {
+        let verifier = merkle_test_verifier();
+        let (xorname, tagged_proof, pool_hash, ts) = make_valid_merkle_proof_bytes();
+
+        // One wei under parity: short, but not the 1x signature.
+        let almost = merkle_parity_per_node_depth2().saturating_sub(Amount::from(1u64));
+        {
+            let info = evmlib::merkle_payments::OnChainPaymentInfo {
+                depth: 2,
+                merkle_payment_timestamp: ts,
+                paid_node_addresses: vec![
+                    (RewardsAddress::new([0u8; 20]), 0, almost),
+                    (RewardsAddress::new([1u8; 20]), 1, almost),
+                ],
+            };
+            verifier.pool_cache.lock().put(pool_hash, info);
+        }
+
+        let err_msg = format!(
+            "{}",
+            verifier
+                .verify_payment(
+                    &xorname,
+                    Some(&tagged_proof),
+                    VerificationContext::ClientPut
+                )
+                .await
+                .expect_err("a short settlement must be refused")
+        );
+        assert!(
+            err_msg.contains("Underpayment"),
+            "Error should still name the underpayment: {err_msg}"
+        );
+        assert!(
+            !err_msg.contains("ant update"),
+            "A partial shortfall must not be reported as an outdated client: {err_msg}"
         );
     }
 

--- a/src/payment/verifier.rs
+++ b/src/payment/verifier.rs
@@ -354,6 +354,24 @@ fn merkle_required_multiplier(receipt_timestamp: u64, enforced_from: u64) -> u64
 /// scaling a 1x result is wrong. The order here — multiply the total, then
 /// divide once — is deliberate, and matches the contract, which computes
 /// `totalAmount` before splitting it.
+/// Does this underpayment look like a client that applied no multiplier at
+/// all, as opposed to one that merely paid too little?
+///
+/// Compares against the **bare** expectation rather than scaling the paid
+/// amount up by the required multiplier. [`merkle_expected_per_node`] floors
+/// after multiplying, so `expected(m)` is not generally `m * expected(1)`: at
+/// median 901 and depth 7 they differ by one wei. A scaled comparison
+/// therefore misses genuinely unmultiplied settlements at every depth that
+/// does not divide its leaf count evenly, and those are exactly the clients
+/// the upgrade advice exists for.
+fn underpayment_looks_like_a_stale_client(
+    paid: Amount,
+    expected_bare: Amount,
+    required_multiplier: u64,
+) -> bool {
+    required_multiplier > 1 && paid == expected_bare
+}
+
 fn merkle_expected_per_node(
     candidate_prices: &[Amount],
     depth: u8,
@@ -3375,8 +3393,11 @@ impl PaymentVerifier {
                 // pay, but only for clients new enough to declare a version,
                 // which by construction excludes every client this branch
                 // catches.
-                let looks_like_stale_client = expected_per_node
-                    == paid_amount.saturating_mul(Amount::from(required_multiplier));
+                let looks_like_stale_client = underpayment_looks_like_a_stale_client(
+                    *paid_amount,
+                    expected_per_node_bare,
+                    required_multiplier,
+                );
                 let advice = if looks_like_stale_client {
                     " This is exactly the pre-parity settlement amount, so the paying client is \
                      too old to settle correctly. Run `ant update` to upgrade, or reinstall from \
@@ -3652,6 +3673,39 @@ mod tests {
             bare * Amount::from(PAID_QUOTE_PAYMENT_MULTIPLIER) + Amount::from(1u64),
             "dividing before multiplying would lose this wei"
         );
+    }
+
+    /// The same non-linearity that test pins also breaks a naive check for
+    /// "did this client apply no multiplier".
+    ///
+    /// Scaling the paid amount up by the multiplier and comparing against the
+    /// parity expectation asks `49_426 == 49_425` at median 901 depth 7, which
+    /// is false, so a genuinely unmultiplied settlement is not recognised and
+    /// the payer never learns their client is too old. Comparing against the
+    /// bare expectation asks the same arithmetic the expectation was built
+    /// with, and holds at every depth.
+    #[test]
+    fn a_stale_client_is_recognised_where_depth_does_not_divide_its_leaves() {
+        let prices = prices_with_median(901);
+        let bare = merkle_expected_per_node(&prices, 7, 1).expect("bare expectation is payable");
+        let parity = merkle_expected_per_node(&prices, 7, PAID_QUOTE_PAYMENT_MULTIPLIER)
+            .expect("parity expectation is payable");
+
+        // The scaled comparison this replaced would have missed it.
+        assert_ne!(parity, bare * Amount::from(PAID_QUOTE_PAYMENT_MULTIPLIER));
+
+        assert!(
+            underpayment_looks_like_a_stale_client(bare, bare, PAID_QUOTE_PAYMENT_MULTIPLIER),
+            "an exactly-1x settlement must be recognised at depth 7"
+        );
+        // A merely-cheap payment still is not blamed on the client's version.
+        assert!(!underpayment_looks_like_a_stale_client(
+            bare.saturating_sub(Amount::from(1u64)),
+            bare,
+            PAID_QUOTE_PAYMENT_MULTIPLIER
+        ));
+        // And under the legacy regime there is nothing to upgrade away from.
+        assert!(!underpayment_looks_like_a_stale_client(bare, bare, 1));
     }
 
     /// The economic invariant ADR-0008 restores: a merkle **leaf** settles

--- a/src/storage/handler.rs
+++ b/src/storage/handler.rs
@@ -27,13 +27,15 @@
 //! └─────────────────────────────────────────────────────────┘
 //! ```
 
-#[cfg(test)]
-use crate::ant_protocol::DATA_TYPE_CHUNK;
 use crate::ant_protocol::{
-    ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkMessageBody, ChunkPutRequest,
-    ChunkPutResponse, ChunkQuoteRequest, ChunkQuoteResponse, MerkleCandidateQuoteRequest,
+    settlement_version_is_supported, ChunkGetRequest, ChunkGetResponse, ChunkMessage,
+    ChunkMessageBody, ChunkPutRequest, ChunkPutResponse, ChunkQuoteRequest, ChunkQuoteRequestV2,
+    ChunkQuoteResponse, MerkleCandidateQuoteRequest, MerkleCandidateQuoteRequestV2,
     MerkleCandidateQuoteResponse, ProtocolError, CHUNK_PROTOCOL_ID, MAX_CHUNK_SIZE,
+    MIN_SUPPORTED_SETTLEMENT_VERSION,
 };
+#[cfg(test)]
+use crate::ant_protocol::{CURRENT_SETTLEMENT_VERSION, DATA_TYPE_CHUNK};
 use crate::client::compute_address;
 use crate::error::{Error, Result};
 use crate::logging::{debug, info, warn};
@@ -45,6 +47,7 @@ use crate::storage::lmdb::LmdbStorage;
 use bytes::Bytes;
 use parking_lot::RwLock;
 use saorsa_core::P2PNode;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
@@ -206,6 +209,51 @@ impl Drop for GetRequestTelemetry {
             self.finished = true;
         }
     }
+}
+
+/// How many unversioned quote requests to serve between adoption log lines.
+///
+/// One line per request would drown the log at production quote rates, and one
+/// line total would say nothing about the trend. A running count emitted every
+/// `N` gives the shape of client adoption, which is the number that decides
+/// when unversioned requests can start being refused outright.
+const UNVERSIONED_QUOTE_LOG_INTERVAL: u64 = 1_000;
+
+/// Unversioned quote requests served since start, by path.
+///
+/// Indices are `[single_node, merkle]`. A plain counter rather than a metric
+/// because the only consumer is the rollout decision, and that reads logs.
+static UNVERSIONED_QUOTES_SERVED: [AtomicU64; 2] = [AtomicU64::new(0), AtomicU64::new(0)];
+
+/// Refuse a quote when the requesting client settles under rules this node no
+/// longer accepts. `None` means the request may proceed.
+///
+/// This is the whole point of the settlement version. A merkle batch pays
+/// on-chain **before** any storer sees a PUT, so refusing the *payment* is
+/// refusing something already spent and unrefundable. Refusing the *quote*
+/// costs the client nothing: no quote means no pool commitment, which means no
+/// payment.
+///
+/// A version NEWER than this node understands is deliberately allowed through.
+/// The storer still verifies whatever payment actually arrives, so nothing is
+/// weakened by letting it past, whereas rejecting it would let a stale node
+/// veto a rule set the network has already moved to.
+fn settlement_gate(client_settlement_version: u32, path: &str) -> Option<ProtocolError> {
+    if settlement_version_is_supported(client_settlement_version) {
+        return None;
+    }
+
+    warn!(
+        target: "ant_node::quote::settlement",
+        "Refusing {path} quote: client settlement version {client_settlement_version} \
+         is below the minimum {MIN_SUPPORTED_SETTLEMENT_VERSION}. No quote issued, \
+         so the client has not been charged.",
+    );
+
+    Some(ProtocolError::ClientUpdateRequired {
+        client_settlement_version,
+        min_settlement_version: MIN_SUPPORTED_SETTLEMENT_VERSION,
+    })
 }
 
 /// ANT protocol handler.
@@ -420,11 +468,21 @@ impl AntProtocol {
                 ChunkMessageBody::GetResponse(response)
             }
             ChunkMessageBody::QuoteRequest(ref req) => {
+                Self::note_unversioned_quote("single_node");
                 ChunkMessageBody::QuoteResponse(self.handle_quote(req))
             }
             ChunkMessageBody::MerkleCandidateQuoteRequest(ref req) => {
+                Self::note_unversioned_quote("merkle");
                 ChunkMessageBody::MerkleCandidateQuoteResponse(
                     self.handle_merkle_candidate_quote(req),
+                )
+            }
+            ChunkMessageBody::QuoteRequestV2(ref req) => {
+                ChunkMessageBody::QuoteResponse(self.handle_quote_v2(req))
+            }
+            ChunkMessageBody::MerkleCandidateQuoteRequestV2(ref req) => {
+                ChunkMessageBody::MerkleCandidateQuoteResponse(
+                    self.handle_merkle_candidate_quote_v2(req),
                 )
             }
             // Anything else — response messages are handled by client
@@ -776,6 +834,66 @@ impl AntProtocol {
                 }
             }
             Err(e) => ChunkQuoteResponse::Error(ProtocolError::QuoteFailed(e.to_string())),
+        }
+    }
+
+    /// Handle a version-declaring storage quote request.
+    ///
+    /// Refuse first, then fall through to the existing unversioned handler
+    /// with the same request. The gate is the only difference between the two
+    /// paths, so nothing else is duplicated and the two cannot drift.
+    fn handle_quote_v2(&self, request: &ChunkQuoteRequestV2) -> ChunkQuoteResponse {
+        if let Some(refusal) = settlement_gate(request.settlement_version, "single_node") {
+            return ChunkQuoteResponse::Error(refusal);
+        }
+        self.handle_quote(&ChunkQuoteRequest {
+            address: request.address,
+            data_size: request.data_size,
+            data_type: request.data_type,
+        })
+    }
+
+    /// Handle a version-declaring merkle candidate quote request.
+    ///
+    /// The gate matters most here: a merkle batch settles on-chain before any
+    /// storer sees a PUT, so this is the last point at which refusing costs
+    /// the client nothing.
+    fn handle_merkle_candidate_quote_v2(
+        &self,
+        request: &MerkleCandidateQuoteRequestV2,
+    ) -> MerkleCandidateQuoteResponse {
+        if let Some(refusal) = settlement_gate(request.settlement_version, "merkle") {
+            return MerkleCandidateQuoteResponse::Error(refusal);
+        }
+        self.handle_merkle_candidate_quote(&MerkleCandidateQuoteRequest {
+            address: request.address,
+            data_type: request.data_type,
+            data_size: request.data_size,
+            merkle_payment_timestamp: request.merkle_payment_timestamp,
+        })
+    }
+
+    /// Record that a client asked for a quote without declaring a settlement
+    /// version, and periodically report the running count.
+    ///
+    /// Unversioned requests are still served. A node cannot tell a client that
+    /// settles correctly but predates the version field from one that does
+    /// not, and refusing both would break clients that are behaving. What the
+    /// count buys is the evidence for flipping that policy later: once
+    /// unversioned traffic has decayed, refusing it stops turning away only
+    /// the clients that were already going to lose their money.
+    fn note_unversioned_quote(path: &str) {
+        let slot = usize::from(path == "merkle");
+        let Some(counter) = UNVERSIONED_QUOTES_SERVED.get(slot) else {
+            return;
+        };
+        let served = counter.fetch_add(1, Ordering::Relaxed).saturating_add(1);
+        if served % UNVERSIONED_QUOTE_LOG_INTERVAL == 0 {
+            info!(
+                target: "ant_node::quote::settlement",
+                "Served {served} {path} quotes to clients that declare no settlement version. \
+                 These clients cannot be told to upgrade before they pay.",
+            );
         }
     }
 
@@ -1469,6 +1587,182 @@ mod tests {
                 assert!(candidate.price >= evmlib::common::Amount::ZERO);
             }
             other => panic!("expected MerkleCandidateQuoteResponse::Success, got: {other:?}"),
+        }
+    }
+
+    /// A current client gets a quote through the versioned request, exactly as
+    /// it would through the legacy one. The gate must be invisible to clients
+    /// that can pay.
+    #[tokio::test]
+    async fn v2_merkle_quote_is_served_at_the_current_settlement_version() {
+        let (protocol, _temp) = create_test_protocol().await;
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_secs();
+
+        let msg = ChunkMessage {
+            request_id: 700,
+            body: ChunkMessageBody::MerkleCandidateQuoteRequestV2(
+                MerkleCandidateQuoteRequestV2::new([0x88; 32], 4096, timestamp),
+            ),
+        };
+        let response_bytes = protocol
+            .try_handle_request(&msg.encode().expect("encode request"))
+            .await
+            .expect("handle v2 merkle candidate quote")
+            .expect("expected response");
+        let response = ChunkMessage::decode(&response_bytes).expect("decode response");
+
+        assert_eq!(response.request_id, 700);
+        match response.body {
+            ChunkMessageBody::MerkleCandidateQuoteResponse(
+                MerkleCandidateQuoteResponse::Success { .. },
+            ) => {}
+            other => panic!("expected Success, got: {other:?}"),
+        }
+    }
+
+    /// The point of the whole change: a client that cannot settle correctly is
+    /// turned away at quote time, so it never reaches the on-chain payment it
+    /// would not be able to spend.
+    #[tokio::test]
+    async fn v2_merkle_quote_is_refused_below_the_minimum_settlement_version() {
+        let (protocol, _temp) = create_test_protocol().await;
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_secs();
+
+        let stale = MIN_SUPPORTED_SETTLEMENT_VERSION.saturating_sub(1);
+        let mut request = MerkleCandidateQuoteRequestV2::new([0x99; 32], 4096, timestamp);
+        request.settlement_version = stale;
+
+        let msg = ChunkMessage {
+            request_id: 701,
+            body: ChunkMessageBody::MerkleCandidateQuoteRequestV2(request),
+        };
+        let response_bytes = protocol
+            .try_handle_request(&msg.encode().expect("encode request"))
+            .await
+            .expect("handle v2 merkle candidate quote")
+            .expect("expected response");
+        let response = ChunkMessage::decode(&response_bytes).expect("decode response");
+
+        match response.body {
+            ChunkMessageBody::MerkleCandidateQuoteResponse(
+                MerkleCandidateQuoteResponse::Error(ProtocolError::ClientUpdateRequired {
+                    client_settlement_version,
+                    min_settlement_version,
+                }),
+            ) => {
+                assert_eq!(client_settlement_version, stale);
+                assert_eq!(min_settlement_version, MIN_SUPPORTED_SETTLEMENT_VERSION);
+                // The refusal has to be actionable, not just correct.
+                let rendered = ProtocolError::ClientUpdateRequired {
+                    client_settlement_version,
+                    min_settlement_version,
+                }
+                .to_string();
+                assert!(rendered.contains("ant update"), "{rendered}");
+            }
+            other => panic!("expected ClientUpdateRequired, got: {other:?}"),
+        }
+    }
+
+    /// Same gate on the single-node path, so a refused merkle client cannot
+    /// simply fall back to per-chunk quotes and burn money that way instead.
+    #[tokio::test]
+    async fn v2_single_node_quote_is_refused_below_the_minimum_settlement_version() {
+        let (protocol, _temp) = create_test_protocol().await;
+
+        let mut request = ChunkQuoteRequestV2::new([0xAA; 32], 4096);
+        request.settlement_version = MIN_SUPPORTED_SETTLEMENT_VERSION.saturating_sub(1);
+
+        let msg = ChunkMessage {
+            request_id: 702,
+            body: ChunkMessageBody::QuoteRequestV2(request),
+        };
+        let response_bytes = protocol
+            .try_handle_request(&msg.encode().expect("encode request"))
+            .await
+            .expect("handle v2 quote")
+            .expect("expected response");
+        let response = ChunkMessage::decode(&response_bytes).expect("decode response");
+
+        match response.body {
+            ChunkMessageBody::QuoteResponse(ChunkQuoteResponse::Error(
+                ProtocolError::ClientUpdateRequired { .. },
+            )) => {}
+            other => panic!("expected ClientUpdateRequired, got: {other:?}"),
+        }
+    }
+
+    /// A settlement version this build has never heard of is served, not
+    /// refused. The storer still verifies the payment that actually arrives,
+    /// so nothing is weakened, and refusing would let a node that has not been
+    /// upgraded veto a rule set the network has already moved to.
+    #[tokio::test]
+    async fn a_newer_settlement_version_is_not_treated_as_an_error() {
+        let (protocol, _temp) = create_test_protocol().await;
+
+        let mut request = ChunkQuoteRequestV2::new([0xBB; 32], 4096);
+        request.settlement_version = CURRENT_SETTLEMENT_VERSION.saturating_add(1);
+
+        let msg = ChunkMessage {
+            request_id: 703,
+            body: ChunkMessageBody::QuoteRequestV2(request),
+        };
+        let response_bytes = protocol
+            .try_handle_request(&msg.encode().expect("encode request"))
+            .await
+            .expect("handle v2 quote")
+            .expect("expected response");
+        let response = ChunkMessage::decode(&response_bytes).expect("decode response");
+
+        match response.body {
+            ChunkMessageBody::QuoteResponse(ChunkQuoteResponse::Error(
+                ProtocolError::ClientUpdateRequired { .. },
+            )) => {
+                panic!("a newer client must not be refused by an older node")
+            }
+            ChunkMessageBody::QuoteResponse(_) => {}
+            other => panic!("expected QuoteResponse, got: {other:?}"),
+        }
+    }
+
+    /// Legacy requests keep working. A node cannot tell a client that settles
+    /// correctly but predates the version field from one that does not, so
+    /// refusing both would break clients that are behaving.
+    #[tokio::test]
+    async fn unversioned_requests_are_still_served() {
+        let (protocol, _temp) = create_test_protocol().await;
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_secs();
+
+        let msg = ChunkMessage {
+            request_id: 704,
+            body: ChunkMessageBody::MerkleCandidateQuoteRequest(MerkleCandidateQuoteRequest {
+                address: [0xCC; 32],
+                data_type: DATA_TYPE_CHUNK,
+                data_size: 4096,
+                merkle_payment_timestamp: timestamp,
+            }),
+        };
+        let response_bytes = protocol
+            .try_handle_request(&msg.encode().expect("encode request"))
+            .await
+            .expect("handle legacy merkle candidate quote")
+            .expect("expected response");
+        let response = ChunkMessage::decode(&response_bytes).expect("decode response");
+
+        match response.body {
+            ChunkMessageBody::MerkleCandidateQuoteResponse(
+                MerkleCandidateQuoteResponse::Success { .. },
+            ) => {}
+            other => panic!("expected Success for a legacy request, got: {other:?}"),
         }
     }
 

--- a/src/storage/handler.rs
+++ b/src/storage/handler.rs
@@ -27,15 +27,15 @@
 //! └─────────────────────────────────────────────────────────┘
 //! ```
 
-use crate::ant_protocol::{
-    settlement_version_is_supported, ChunkGetRequest, ChunkGetResponse, ChunkMessage,
-    ChunkMessageBody, ChunkPutRequest, ChunkPutResponse, ChunkQuoteRequest, ChunkQuoteRequestV2,
-    ChunkQuoteResponse, MerkleCandidateQuoteRequest, MerkleCandidateQuoteRequestV2,
-    MerkleCandidateQuoteResponse, ProtocolError, CHUNK_PROTOCOL_ID, MAX_CHUNK_SIZE,
-    MIN_SUPPORTED_SETTLEMENT_VERSION,
-};
 #[cfg(test)]
-use crate::ant_protocol::{CURRENT_SETTLEMENT_VERSION, DATA_TYPE_CHUNK};
+use crate::ant_protocol::DATA_TYPE_CHUNK;
+use crate::ant_protocol::{
+    settlement_compatibility, ChunkGetRequest, ChunkGetResponse, ChunkMessage, ChunkMessageBody,
+    ChunkPutRequest, ChunkPutResponse, ChunkQuoteRequest, ChunkQuoteRequestV2, ChunkQuoteResponse,
+    MerkleCandidateQuoteRequest, MerkleCandidateQuoteRequestV2, MerkleCandidateQuoteResponse,
+    ProtocolError, SettlementCompatibility, CHUNK_PROTOCOL_ID, CURRENT_SETTLEMENT_VERSION,
+    MAX_CHUNK_SIZE, MIN_SUPPORTED_SETTLEMENT_VERSION,
+};
 use crate::client::compute_address;
 use crate::error::{Error, Result};
 use crate::logging::{debug, info, warn};
@@ -239,21 +239,38 @@ static UNVERSIONED_QUOTES_SERVED: [AtomicU64; 2] = [AtomicU64::new(0), AtomicU64
 /// weakened by letting it past, whereas rejecting it would let a stale node
 /// veto a rule set the network has already moved to.
 fn settlement_gate(client_settlement_version: u32, path: &str) -> Option<ProtocolError> {
-    if settlement_version_is_supported(client_settlement_version) {
-        return None;
+    match settlement_compatibility(client_settlement_version) {
+        SettlementCompatibility::Compatible => None,
+        SettlementCompatibility::ClientTooOld => {
+            warn!(
+                target: "ant_node::quote::settlement",
+                "Refusing {path} quote: client settlement version {client_settlement_version} \
+                 is below the minimum {MIN_SUPPORTED_SETTLEMENT_VERSION}. No quote issued, \
+                 so the client has not been charged.",
+            );
+            Some(ProtocolError::ClientUpdateRequired {
+                client_settlement_version,
+                min_settlement_version: MIN_SUPPORTED_SETTLEMENT_VERSION,
+            })
+        }
+        // This node is the old one. Quoting would promise to accept a payment
+        // whose rules it does not know, and a promise broken at PUT time is
+        // broken after the client has settled on-chain. Refusing sends the
+        // client to a peer that can actually honour the quote, at no cost.
+        SettlementCompatibility::NodeTooOld => {
+            warn!(
+                target: "ant_node::quote::settlement",
+                "Refusing {path} quote: client settles under version \
+                 {client_settlement_version}, newer than this node's \
+                 {CURRENT_SETTLEMENT_VERSION}. This node needs upgrading; the client \
+                 has not been charged.",
+            );
+            Some(ProtocolError::StorerUpdateRequired {
+                client_settlement_version,
+                node_settlement_version: CURRENT_SETTLEMENT_VERSION,
+            })
+        }
     }
-
-    warn!(
-        target: "ant_node::quote::settlement",
-        "Refusing {path} quote: client settlement version {client_settlement_version} \
-         is below the minimum {MIN_SUPPORTED_SETTLEMENT_VERSION}. No quote issued, \
-         so the client has not been charged.",
-    );
-
-    Some(ProtocolError::ClientUpdateRequired {
-        client_settlement_version,
-        min_settlement_version: MIN_SUPPORTED_SETTLEMENT_VERSION,
-    })
 }
 
 /// ANT protocol handler.
@@ -1698,12 +1715,17 @@ mod tests {
         }
     }
 
-    /// A settlement version this build has never heard of is served, not
-    /// refused. The storer still verifies the payment that actually arrives,
-    /// so nothing is weakened, and refusing would let a node that has not been
-    /// upgraded veto a rule set the network has already moved to.
+    /// A settlement version this node has never heard of is refused, because
+    /// quoting it would promise to accept a payment whose rules the verifier
+    /// does not know. That promise would be broken at PUT time, which is after
+    /// the client has settled on-chain and can no longer be refunded.
+    ///
+    /// It must be refused as `StorerUpdateRequired`, not `ClientUpdateRequired`.
+    /// The client is fine; this node is behind. Telling an up-to-date user to
+    /// upgrade would be wrong, and during a client-first rollout it would be
+    /// wrong for most of the fleet at once.
     #[tokio::test]
-    async fn a_newer_settlement_version_is_not_treated_as_an_error() {
+    async fn a_newer_settlement_version_is_refused_as_this_nodes_fault() {
         let (protocol, _temp) = create_test_protocol().await;
 
         let mut request = ChunkQuoteRequestV2::new([0xBB; 32], 4096);
@@ -1722,12 +1744,18 @@ mod tests {
 
         match response.body {
             ChunkMessageBody::QuoteResponse(ChunkQuoteResponse::Error(
-                ProtocolError::ClientUpdateRequired { .. },
+                ProtocolError::StorerUpdateRequired {
+                    client_settlement_version,
+                    node_settlement_version,
+                },
             )) => {
-                panic!("a newer client must not be refused by an older node")
+                assert_eq!(
+                    client_settlement_version,
+                    CURRENT_SETTLEMENT_VERSION.saturating_add(1)
+                );
+                assert_eq!(node_settlement_version, CURRENT_SETTLEMENT_VERSION);
             }
-            ChunkMessageBody::QuoteResponse(_) => {}
-            other => panic!("expected QuoteResponse, got: {other:?}"),
+            other => panic!("expected StorerUpdateRequired, got: {other:?}"),
         }
     }
 

--- a/src/storage/handler.rs
+++ b/src/storage/handler.rs
@@ -234,10 +234,12 @@ static UNVERSIONED_QUOTES_SERVED: [AtomicU64; 2] = [AtomicU64::new(0), AtomicU64
 /// costs the client nothing: no quote means no pool commitment, which means no
 /// payment.
 ///
-/// A version NEWER than this node understands is deliberately allowed through.
-/// The storer still verifies whatever payment actually arrives, so nothing is
-/// weakened by letting it past, whereas rejecting it would let a stale node
-/// veto a rule set the network has already moved to.
+/// A version NEWER than this node understands is refused too, as
+/// `StorerUpdateRequired`. Quoting it would promise to accept a payment whose
+/// rules this build does not know, and that promise can only be broken at PUT
+/// time, once the client has settled on-chain. The client is told to use a
+/// different storer rather than to upgrade, because it is this node that is
+/// behind.
 fn settlement_gate(client_settlement_version: u32, path: &str) -> Option<ProtocolError> {
     match settlement_compatibility(client_settlement_version) {
         SettlementCompatibility::Compatible => None,

--- a/src/storage/handler.rs
+++ b/src/storage/handler.rs
@@ -211,7 +211,7 @@ impl Drop for GetRequestTelemetry {
     }
 }
 
-/// How many unversioned quote requests to serve between adoption log lines.
+/// How many unversioned quote requests to receive between adoption log lines.
 ///
 /// One line per request would drown the log at production quote rates, and one
 /// line total would say nothing about the trend. A running count emitted every
@@ -219,11 +219,16 @@ impl Drop for GetRequestTelemetry {
 /// when unversioned requests can start being refused outright.
 const UNVERSIONED_QUOTE_LOG_INTERVAL: u64 = 1_000;
 
-/// Unversioned quote requests served since start, by path.
+/// Unversioned quote requests received since start, by path.
+///
+/// Counted on arrival, before the quote is generated, because the question
+/// this answers is how many clients still cannot declare a version. A request
+/// this node then refuses for an unrelated reason still came from such a
+/// client, and would still break if the unversioned path were retired.
 ///
 /// Indices are `[single_node, merkle]`. A plain counter rather than a metric
 /// because the only consumer is the rollout decision, and that reads logs.
-static UNVERSIONED_QUOTES_SERVED: [AtomicU64; 2] = [AtomicU64::new(0), AtomicU64::new(0)];
+static UNVERSIONED_QUOTE_REQUESTS: [AtomicU64; 2] = [AtomicU64::new(0), AtomicU64::new(0)];
 
 /// Refuse a quote when the requesting client settles under rules this node no
 /// longer accepts. `None` means the request may proceed.
@@ -903,15 +908,16 @@ impl AntProtocol {
     /// the clients that were already going to lose their money.
     fn note_unversioned_quote(path: &str) {
         let slot = usize::from(path == "merkle");
-        let Some(counter) = UNVERSIONED_QUOTES_SERVED.get(slot) else {
+        let Some(counter) = UNVERSIONED_QUOTE_REQUESTS.get(slot) else {
             return;
         };
-        let served = counter.fetch_add(1, Ordering::Relaxed).saturating_add(1);
-        if served % UNVERSIONED_QUOTE_LOG_INTERVAL == 0 {
+        let seen = counter.fetch_add(1, Ordering::Relaxed).saturating_add(1);
+        if seen % UNVERSIONED_QUOTE_LOG_INTERVAL == 0 {
             info!(
                 target: "ant_node::quote::settlement",
-                "Served {served} {path} quotes to clients that declare no settlement version. \
-                 These clients cannot be told to upgrade before they pay.",
+                "Received {seen} {path} quote requests from clients that declare no \
+                 settlement version. These clients cannot be told to upgrade before \
+                 they pay.",
             );
         }
     }

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -81,6 +81,9 @@ mod fresh_offer_capacity;
 #[cfg(test)]
 mod verify_storage_gate;
 
+#[cfg(test)]
+mod settlement_version_gate;
+
 pub use anvil::TestAnvil;
 pub use harness::TestHarness;
 pub use testnet::{NetworkState, NodeState, TestNetwork, TestNetworkConfig, TestNode};

--- a/tests/e2e/settlement_version_gate.rs
+++ b/tests/e2e/settlement_version_gate.rs
@@ -2,9 +2,10 @@
 //!
 //! Every other test of this gate calls the handler in-process. This one puts
 //! the four cases on a real QUIC connection between two nodes built from this
-//! branch, which is the one thing ADR-0013 records as never having been done:
-//! "the gate itself has never run over a real connection, because the devnet
-//! speaks the pre-versioned dialect".
+//! branch, closing the gap ADR-0013 recorded before this test existed: the
+//! gate had never run over a real connection, because the devnet speaks the
+//! pre-versioned dialect. ADR-0013 now records this run under "The gate
+//! itself, over a real connection".
 //!
 //! Four cases per quote path, all against the same node so routing state and
 //! quote pricing are shared:

--- a/tests/e2e/settlement_version_gate.rs
+++ b/tests/e2e/settlement_version_gate.rs
@@ -1,8 +1,8 @@
-//! Live driver for the settlement-version quote gate (ADR-0010).
+//! Live driver for the settlement-version quote gate (ADR-0013).
 //!
 //! Every other test of this gate calls the handler in-process. This one puts
 //! the four cases on a real QUIC connection between two nodes built from this
-//! branch, which is the one thing ADR-0010 records as never having been done:
+//! branch, which is the one thing ADR-0013 records as never having been done:
 //! "the gate itself has never run over a real connection, because the devnet
 //! speaks the pre-versioned dialect".
 //!

--- a/tests/e2e/settlement_version_gate.rs
+++ b/tests/e2e/settlement_version_gate.rs
@@ -1,0 +1,314 @@
+//! Live driver for the settlement-version quote gate (ADR-0010).
+//!
+//! Every other test of this gate calls the handler in-process. This one puts
+//! the four cases on a real QUIC connection between two nodes built from this
+//! branch, which is the one thing ADR-0010 records as never having been done:
+//! "the gate itself has never run over a real connection, because the devnet
+//! speaks the pre-versioned dialect".
+//!
+//! Four cases per quote path, all against the same node so routing state and
+//! quote pricing are shared:
+//!
+//! - **Unversioned** request — the old client against an upgraded node. Must
+//!   still be served, because a node cannot tell a client that settles
+//!   correctly but predates the version field from one that does not.
+//! - **Current version** — the new client against an upgraded node. Must be
+//!   served, so the gate is invisible to clients that can pay.
+//! - **Below the minimum** — must come back `ClientUpdateRequired`, refused
+//!   *before* any quote is issued, so nothing has been committed on-chain.
+//! - **Above this node's current** — must come back `StorerUpdateRequired`.
+//!   A lagging node never reports a client fault.
+//!
+//! Both refusals are unreachable in production today (`MIN` and `CURRENT` are
+//! both the first declarable version), so they are driven here by crafting the
+//! versions directly, which is what a future settlement bump will make real.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use super::testnet::TestNetworkConfig;
+use super::TestHarness;
+use ant_node::ant_protocol::{
+    ChunkMessage, ChunkMessageBody, ChunkQuoteRequest, ChunkQuoteRequestV2, ChunkQuoteResponse,
+    MerkleCandidateQuoteRequest, MerkleCandidateQuoteRequestV2, MerkleCandidateQuoteResponse,
+    ProtocolError, CURRENT_SETTLEMENT_VERSION, MIN_SUPPORTED_SETTLEMENT_VERSION,
+};
+use ant_node::client::send_and_await_chunk_response;
+use saorsa_core::identity::PeerId;
+use saorsa_core::P2PNode;
+use serial_test::serial;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Node that answers every quote in this driver.
+const STORER_INDEX: usize = 1;
+/// Node the requests are sent from.
+const CLIENT_INDEX: usize = 3;
+/// Wire timeout for one quote round trip.
+const QUOTE_TIMEOUT: Duration = Duration::from_secs(20);
+/// Quote size used throughout; well under `MAX_CHUNK_SIZE`.
+const QUOTE_DATA_SIZE: u64 = 4096;
+
+/// Request ids, unique per request so a late response cannot be mistaken for
+/// the answer to a later one. That matters here specifically: the fallback
+/// path this gate coexists with re-asks under a *new* id.
+static NEXT_REQUEST_ID: AtomicU64 = AtomicU64::new(0x5E77_1E00);
+
+fn next_request_id() -> u64 {
+    NEXT_REQUEST_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
+/// Send one chunk message and return the single-node quote response.
+async fn single_node_quote(
+    client: &Arc<P2PNode>,
+    storer: &PeerId,
+    request_id: u64,
+    body: ChunkMessageBody,
+) -> ChunkQuoteResponse {
+    let message = ChunkMessage { request_id, body };
+    let bytes = message.encode().expect("encode quote request");
+    send_and_await_chunk_response(
+        client,
+        storer,
+        bytes,
+        request_id,
+        QUOTE_TIMEOUT,
+        &[],
+        |body| match body {
+            ChunkMessageBody::QuoteResponse(response) => Some(Ok(response)),
+            _ => None,
+        },
+        |e| format!("send single-node quote request: {e}"),
+        || "single-node quote request timed out".to_string(),
+    )
+    .await
+    .expect("single-node quote round trip")
+}
+
+/// Send one chunk message and return the merkle candidate quote response.
+async fn merkle_quote(
+    client: &Arc<P2PNode>,
+    storer: &PeerId,
+    request_id: u64,
+    body: ChunkMessageBody,
+) -> MerkleCandidateQuoteResponse {
+    let message = ChunkMessage { request_id, body };
+    let bytes = message.encode().expect("encode merkle quote request");
+    send_and_await_chunk_response(
+        client,
+        storer,
+        bytes,
+        request_id,
+        QUOTE_TIMEOUT,
+        &[],
+        |body| match body {
+            ChunkMessageBody::MerkleCandidateQuoteResponse(response) => Some(Ok(response)),
+            _ => None,
+        },
+        |e| format!("send merkle quote request: {e}"),
+        || "merkle quote request timed out".to_string(),
+    )
+    .await
+    .expect("merkle quote round trip")
+}
+
+/// A version below the minimum this node accepts. `saturating_sub` rather than
+/// `- 1` because `MIN` is a constant that a future bump moves.
+fn below_minimum_version() -> u32 {
+    MIN_SUPPORTED_SETTLEMENT_VERSION.saturating_sub(1)
+}
+
+/// A version newer than this node understands.
+fn above_current_version() -> u32 {
+    CURRENT_SETTLEMENT_VERSION.saturating_add(1)
+}
+
+#[tokio::test]
+#[serial]
+async fn settlement_version_gate_observed_on_live_network() {
+    // Route node logs to stderr so a run with
+    // `RUST_LOG=ant_node::quote::settlement=warn` shows the refusal lines an
+    // operator would have to find in production.
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .with_writer(std::io::stderr)
+        .try_init();
+
+    let harness = TestHarness::setup_with_config(TestNetworkConfig::minimal())
+        .await
+        .expect("setup settlement-gate network");
+    harness.warmup_dht().await.expect("warmup");
+
+    let client = harness.node(CLIENT_INDEX).expect("client node");
+    let storer_peer = *harness.node(STORER_INDEX).expect("storer node").peer_id();
+
+    let address = [0x51_u8; 32];
+    let merkle_address = [0x52_u8; 32];
+    let timestamp = unix_now();
+
+    // -- Old client, upgraded node. The pre-versioned request shape, which is
+    //    every client released to date, must still get a quote.
+    let legacy = single_node_quote(
+        &client,
+        &storer_peer,
+        next_request_id(),
+        ChunkMessageBody::QuoteRequest(ChunkQuoteRequest {
+            address,
+            data_size: QUOTE_DATA_SIZE,
+            data_type: 0,
+        }),
+    )
+    .await;
+    let legacy_merkle = merkle_quote(
+        &client,
+        &storer_peer,
+        next_request_id(),
+        ChunkMessageBody::MerkleCandidateQuoteRequest(MerkleCandidateQuoteRequest {
+            address: merkle_address,
+            data_type: 0,
+            data_size: QUOTE_DATA_SIZE,
+            merkle_payment_timestamp: timestamp,
+        }),
+    )
+    .await;
+
+    // -- New client, upgraded node. The case the whole fleet lands on.
+    let current = single_node_quote(
+        &client,
+        &storer_peer,
+        next_request_id(),
+        ChunkMessageBody::QuoteRequestV2(ChunkQuoteRequestV2::new(address, QUOTE_DATA_SIZE)),
+    )
+    .await;
+    let current_merkle = merkle_quote(
+        &client,
+        &storer_peer,
+        next_request_id(),
+        ChunkMessageBody::MerkleCandidateQuoteRequestV2(MerkleCandidateQuoteRequestV2::new(
+            merkle_address,
+            QUOTE_DATA_SIZE,
+            timestamp,
+        )),
+    )
+    .await;
+
+    // -- A client this node will not settle with. Refused, and refused with a
+    //    verdict about the client.
+    let mut stale = ChunkQuoteRequestV2::new(address, QUOTE_DATA_SIZE);
+    stale.settlement_version = below_minimum_version();
+    let refused = single_node_quote(
+        &client,
+        &storer_peer,
+        next_request_id(),
+        ChunkMessageBody::QuoteRequestV2(stale),
+    )
+    .await;
+
+    let mut stale_merkle =
+        MerkleCandidateQuoteRequestV2::new(merkle_address, QUOTE_DATA_SIZE, timestamp);
+    stale_merkle.settlement_version = below_minimum_version();
+    let refused_merkle = merkle_quote(
+        &client,
+        &storer_peer,
+        next_request_id(),
+        ChunkMessageBody::MerkleCandidateQuoteRequestV2(stale_merkle),
+    )
+    .await;
+
+    // -- A client newer than this node. Refused, with a verdict about the
+    //    *node*, so an up-to-date user is never told to upgrade.
+    let mut ahead = ChunkQuoteRequestV2::new(address, QUOTE_DATA_SIZE);
+    ahead.settlement_version = above_current_version();
+    let node_behind = single_node_quote(
+        &client,
+        &storer_peer,
+        next_request_id(),
+        ChunkMessageBody::QuoteRequestV2(ahead),
+    )
+    .await;
+
+    let mut ahead_merkle =
+        MerkleCandidateQuoteRequestV2::new(merkle_address, QUOTE_DATA_SIZE, timestamp);
+    ahead_merkle.settlement_version = above_current_version();
+    let node_behind_merkle = merkle_quote(
+        &client,
+        &storer_peer,
+        next_request_id(),
+        ChunkMessageBody::MerkleCandidateQuoteRequestV2(ahead_merkle),
+    )
+    .await;
+
+    println!(
+        "SETTLEMENT-GATE-RESULT min={MIN_SUPPORTED_SETTLEMENT_VERSION} \
+         current={CURRENT_SETTLEMENT_VERSION}"
+    );
+
+    assert!(
+        matches!(legacy, ChunkQuoteResponse::Success { .. }),
+        "REGRESSION: an unversioned single-node quote was not served: {legacy:?}"
+    );
+    assert!(
+        matches!(legacy_merkle, MerkleCandidateQuoteResponse::Success { .. }),
+        "REGRESSION: an unversioned merkle quote was not served: {legacy_merkle:?}"
+    );
+    assert!(
+        matches!(current, ChunkQuoteResponse::Success { .. }),
+        "REGRESSION: the gate is not invisible to a current client: {current:?}"
+    );
+    assert!(
+        matches!(current_merkle, MerkleCandidateQuoteResponse::Success { .. }),
+        "REGRESSION: the gate is not invisible to a current merkle client: {current_merkle:?}"
+    );
+
+    match refused {
+        ChunkQuoteResponse::Error(ProtocolError::ClientUpdateRequired {
+            client_settlement_version,
+            min_settlement_version,
+        }) => {
+            assert_eq!(client_settlement_version, below_minimum_version());
+            assert_eq!(min_settlement_version, MIN_SUPPORTED_SETTLEMENT_VERSION);
+        }
+        other => panic!("a stale single-node client was not refused as its own fault: {other:?}"),
+    }
+    match refused_merkle {
+        MerkleCandidateQuoteResponse::Error(ProtocolError::ClientUpdateRequired {
+            client_settlement_version,
+            min_settlement_version,
+        }) => {
+            assert_eq!(client_settlement_version, below_minimum_version());
+            assert_eq!(min_settlement_version, MIN_SUPPORTED_SETTLEMENT_VERSION);
+        }
+        other => panic!("a stale merkle client was not refused as its own fault: {other:?}"),
+    }
+    match node_behind {
+        ChunkQuoteResponse::Error(ProtocolError::StorerUpdateRequired {
+            client_settlement_version,
+            node_settlement_version,
+        }) => {
+            assert_eq!(client_settlement_version, above_current_version());
+            assert_eq!(node_settlement_version, CURRENT_SETTLEMENT_VERSION);
+        }
+        other => panic!("a lagging node blamed the client instead of itself: {other:?}"),
+    }
+    match node_behind_merkle {
+        MerkleCandidateQuoteResponse::Error(ProtocolError::StorerUpdateRequired {
+            client_settlement_version,
+            node_settlement_version,
+        }) => {
+            assert_eq!(client_settlement_version, above_current_version());
+            assert_eq!(node_settlement_version, CURRENT_SETTLEMENT_VERSION);
+        }
+        other => panic!("a lagging node blamed the merkle client instead of itself: {other:?}"),
+    }
+
+    harness.teardown().await.expect("teardown");
+}


### PR DESCRIPTION
## Linear issue

Closes V2-975 — https://linear.app/autonominetwork/issue/V2-975/refuse-to-quote-clients-that-cannot-settle-correctly-instead-of

## Risk tier

- [ ] T0 — docs / tooling / CI / pure UX-output. Repo CI only.
- [ ] T1 — client-only, no network-facing behavior change. CI + prod compat smoke.
- [ ] T2 — node/client logic with behavioral surface, no protocol/format/economics change. Dev testnet + ADR.
- [x] T3 — protocol / storage format / payments / routing. T2 evidence + adversarial testing.

New wire handling on the payment-admission path.

## What this fixes

Production nodes reject a steady trickle of merkle uploads for underpayment at an exact 3x ratio. The node is right and the client is wrong: those clients settle under the pre-ADR-0008 rule and apply no multiplier.

The problem is *when* we refuse. A merkle batch pays on-chain before any storer sees a PUT, so checking the settlement rule at PUT time checks it after the money is gone, and merkle receipts are not refundable. ADR-0008 already names this as a re-open trigger: "a rise in refused batch uploads after the boundary, indicating clients that never upgraded." That trigger has fired.

## Change

Refuse at quote time instead. No quote means no pool commitment, which means no payment, so a refused client has spent nothing.

- A client **below** `MIN_SUPPORTED_SETTLEMENT_VERSION` gets `ClientUpdateRequired` with an upgrade instruction.
- A client **above** `CURRENT_SETTLEMENT_VERSION` gets `StorerUpdateRequired`. This node is the old one; the client should use a different storer and tell its user nothing.
- **Unversioned requests are still served.** A node cannot distinguish a client that settles correctly but predates the version field (ant-core 0.5.1 through 0.6.0) from one that does not, so refusing both would break clients that are behaving. A running count is logged every 1000 per path under `ant_node::quote::settlement`, which is the evidence for flipping that later.
- **The underpayment message now carries upgrade advice**, keyed on an exact multiplier shortfall. This is the only signal that reaches clients losing money today, since a client too old to settle correctly is also too old to declare a version.

## Changes since the last review

- **Merged current `main`** (22 commits, through the unresolved-verification backoff merge). Git reported no conflicts; `main`'s only edit to a file this branch also touches is a comment and test rename in `src/storage/handler.rs`, and it does not move the quote path. Lint, docs and the library suite are clean on the merged tree.
- **Renumbered the ADR to 0013.** `main` took ADR-0010 for the beta upgrade channel decision while this branch was open and has since reached ADR-0012, so the repository's ADR governance check was failing this branch on a duplicate number. Number only; the content is unchanged. Three other open pull requests (#197, #213, #215/#216) still carry numbers `main` has taken, so whoever renumbers next should start at 0014.
- **Corrected two stale references to `ant-protocol#23`**, which was reverted in `ant-protocol#24`. The live protocol pull request is `ant-protocol#25`.
- **The unversioned-quote counter now says what it counts.** It increments when the request arrives, before validation and before a quote is generated, so a refused request is counted too, but the log line reported a running total of quotes *served*. A node turning away a thousand oversized unversioned requests would have reported serving a thousand quotes, and that number is the stated input to the decision to retire the legacy path. Arrival is the right place to count, since a client whose request failed for an unrelated reason still cannot declare a version and would still break if the path closed, so the counter and the log line are reworded to match where the increment fires rather than the increment being moved. No behavioural change.
- **Rebased onto `main`** (through the chunk GET telemetry merge). The one conflict was two additive blocks landing at the same point in `src/storage/handler.rs`; both are kept. 932 lib tests pass, `cfd` clean.
- **The gate now runs over a real connection.** New e2e driver, details under Test evidence. This closes the half of the mixed-version gate that did not need the coordinated set to land, and it is the first observation of the `ant_node::quote::settlement` log target on a running node.
- **Took the `h2` fix for RUSTSEC-2026-0258.** The advisory published on 2026-08-17, after main's last CI run, so Security Audit started failing here without anything in the branch causing it; main is affected identically. Lockfile only, and the `h2` entry alone — a plain `cargo update` re-resolves socket2 and windows-sys across quinn and hyper-util, which is QUIC-stack churn a settlement change should not carry. `cargo check --locked` accepts the result.
- **ADR-0013 gained a rollout order and a revert order**, with the signal that says each step worked. Both rows stay marked not rehearsed.

## Changes since first review

- **Bounded the range at both ends.** The first revision served any version at or above the minimum, on the reasoning that the storer verifies whatever arrives anyway. That holds only for settlement changes that *raise* what is paid, which ADR-0008 happened to be; a change to the median rule or the payable field breaks it, after the client has already settled. Corrected, and the test that pinned the old behaviour is inverted rather than deleted.
- **Split the refusal in two**, so a lagging node never reports a client fault. Collapsing them would tell up-to-date users to upgrade during exactly the window when most of the fleet is the old side.
- **Added ADR-0013** (below), including a correction: it had claimed the client's downgrade path was build-enforced, which held for one of the two fallbacks only.

## Compatibility

- Wire: additive, no `CHUNK_PROTOCOL_ID` bump. Every existing message shape is handled as before. Deployment ordering matters in one direction: **nodes before clients**, since a node on the current published `ant-protocol` cannot decode versioned requests. The client PR covers the mixed fleet with a per-peer fallback, so this is a preference rather than a hard gate.
- Storage: none.
- API: none. Both new handler methods are private.

## Semver impact

- [ ] breaking
- [x] feature
- [ ] fix

No version bump is taken in this PR; the release train owns that.

## Test evidence

`cargo test --lib` — **932 passed, 0 failed**. `cfd` (fmt + clippy with `-D clippy::panic -D clippy::unwrap_used -D clippy::expect_used -D warnings`) clean.

Gate behaviour (`storage::handler`):
- `v2_merkle_quote_is_served_at_the_current_settlement_version` — the gate is invisible to clients that can pay.
- `v2_merkle_quote_is_refused_below_the_minimum_settlement_version` — asserts the refusal type, both versions, and that the rendered message contains `ant update`.
- `v2_single_node_quote_is_refused_below_the_minimum_settlement_version` — so a refused merkle client cannot fall back to per-chunk quotes and burn money that way instead.
- `a_newer_settlement_version_is_refused_as_this_nodes_fault` — the corrected upper bound, asserting `StorerUpdateRequired` specifically.
- `unversioned_requests_are_still_served` — the decision that would break correctly-paying clients if it regressed.

Message behaviour (`payment::verifier`):
- `merkle_legacy_1x_settlement_rejected_after_the_parity_boundary` extended to assert the upgrade advice on an exact 1x settlement.
- `a_partial_shortfall_is_not_blamed_on_an_outdated_client` — a one-wei shortfall rejects without upgrade advice, so the advice keeps meaning something.

### The gate over a real connection

`settlement_version_gate_observed_on_live_network` (`tests/e2e/settlement_version_gate.rs`) spawns a devnet from **this branch** and puts all four cases on real QUIC between two nodes, on both quote paths:

| Request | Result |
|---|---|
| Unversioned — the shape every released client sends | Served |
| Declaring `CURRENT` | Served |
| Declaring below `MIN` | `ClientUpdateRequired`, no quote issued |
| Declaring above `CURRENT` | `StorerUpdateRequired`, no quote issued |

That promotes **old client against an upgraded node** and the **structured refusal against a real peer**, both previously unit-level only, to observed. Run with `RUST_LOG=ant_node::quote::settlement=warn` it also prints the refusal lines as a running node emits them:

```text
WARN ant_node::quote::settlement: Refusing single_node quote: client settlement version 0
  is below the minimum 1. No quote issued, so the client has not been charged.
WARN ant_node::quote::settlement: Refusing merkle quote: client settles under version 2,
  newer than this node's 1. This node needs upgrading; the client has not been charged.
```

### Mixed-version validation

No longer outstanding for the direction that could be tested. `ant-client`'s merkle E2E spawns a 35-node testnet from the **published** `ant-node`, so it is a live new-client-against-old-fleet run: every node logs a decode failure for each versioned probe and answers only the unversioned retry.

It passed functionally and **failed on cost**, which is what makes it worth having run: the suite went from a 24–38 minute baseline on `main` to exceeding the 60-minute CI cap with 4 of 7 tests done. A peer that cannot decode never answers, so the client waited a full quote timeout before falling back, on every request rather than once per peer. Two bounds on the client PR fix it. Full write-up in ADR-0013.

**Still outstanding:** the reverse direction, old client against an upgraded node, and a genuinely mixed fleet. Both need a testnet built from this branch's `ant-node`, which does not exist until the coordinated set lands.

### CI

**All 15 checks green** on the current head, `Test (windows-latest)` included.

That job failed on an earlier head, in testnet **setup** ("Failed to create dual-stack network nodes") rather than on an assertion, and the same job fails on `main` in both of its recent failing runs. It passes here on re-run, which settles it as the known hosted-runner flake rather than anything in this change.

## New dependency

None added. One transitive lockfile bump, `h2` 0.4.15 to 0.4.16, for the advisory above. `ant-protocol` is temporarily repointed at the review branch for WithAutonomi/ant-protocol#23, and reverts to a published version pin once that merges and the release train publishes it. **That repin is a merge-order dependency, not something this PR can take**: publishing is the train's step, and per repo policy a feature PR does not bump or name crate versions.

## ADR

**ADR-0013: Settlement version and pre-payment compatibility** (Proposed) — added on this branch in response to review.

https://github.com/grumbach/ant-node/blob/settlement-version-quote-gate/docs/adr/ADR-0013-settlement-version-and-pre-payment-compatibility.md

Records the inclusive `MIN..=CURRENT` range and why the upper bound is load-bearing, the two refusal directions and why they must stay distinct during a client-first rollout, the unversioned retry as a bounded downgrade path with a shared compile-time cutover guard, the rule that a refusal must not depend on which peers answered first, and the residual that merkle storers are not exactly the peers a client quotes.

Builds on ADR-0008, whose re-open trigger is what fired here.

## Release readiness: NOT production ready

Merging puts this in the next release, so the bar is fleet-ready rather than code-complete. CI being green is evidence for the code gate only. **Do not merge while any row below is open.**

| Gate | Status | What closes it |
|---|---|---|
| Code / CI | **Proven.** 15/15 green, 931 lib tests, three Codex xhigh rounds adjudicated | — |
| Dependency | **Open**, and the only code-level blocker left. `Cargo.toml` pins a mutable personal-fork branch | ant-protocol #23 merged, then repin to upstream. The registry repin waits on the train, since publishing needs a tag and a version bump a feature PR cannot take |
| Mixed-version | **Partial.** New-client/old-fleet proven by the client suite. Old-client/new-node, new-client/new-node and both refusal directions now run over a real connection on a devnet built from this branch | A fleet running both node versions at once, which needs a deployment rather than a devnet |
| Deployment ordering | **Planned, not rehearsed.** ADR-0013 now carries the order, the three steps and the signal that says each one worked | Node deployment preceding the client release, observed |
| Observability | **Open**, narrowed. The refusal lines are now seen emitting from a running node. The unversioned-quote counter is the signal that retires the legacy path, and at one line per 1000 requests it cannot fire below production volumes, let alone have been read there | Confirm that line appears and is queryable on a production node |
| NAT / canary | **Open.** No canary. Relayed and NAT'd peers are the slow paths this change adds work to | A canary run with the counter and quote latency observed |
| Rollback | **Planned, not rehearsed.** ADR-0013 states the revert order — clients first, then nodes, deliberately not the reverse of the rollout — and what it costs | Rehearsing it |
| Fleet safety | **Open.** The corroboration quorum and client-wide latch have never met a real fleet | Canary evidence that no honest upload is halted |

### What is genuinely low risk today

The gate is **inert on arrival**. `MIN_SUPPORTED_SETTLEMENT_VERSION` and `CURRENT_SETTLEMENT_VERSION` are both the first declarable version, so no client in existence can be refused for being too old and no node can be refused for being behind. The refusal machinery, the corroboration quorum and the latch cannot fire until a future settlement bump.

That is a reason the *risk* is low. It is not evidence the gates are closed, and it does not make the set fleet-ready.

## Mitigation / rollback

Revert. `MIN_SUPPORTED_SETTLEMENT_VERSION` equals the first version any client can declare, so no client in existence can trip the lower gate, and no node has a lower `CURRENT`, so none can trip the upper one. The change is inert on arrival and becomes load-bearing at the next settlement bump. The underpayment message change is text only.







