### PR TITLE
fix(replication): stop a write-blocked node probing its close group

### DIFF
--- a/docs/adr/ADR-0011-capacity-gated-source-discovery.md
+++ b/docs/adr/ADR-0011-capacity-gated-source-discovery.md
@@ -174,6 +174,16 @@ set.
   one of those is not suppressed. The default 500 MiB reserve normally makes the node
   refuse chunks well before literal ENOSPC, which is why this predicate covers the
   observed condition — but it is narrower than the name suggests.
+- The verdict restates the pre-check's predicate rather than sharing its code, so the two
+  can drift apart. That is not hypothetical. ant-node #210 makes the pre-check two-part —
+  below the reserve *and* out of reusable pages inside the store, since LMDB returns a
+  deleted record's pages to its own free list and never to the filesystem. Left
+  unreconciled, a heavily pruned node would read as `Full` here while its own dial
+  pre-check admits the write, standing its keys down for five minutes at a time instead
+  of looking for chunks it could store. That is under-replication, which is worse than
+  the probe traffic this gate exists to remove, so the coupling is held by a test rather
+  than by a comment: `capacity_verdict_refuses_exactly_when_check_capacity_does` fails in
+  exactly that state.
 - The second gate is now covered by a test rather than by inspection. Hosting the chunk
   on every other node clears the four-of-seven quorum threshold, and leaving it out of
   the target's paid list forces the network branch. Cutting the capacity-specific
@@ -196,6 +206,13 @@ set.
 - Unit: the existing `apply_fetch_result` cases still hold with `LocalWriteFailed` back
   to its upstream shape — no alternate source is conscripted, and the no-metadata path
   stays terminal.
+- Unit: `capacity_verdict_refuses_exactly_when_check_capacity_does` holds the gate's
+  verdict and the dial's pre-check to one predicate. It is built on a store that has
+  deleted more than one chunk's worth of pages rather than on a bare full disk, because
+  that is the state the two predicates are about to part company over; on a bare full
+  disk they still agree, so a test built on one would pass straight through the
+  divergence. Applying #210's predicate to the pre-check fails this test and nothing
+  else in the 934-test suite.
 - E2E: `write_blocked_node_neither_probes_nor_dials` runs all three phases on one
   network — no dial, then no probe — seeding two nodes identically through the local
   paid-list path so they differ only in whether storage accepts writes. Probes are
@@ -228,7 +245,9 @@ set.
   the plan's 60-minute allowance. Flat *near zero* is the wrong expectation either way:
   unauthorized keys still run their quorum round by design.
 - Review trigger: if `PENDING_VERIFY_MAX_AGE`, the neighbour-sync cadence, or
-  `MAX_PENDING_VERIFY` change, revisit the 5-minute constant.
+  `MAX_PENDING_VERIFY` change, revisit the 5-minute constant. If what
+  `LmdbStorage::check_capacity` refuses on changes, carry the change into
+  `capacity_verdict` in the same commit.
 
 ## Notes for AI-assisted work
 

--- a/docs/adr/ADR-0011-capacity-gated-source-discovery.md
+++ b/docs/adr/ADR-0011-capacity-gated-source-discovery.md
@@ -1,0 +1,237 @@
+# ADR-0011: Capacity-gated source discovery in the replication verification cycle
+
+- **Status:** Proposed
+- **Date:** 2026-08-18
+- **Decision owners:** Anselme
+- **Reviewers:** <pending>
+- **Supersedes:** none
+- **Superseded by:** none
+- **Related:** ADR-0003 (full-node detection and eviction — decides how *other* nodes treat a full peer; this decides what the full peer itself stops doing); ADR-0005 (replication repair hardening — owns the verification/fetch pipeline this changes). V2-1009 is the issue, V2-963 / PR #202 added the pre-check this builds on, V2-987 is the testnet run that measured the cost.
+
+## Context
+
+PR #202 stopped a node that cannot write from *pulling* chunks: `execute_single_fetch`
+runs `check_capacity()` before it dials, and a local write failure is classified as
+`LocalWriteFailed` so no alternate holder is conscripted. That removed 93.9% of
+replication egress on a local testnet with a quarter of the nodes capacity-blocked.
+
+It did not remove the round that *precedes* the dial. A node that cannot write still
+holds none of the keys it owes, so none of them terminate. Each one is selected by the
+verification cycle, probed against its close group for a holder, promoted, refused by
+the capacity pre-check, and requeued at `VERIFICATION_REQUEST_TIMEOUT`. At 15 seconds
+that is up to 120 close-group probes per entry lifetime, for every key the node owes —
+nominally, since the 15 seconds is a requested delay and cycle polling, round duration
+and bounded per-cycle selection all stretch it. The owed set grows with the network
+rather than with anything the node can do about it.
+
+The testnet run on V2-987 measured it at scale: 195 services with 50 (25.6%) held
+storage-full produced **99.6% of every `verification_request_tx_bytes` on the network**
+from that quarter of the fleet. Freeing half the full VMs collapsed their
+verification-request traffic 87% within 28 minutes while the untouched half moved
++9.5%, which is what attributes the traffic to the storage-full condition rather than
+to the fetch guard.
+
+The absolute volume in that run was small. The reason to act is the scaling: the
+per-node cost is `owed_keys x close_group x 32 B` per round, `MAX_PENDING_VERIFY` is
+131,072 keys, and every probe costs a close-group neighbour an LMDB presence lookup on
+its serial replication message path.
+
+## Decision Drivers
+
+- A node that cannot write should stop *repeating* work that cannot succeed. Re-probing
+  for a key it has already authorized and still cannot store buys nothing, and its
+  neighbours pay a presence lookup for each attempt.
+- Suppressing work must not suppress duties that do not need a local write. A full node
+  must keep learning which keys it owes were paid for, and must keep retiring keys it
+  already holds or is no longer admitted for, or it stalls its own bootstrap drain and
+  keeps its audits disabled.
+- Recovery should stay prompt. Capacity comes back — an operator resizes a volume, a
+  prune pass frees space — and the node should notice while the duty is still live. That
+  is the objective, not a guarantee: see the trade-offs below for when it is missed.
+- No wire or storage change, and no public API change in a default build. This rides the
+  release train into a mixed fleet, and an upgraded node must stay wire-compatible with
+  old peers — which it does, since no peer-side behaviour depends on receiving the
+  requests it stops sending.
+
+## Considered Options
+
+1. **Gate on hint provenance at the top of the cycle.** Drop every key whose hint
+   carried a possession claim before the cycle does anything else.
+2. **Gate the two steps that exist to enable a fetch**, after authorization and after
+   the terminal checks: the presence probe that discovers holders, and the promotion
+   that queues the download.
+3. **Leave the cycle alone and only lengthen the requeue delay** after a refused fetch.
+4. **Do nothing.** The measured volume was ~6 KB/s per full node.
+
+## Decision
+
+We will take option 2: gate source discovery, not the cycle.
+
+`run_verification_cycle` reads the storage capacity verdict once and uses it in exactly
+two places — before the local paid-list presence probe, and before promotion on the
+network-verified path. Everything else runs unchanged on a full node: the local
+paid-list fast path, `PaidForList` convergence through the quorum round, and the
+terminal checks that retire a key the node already holds or is no longer admitted for.
+
+Held keys are deferred by `CAPACITY_BLOCKED_RETRY` (5 minutes) through the existing
+`defer_pending`, and deliberately nothing more: an earlier revision also clamped the deferral to
+half the entry's remaining life, gave the deferred key fairness-eviction protection, and
+carried a capacity verdict through `FetchResult` so a refused fetch took the same long
+backoff. All three were cut on review.
+
+The clamp existed so an aged entry could not be retired without one last look. It cost a
+logarithmic burst of looks near expiry, and — where the paid-list insert had failed —
+those looks become *ungated* quorum rounds, working against the thing this ADR is for.
+Without it, a key deferred inside the last five minutes of its life expires without a
+final look and is re-acquired from the next neighbour-sync hint, which is what the
+30-minute TTL already implies.
+
+The eviction protection preserved a duty the node cannot discharge, letting a full node
+hoard pending entries against the 131,072-entry ceiling. Losing one to fairness
+reclamation is the better outcome, and it returns on the next hint.
+
+The `FetchResult` propagation duplicated the gate. After a refused fetch the key returns
+to pending and the gate at the head of the next cycle defers it for minutes anyway, so
+the machinery bought one 15-second round on a race the gate already makes rare.
+
+Only a **full** disk drives the gate. `check_capacity()` answers `Err` both for
+insufficient space and for a space query that itself failed, and neither the second nor a
+failed resize, write transaction or commit is a standing condition. A three-way
+`CapacityVerdict` separates `Full` from `Unknown`, and the gate reads only `Full`. The
+fetch path is left alone entirely: a refused fetch returns `LocalWriteFailed` and requeues
+on the ordinary schedule, because the gate at the head of the next cycle re-decides.
+
+Option 1 was implemented first and rejected in review: `HintPipeline` records only
+whether an advertiser claimed possession, so gating on it skips `PaidForList`
+convergence for keys that arrive as replica hints, strands keys that should have
+retired, and can be flipped by any routing-table peer adding a false possession claim to
+a paid-only key. Option 3 leaves the dominant cost in place, because the probe is paid
+before the fetch is ever attempted. Option 4 ignores that the cost scales with the owed
+set.
+
+## Consequences
+
+### Positive
+
+- The loop this targets goes away: a key the node has **already authorized** and cannot
+  store is no longer re-probed on every cycle it comes back on, for the rest of its
+  entry's life. That is the loop that scales with the owed set. (The 15 s request timeout
+  is the requested eligibility, not the achieved cadence — poll latency, round duration
+  and bounded per-cycle selection all stretch it.)
+
+  **How much of V2-987's 99.6% that removes is a hypothesis, not a measurement.**
+  `verification_request_tx_bytes` aggregates both branches — the gated local-paid
+  presence round and the ungated network-authorization round — so the run never
+  established which dominated. The mechanism favours the gated branch: `PaidForList` is
+  persistent LMDB, `PaidNotify` inserts into it across the 20-wide paid group with no
+  storage requirement, a successful quorum inserts before the second gate, and definitive
+  quorum failure removes the key rather than retrying. So an owed key should reach the
+  gated branch and stay there. Against that, real ENOSPC can fail the paid-list insert
+  itself, and `QuorumInconclusive` keeps the old cadence entirely. A reasoned estimate is
+  80–90% of the cohort's verification bytes; treat it as a prediction the testnet run is
+  there to test.
+- What remains is purposeful but not free. A key the node has **not** yet authorized
+  still runs its quorum round, because that is how `PaidForList` converges, and its close
+  group still pays a presence lookup for it. If that round comes back
+  `QuorumInconclusive` — partial reachability, too few replies to succeed or fail fast —
+  it is deferred by the request timeout and tried again, so an unauthorized key under a
+  degraded close group can still re-probe on the old cadence until it authorizes, fails
+  definitively, or ages out. Traffic from a full node therefore falls to a convergence
+  floor whose height depends on reachability, not to zero.
+- For an authorized key that stays blocked, the probe count drops from roughly 120 to
+  **zero**: the gate stops the round before it is sent. What the five-minute cadence
+  schedules are *looks* — cheap local capacity checks — not probes. A probe happens only
+  if capacity has returned by the time a look runs, which is the point.
+- A transient LMDB error keeps the ordinary retry schedule rather than inheriting the
+  capacity backoff. That is a property this change has to *preserve* rather than one it
+  introduces — the pre-change path already requeued on the request timeout — and it is
+  why the fetch path keeps the ordinary schedule rather than inheriting the gate's.
+
+### Negative / Trade-offs
+
+- The deferral is flat, so an aged entry is looked at no more often than a young one, and
+  a key deferred inside the last five minutes of its entry's life expires without a
+  further look. It returns on the next neighbour-sync hint; this is the trade for not
+  carrying a clamp whose tail looks can themselves become ungated quorum rounds.
+- Recovery after capacity frees is slower, and five minutes is the *requested* deferral
+  rather than a bound. The actual delay adds worker poll latency, cycle runtime, bounded
+  per-cycle selection under backlog, and a capacity verdict read once per cycle. Under a
+  deep backlog those can push a given key's next look well past five minutes, so the
+  figure belongs in a design discussion and not in a fleet acceptance threshold. What is
+  bounded is the entry lifetime: past stale eviction at 30 minutes, re-acquisition
+  depends on a fresh neighbour-sync hint.
+- `CAPACITY_BLOCKED_RETRY` is a constant, not a `ReplicationConfig` field. The struct is
+  publicly re-exported and is not `#[non_exhaustive]`, so a new field would be a
+  semver-visible break for a knob nothing needs to tune at runtime. The cost is that
+  operators cannot retune it without a release.
+- Each gate is pinned independently. Disabling the promotion gate alone leaves the first
+  gate passing and fails only the promotion phase, with the key requeued on the 15 s
+  schedule instead of the capacity backoff; disabling both fails the probe count first.
+  Neither can be removed without a test catching it.
+- `CapacityVerdict::Full` means "available space is below the configured reserve", not
+  "storage cannot write". A persistent LMDB transaction, commit, resize or permission
+  error with filesystem headroom still reads `Writable`, so an equivalent loop caused by
+  one of those is not suppressed. The default 500 MiB reserve normally makes the node
+  refuse chunks well before literal ENOSPC, which is why this predicate covers the
+  observed condition — but it is narrower than the name suggests.
+- The second gate is now covered by a test rather than by inspection. Hosting the chunk
+  on every other node clears the four-of-seven quorum threshold, and leaving it out of
+  the target's paid list forces the network branch. Cutting the capacity-specific
+  `FetchResult` backoff is what made this observable: a refused fetch now requeues on the
+  ordinary 15 s schedule, so the deferral delay separates "held before promotion" from
+  "promoted, then refused".
+
+### Neutral / Operational
+
+- `capacity_deferred_probe` and `capacity_deferred_promote` are reported on the existing
+  per-cycle verification summary, so each gate is visible in fleet logs without a new
+  instrumentation path.
+- No wire or storage change, and no public API change in a default build; under
+  `test-utils` four additive test-only items appear. An upgraded node is quieter where an
+  old one probed, and no peer-side heuristic consumes the absence of unsolicited
+  verification requests.
+
+## Validation
+
+- Unit: the existing `apply_fetch_result` cases still hold with `LocalWriteFailed` back
+  to its upstream shape — no alternate source is conscripted, and the no-metadata path
+  stays terminal.
+- E2E: `write_blocked_node_neither_probes_nor_dials` runs all three phases on one
+  network — no dial, then no probe — seeding two nodes identically through the local
+  paid-list path so they differ only in whether storage accepts writes. Probes are
+  counted per key at the *sending* side, on the wire call itself, so the assertion is a
+  measurement rather than an inference and a responder shedding a request cannot turn a
+  probe that happened into a zero: `blocked_probes=0` against `control_probes=7`, and
+  neutralising the gates turns the blocked count into 7 and fails the test. The control
+  also completes its acquisition, so a cycle that never reached the probe cannot read as
+  a pass.
+- **The measurement that settles the branch question, and its limit.** The per-cycle
+  verification summary counts each gate separately, `capacity_deferred_probe=` against
+  `capacity_deferred_promote=`, so sampling those on a storage-full node for an hour
+  establishes which branch its gated keys are taking. They have to be separate counts:
+  `local_paid_probe=` counts probes actually sent, so it reads zero on a full node once
+  the first gate fires, and a single combined deferral count could not be split back
+  apart. The line is `debug!` unless the cycle is slow, so it wants debug logging on a
+  canary. What it does **not** give is the byte share: the two
+  branches fan out differently (the presence probe to the close group, the quorum round to
+  the union of quorum and paid targets, which is up to 20 wide) and the network round also
+  carries `paid_list_check_indices`, so equal key counts do not mean equal bytes. Settling
+  the byte fraction needs per-branch encoded-byte accounting or a straight A/B, which is
+  what the testnet run is for.
+- Fleet: this is the T2 evidence that is *not* in the PR and has to be run. On a repeat
+  of the V2-987 topology, the full cohort's **per-hour delta** of
+  `verification_request_tx_bytes` should settle instead of climbing with the owed set —
+  the counter itself is cumulative and will keep rising, so the criterion is its growth
+  rate, not its value. On V2-987 that delta went 1.06 → 1.77 → 2.53 GB across three
+  hours; settling is the result to look for. `key_absent` audit rates and download
+  success should be unchanged, and freed nodes should still resume acquisition inside
+  the plan's 60-minute allowance. Flat *near zero* is the wrong expectation either way:
+  unauthorized keys still run their quorum round by design.
+- Review trigger: if `PENDING_VERIFY_MAX_AGE`, the neighbour-sync cadence, or
+  `MAX_PENDING_VERIFY` change, revisit the 5-minute constant.
+
+## Notes for AI-assisted work
+
+AI tools may help draft this ADR, but **must not mark it Accepted without human review**.
+Accepted ADRs are immutable: create a new superseding ADR rather than editing an
+Accepted ADR.

--- a/src/replication/config.rs
+++ b/src/replication/config.rs
@@ -626,6 +626,45 @@ const PENDING_VERIFY_MAX_AGE_SECS: u64 = 30 * 60;
 /// Maximum age for pending-verification entries before stale eviction.
 pub const PENDING_VERIFY_MAX_AGE: Duration = Duration::from_secs(PENDING_VERIFY_MAX_AGE_SECS);
 
+/// How long a key waits for another look once this node's disk is **full**.
+///
+/// Only a full disk, not any refused write: a space query that fails says
+/// nothing about available space and keeps the ordinary retry schedule.
+///
+/// A node that cannot write cannot finish an acquisition, so before this gate
+/// the key came straight back. At [`VERIFICATION_REQUEST_TIMEOUT`] that was a
+/// close-group probe as often as every 15 s for every key the node owes — the
+/// requested delay, so cycle polling, round duration and bounded per-cycle
+/// selection make it an upper rate rather than an observed cadence. The owed set
+/// grows with the network rather than with anything this node does — 25.6% of a
+/// 195-service testnet, held full, produced 99.6% of every verification-request
+/// byte on the network (V2-987).
+///
+/// What this schedules is a *look*: the cycle re-reads local capacity and only
+/// probes if space has returned. A key that stays full and authorized sends no
+/// probes at all, because the gate stops the round before it is sent.
+///
+/// Five minutes is chosen against [`PENDING_VERIFY_MAX_AGE`], which it is well
+/// inside. That is not a guarantee that freed space is noticed while the entry
+/// lives: one deferred inside its final five minutes expires first, and a
+/// backlog can delay selection further.
+///
+/// This is deliberately a constant rather than a [`ReplicationConfig`] field.
+/// The struct is publicly re-exported and is not `#[non_exhaustive]`, so a new
+/// field would break downstream exhaustive construction for a knob nothing
+/// needs to tune at runtime.
+///
+/// Applied flat, through the ordinary `defer_pending`. A key deferred inside the
+/// last five minutes of its entry's life therefore expires at
+/// [`PENDING_VERIFY_MAX_AGE`] without a further look and comes back on the next
+/// neighbour-sync hint. An earlier revision clamped the delay to half the
+/// entry's remaining life to avoid that; it was cut because the extra looks it
+/// bought near expiry can themselves become ungated quorum rounds.
+const CAPACITY_BLOCKED_RETRY_SECS: u64 = 5 * 60;
+/// How long a key waits for another look once this node's disk is full.
+pub(crate) const CAPACITY_BLOCKED_RETRY: Duration =
+    Duration::from_secs(CAPACITY_BLOCKED_RETRY_SECS);
+
 /// Trust event weight for confirmed audit failures.
 pub const AUDIT_FAILURE_TRUST_WEIGHT: f64 = 5.0;
 
@@ -1801,6 +1840,30 @@ mod tests {
         assert!(
             saw_different,
             "audit intervals should exhibit randomized jitter across samples"
+        );
+    }
+
+    /// The capacity stand-down has to be an order of magnitude above the retry
+    /// it replaces and still below the life of the entry it defers.
+    ///
+    /// A stand-down only a little above the request timeout would leave the
+    /// repeat cost the same order as before, which is the cost this change
+    /// exists to remove. At or past `PENDING_VERIFY_MAX_AGE` every deferral
+    /// would instead become an eviction, which is a different design with
+    /// different failure modes: the key would only return on a fresh
+    /// neighbour-sync hint rather than on its own schedule.
+    ///
+    /// What this does not show: that either gate uses the constant. It pins the
+    /// policy the constant encodes; the e2e proves the gates.
+    #[test]
+    fn capacity_blocked_retry_is_an_order_above_the_request_timeout_and_below_the_entry_lifetime() {
+        assert!(
+            CAPACITY_BLOCKED_RETRY >= VERIFICATION_REQUEST_TIMEOUT * 10,
+            "a stand-down near the request timeout leaves the repeat cost unchanged in order"
+        );
+        assert!(
+            CAPACITY_BLOCKED_RETRY < PENDING_VERIFY_MAX_AGE,
+            "a deferral at or past the entry lifetime is an eviction, not a deferral"
         );
     }
 }

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -97,7 +97,7 @@ use crate::replication::types::{
     NeighborSyncState, PeerSyncRecord, PresenceEvidence, RepairProofs, VerificationEntry,
     VerificationState,
 };
-use crate::storage::LmdbStorage;
+use crate::storage::{CapacityVerdict, LmdbStorage};
 use saorsa_core::identity::{NodeIdentity, PeerId};
 use saorsa_core::{DhtNetworkEvent, P2PEvent, P2PNode, TrustEvent};
 use saorsa_pqc::api::sig::{MlDsaSecretKey, MlDsaVariant};
@@ -2147,6 +2147,42 @@ impl ReplicationEngine {
     #[cfg(any(test, feature = "test-utils"))]
     pub async fn fetch_pipeline_contains_for_test(&self, key: &XorName) -> bool {
         self.queues.read().await.contains_key(key)
+    }
+
+    /// Test-only: place `key` into pending verification as though `hinter` had
+    /// just advertised it with a replica hint. Returns whether it was admitted.
+    ///
+    /// Enters the pipeline one stage earlier than
+    /// [`Self::enqueue_fetch_for_test`], so what the verification cycle itself
+    /// decides about the key is observable.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub async fn enqueue_pending_verify_for_test(&self, key: XorName, hinter: PeerId) -> bool {
+        let now = Instant::now();
+        let entry = VerificationEntry {
+            state: VerificationState::PendingVerify,
+            verified_sources: Vec::new(),
+            tried_sources: HashSet::new(),
+            created_at: now,
+            next_verify_at: now,
+            hint_sources: HashSet::from([hinter]),
+            replica_hint_sources: HashSet::from([hinter]),
+        };
+        self.queues
+            .write()
+            .await
+            .add_pending_verify(key, entry)
+            .admitted()
+    }
+
+    /// Test-only: how far ahead `key`'s next verification round is scheduled,
+    /// or `None` when the key is not pending verification.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub async fn pending_verify_delay_for_test(&self, key: &XorName) -> Option<Duration> {
+        self.queues.read().await.get_pending(key).map(|entry| {
+            entry
+                .next_verify_at
+                .saturating_duration_since(Instant::now())
+        })
     }
 
     /// Start all background tasks.
@@ -6546,6 +6582,99 @@ async fn handle_neighbor_sync_request(
     Ok(())
 }
 
+/// Test-only record of who *sent* a verification request covering a watched key.
+///
+/// The capacity gate's entire effect is a request that is never sent, and a
+/// request that was not sent leaves no production counter anywhere — not on the
+/// sender, whose traffic counters are process-global and so cannot separate one
+/// node of a single-process testnet from another, and not on the responder,
+/// which simply never hears from it. Recording who asked is what lets a test
+/// tell "held the key back" apart from "probed the close group, was refused at
+/// the dial, and then held the key back", which are otherwise identical from the
+/// queue's point of view.
+///
+/// Arming replaces the previous watch, so the outer map holds exactly the keys
+/// the current test named, and each inner map holds at most one entry per node
+/// in the process. Nothing is recorded until a test arms it, and the armed path
+/// costs one read lock on the sending side.
+///
+/// Counting is per key because a node that cannot write legitimately keeps
+/// sending verification requests for keys it has not yet authorized — that is
+/// `PaidForList` convergence, which the gate leaves alone — so a per-peer total
+/// would assert something untrue.
+///
+/// It counts *send attempts*, deliberately, recorded immediately before the wire
+/// call. A responder sheds requests at admission and as stale, so a
+/// receiver-side count would report zero for probes that were really sent, and
+/// an assertion that this node asked nobody would pass on the strength of the
+/// receiver dropping the question. It is not proof of delivery: a send that
+/// fails immediately, with no route or during shutdown, is still counted.
+///
+/// `OnceLock` rather than `LazyLock`, which needs a newer Rust than this crate's
+/// MSRV.
+#[cfg(any(test, feature = "test-utils"))]
+type VerificationWatch = HashMap<XorName, HashMap<PeerId, usize>>;
+
+#[cfg(any(test, feature = "test-utils"))]
+static VERIFICATION_WATCH: std::sync::OnceLock<std::sync::RwLock<VerificationWatch>> =
+    std::sync::OnceLock::new();
+
+#[cfg(any(test, feature = "test-utils"))]
+fn verification_watch() -> &'static std::sync::RwLock<VerificationWatch> {
+    VERIFICATION_WATCH.get_or_init(|| std::sync::RwLock::new(HashMap::new()))
+}
+
+/// Test-only: start counting verification requests for `keys`, from zero.
+///
+/// Replaces any previous watch rather than adding to it, so the map is bounded
+/// by the keys of the test that armed it last and nothing accumulates across a
+/// process running many tests.
+#[cfg(any(test, feature = "test-utils"))]
+pub fn watch_verification_requests_for_test(keys: &[XorName]) {
+    if let Ok(mut watch) = verification_watch().write() {
+        watch.clear();
+        for key in keys {
+            watch.insert(*key, HashMap::new());
+        }
+    }
+}
+
+/// Record that `requester` sent a verification request covering `keys`, for
+/// whichever of them are watched. A poisoned lock is ignored rather than
+/// propagated: this is observation for tests and must never change behaviour.
+#[cfg(any(test, feature = "test-utils"))]
+pub(crate) fn record_verification_request_sent(requester: &PeerId, keys: &[XorName]) {
+    // Fast path under a read lock: with nothing watched — every production
+    // build, and every test that did not ask — this is all the sender pays.
+    match verification_watch().read() {
+        Ok(watch) if watch.is_empty() => return,
+        Ok(watch) if !keys.iter().any(|key| watch.contains_key(key)) => return,
+        Ok(_) => {}
+        Err(_) => return,
+    }
+    if let Ok(mut watch) = verification_watch().write() {
+        for key in keys {
+            if let Some(by_peer) = watch.get_mut(key) {
+                *by_peer.entry(*requester).or_insert(0) += 1;
+            }
+        }
+    }
+}
+
+/// Test-only: how many times `requester` has asked this process about `key`.
+/// Zero unless the key was registered with `watch_verification_requests_for_test`.
+#[cfg(any(test, feature = "test-utils"))]
+#[must_use]
+pub fn verification_requests_for_key_from_for_test(requester: &PeerId, key: &XorName) -> usize {
+    verification_watch().read().map_or(0, |watch| {
+        watch
+            .get(key)
+            .and_then(|by_peer| by_peer.get(requester))
+            .copied()
+            .unwrap_or(0)
+    })
+}
+
 async fn handle_verification_request(
     source: &PeerId,
     request: &protocol::VerificationRequest,
@@ -7752,6 +7881,30 @@ async fn run_verification_cycle(ctx: VerificationCycleContext<'_>) {
     }
     let initial_pending_count = pending_keys.len();
 
+    // Capacity verdict for this cycle — the same pre-check the PUT handler and
+    // the fresh-offer path already run (V2-411), read once and reused below.
+    //
+    // It gates only the two steps that exist to enable a fetch: the presence
+    // probe that discovers holders, and the promotion that queues the download.
+    // Everything a cycle does that does not need a local write still runs on a
+    // full node — the local paid-list fast path, `PaidForList` convergence
+    // through the quorum round, and the terminal checks that retire a key this
+    // node already holds or is no longer admitted for. Gating earlier than this
+    // would stop a full node learning which of its keys were paid for, and
+    // would strand keys that should have retired, which keeps bootstrap drain
+    // pending and audits disabled until stale eviction.
+    // Only a *full* disk is a standing condition worth minutes of backoff. A
+    // failed `statvfs` says nothing about available space and may have cleared
+    // by the next cycle, so it is treated as writable here and left to the
+    // pre-check at the dial, which queries again and may well permit the write.
+    let write_blocked = storage.capacity_verdict() == CapacityVerdict::Full;
+    // Counted per gate rather than combined. `local_paid_probe` below counts
+    // probes actually sent, so it reads zero once the first gate fires; keeping
+    // the two deferral counts apart is what lets an operator see which branch a
+    // full node's keys are taking without adding a code path to find out.
+    let mut capacity_deferred_probe = 0usize;
+    let mut capacity_deferred_promote = 0usize;
+
     let self_id = *p2p_node.peer_id();
 
     // Step 1: Check local PaidForList for fast-path authorization (Section 9,
@@ -7800,6 +7953,21 @@ async fn run_verification_cycle(ctx: VerificationCycleContext<'_>) {
             for key in terminal_paid {
                 q.remove_pending(&key);
                 terminal_keys.push(key);
+            }
+        }
+
+        // Capacity gate, first of two. Everything above this point has already
+        // run: authorization succeeded via the local `PaidForList` hit, and the
+        // keys that should retire (already held, or no longer storage-admitted)
+        // have retired. What is left is a probe whose only purpose is finding a
+        // holder to download from, and this node cannot write what it would
+        // download.
+        if write_blocked && !local_paid_presence_probe_keys.is_empty() {
+            let mut q = queues.write().await;
+            for key in std::mem::take(&mut local_paid_presence_probe_keys) {
+                if q.defer_pending(&key, config::CAPACITY_BLOCKED_RETRY) {
+                    capacity_deferred_probe += 1;
+                }
             }
         }
     }
@@ -8023,7 +8191,16 @@ async fn run_verification_cycle(ctx: VerificationCycleContext<'_>) {
                     let mut fetch_sources = sources;
                     add_replica_hint_sources(&mut fetch_sources, &replica_hint_sources);
                     let fetch_eligible = fetch_allowed_keys.contains(&key);
-                    if fetch_eligible && !fetch_sources.is_empty() {
+                    if fetch_eligible && write_blocked {
+                        // Capacity gate, second of two, and deliberately after
+                        // Step 4: the key is now recorded in `PaidForList` and
+                        // its verification stands. Only the download is held,
+                        // because `execute_single_fetch` would refuse it and
+                        // hand the key straight back here.
+                        if q.defer_pending(&key, config::CAPACITY_BLOCKED_RETRY) {
+                            capacity_deferred_promote += 1;
+                        }
+                    } else if fetch_eligible && !fetch_sources.is_empty() {
                         let distance =
                             crate::client::xor_distance(&key, p2p_node.peer_id().as_bytes());
                         // Atomic remove+enqueue: on fetch_queue capacity miss
@@ -8098,12 +8275,12 @@ async fn run_verification_cycle(ctx: VerificationCycleContext<'_>) {
     if elapsed_ms >= VERIFICATION_CYCLE_SLOW_LOG_MS {
         info!(
             target: "ant_node::replication::verification",
-            "Slow replication verification cycle: pending_start={initial_pending_count}, local_paid_probe={local_paid_probe_count}, network_verify={keys_needing_network_count}, terminal={terminal_key_count}, pending_after={pending_after}, fetch_after={fetch_after}, in_flight_after={in_flight_after}, elapsed_ms={elapsed_ms}",
+            "Slow replication verification cycle: pending_start={initial_pending_count}, capacity_deferred_probe={capacity_deferred_probe}, capacity_deferred_promote={capacity_deferred_promote}, local_paid_probe={local_paid_probe_count}, network_verify={keys_needing_network_count}, terminal={terminal_key_count}, pending_after={pending_after}, fetch_after={fetch_after}, in_flight_after={in_flight_after}, elapsed_ms={elapsed_ms}",
         );
     } else {
         debug!(
             target: "ant_node::replication::verification",
-            "Replication verification cycle: pending_start={initial_pending_count}, local_paid_probe={local_paid_probe_count}, network_verify={keys_needing_network_count}, terminal={terminal_key_count}, pending_after={pending_after}, fetch_after={fetch_after}, in_flight_after={in_flight_after}, elapsed_ms={elapsed_ms}",
+            "Replication verification cycle: pending_start={initial_pending_count}, capacity_deferred_probe={capacity_deferred_probe}, capacity_deferred_promote={capacity_deferred_promote}, local_paid_probe={local_paid_probe_count}, network_verify={keys_needing_network_count}, terminal={terminal_key_count}, pending_after={pending_after}, fetch_after={fetch_after}, in_flight_after={in_flight_after}, elapsed_ms={elapsed_ms}",
         );
     }
 }
@@ -8342,6 +8519,12 @@ fn apply_fetch_result(
         // stranded — it comes back once capacity allows — and the fallthrough
         // to `Terminal` when there is no retry metadata is what keeps
         // bootstrap drain accounting correct, exactly as for a source failure.
+        //
+        // The ordinary requeue delay, deliberately. A standing capacity block
+        // does not need a longer one here: the key returns to pending, and the
+        // gate at the head of the next cycle defers it for minutes. A separate
+        // backoff on this path would duplicate that to save one 15 s round, on
+        // a race the gate already makes rare.
         FetchResult::LocalWriteFailed => {
             if q.requeue_fetch_for_verification(key, verification_retry_after) {
                 FetchFollowUp::RequeuedForVerification

--- a/src/replication/quorum.rs
+++ b/src/replication/quorum.rs
@@ -600,6 +600,16 @@ fn spawn_verification_batch_task(
             }
         };
 
+        // Recorded at the wire call, after the permit and the encode, so the
+        // count is send attempts rather than scheduled batches — recording where
+        // a batch is merely queued would stay positive if the encode or the task
+        // itself regressed. It is not proof of delivery: a send that fails
+        // immediately is still counted. Recording on the responder would be
+        // worse, reading zero for requests the receiver shed at admission or as
+        // stale.
+        #[cfg(any(test, feature = "test-utils"))]
+        crate::replication::record_verification_request_sent(p2p.peer_id(), &requested_keys);
+
         let response = match p2p
             .send_request(&peer, REPLICATION_PROTOCOL_ID, encoded, timeout)
             .await

--- a/src/replication/scheduling.rs
+++ b/src/replication/scheduling.rs
@@ -1414,6 +1414,7 @@ fn max_min_allocations(
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use crate::replication::config::CAPACITY_BLOCKED_RETRY;
 
     /// Build a `PeerId` from a single byte (zero-padded to 32 bytes).
     fn peer_id_from_byte(b: u8) -> PeerId {
@@ -2642,5 +2643,53 @@ mod tests {
             !queues.contains_key(&key),
             "key should be fully processed out of pipeline"
         );
+    }
+
+    // -- capacity gate -----------------------------------------------------
+
+    /// Deferral moves the next look, not the entry's birth, so a blocked key
+    /// still ages out on the ordinary schedule.
+    ///
+    /// This is why the change carries no eviction protection for deferred keys:
+    /// protecting them would preserve, against a bounded queue, exactly the duty
+    /// a full node cannot discharge. The deferred key here is older than the age
+    /// limit and the control is not, so the assertion fails both if deferral
+    /// exempted a key from eviction and if it refreshed `created_at` — either
+    /// would let a full node hold entries indefinitely.
+    ///
+    /// What this does not show: that either gate calls `defer_pending`. The
+    /// gates need a network, so the e2e covers them.
+    #[test]
+    fn capacity_deferral_does_not_extend_entry_lifetime() {
+        // Small enough that the back-dated instant is representable on a
+        // machine that only just booted, wide enough that the control cannot
+        // age out while three in-memory queue operations run.
+        const MAX_AGE: Duration = Duration::from_secs(1);
+
+        let mut queues = ReplicationQueues::new();
+        let aged = xor_name_from_byte(1);
+        let fresh = xor_name_from_byte(2);
+
+        let mut aged_entry = test_entry(1);
+        aged_entry.created_at = Instant::now()
+            .checked_sub(MAX_AGE * 2)
+            .expect("backdate the aged entry");
+        assert!(queues.add_pending_verify(aged, aged_entry).admitted());
+        assert!(queues.add_pending_verify(fresh, test_entry(2)).admitted());
+
+        // The deferral puts the next look beyond the age limit, so an eviction
+        // that read the next look instead of the creation time would spare it.
+        assert!(queues.defer_pending(&aged, CAPACITY_BLOCKED_RETRY));
+
+        let evicted = queues.evict_stale(MAX_AGE);
+        assert!(
+            evicted.contains(&aged),
+            "a capacity-deferred key must still age out on its creation time"
+        );
+        assert!(
+            !evicted.contains(&fresh),
+            "the age limit, not the deferral, is what retires an entry"
+        );
+        assert_eq!(queues.pending_count(), 1);
     }
 }

--- a/src/storage/lmdb.rs
+++ b/src/storage/lmdb.rs
@@ -954,6 +954,7 @@ fn check_disk_space(db_dir: &Path, reserve: u64) -> Result<()> {
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
+    use crate::ant_protocol::MAX_CHUNK_SIZE;
 
     /// Short probe used to prove `wait_idle` is still blocked on a parked op.
     const WAIT_IDLE_BLOCKED_PROBE: std::time::Duration = std::time::Duration::from_millis(200);
@@ -1453,6 +1454,94 @@ mod tests {
             verdict_from_available_space(Ok(RESERVE), RESERVE),
             CapacityVerdict::Writable,
             "at the reserve is not below it"
+        );
+    }
+
+    /// The verdict and the pre-check have to refuse on the same condition.
+    ///
+    /// They are two readings of one question — can this node write? — and two
+    /// callers depend on them separately: the verification cycle gates the
+    /// close-group probe on the verdict, while `execute_single_fetch` gates the
+    /// dial on the pre-check. A verdict stricter than the pre-check is the
+    /// harmful direction. A node the pre-check would let write stops
+    /// discovering holders for keys it could have stored, which is
+    /// under-replication rather than a saved probe, and nothing else in the
+    /// change would notice.
+    ///
+    /// This is a tripwire, deliberately built on the state where the two are
+    /// about to part company rather than on a bare full disk. ant-node
+    /// \#210 makes the pre-check a two-part predicate — below the reserve *and*
+    /// out of reusable pages inside the store — and a store that has deleted
+    /// more than one chunk's worth of pages fails only the first half, because
+    /// LMDB returns those pages to its own free list and never to the
+    /// filesystem. On a bare full disk the two predicates still agree, so a
+    /// test built on one would pass straight through the divergence. Whichever
+    /// of the two changes merges second has to carry the second half into the
+    /// verdict, and this is what makes that a red test rather than a textual
+    /// conflict resolved without it.
+    ///
+    /// What this does not show: which of `Full` and `Unknown` a refusal is.
+    /// `a_failed_space_query_reads_as_unknown_not_full` pins that, and only
+    /// `Full` reaches the gate.
+    #[tokio::test]
+    async fn capacity_verdict_refuses_exactly_when_check_capacity_does() {
+        let (mut storage, _temp) = create_test_storage().await;
+        assert_eq!(storage.capacity_verdict(), CapacityVerdict::Writable);
+        assert!(
+            storage.check_capacity().is_ok(),
+            "a writable verdict has to mean the pre-check admits the write"
+        );
+
+        // Two chunks written and deleted, so the store sits on more than one
+        // chunk of space LMDB can reuse and the filesystem will never take
+        // back. This is the pruned node the two predicates disagree about.
+        for fill in [1u8, 2u8] {
+            let content = vec![fill; MAX_CHUNK_SIZE];
+            let address = LmdbStorage::compute_address(&content);
+            assert!(storage.put(&address, &content).await.expect("put"));
+            assert!(storage.delete(&address).await.expect("delete"));
+        }
+
+        // Established without either function under test, so the scenario does
+        // not rest on the thing being measured.
+        storage.config.disk_reserve = u64::MAX / 2;
+        *storage.last_disk_ok.lock() = None;
+        let available = fs2::available_space(&storage.env_dir).expect("query available space");
+        assert!(
+            available < storage.config.disk_reserve,
+            "the volume has to read as below the reserve, or neither predicate is \
+             being asked the interesting question"
+        );
+        // Reusable bytes read the way the two-part predicate reads them: the
+        // file's size less the pages still holding data. `Env::stat` rather
+        // than `non_free_pages_size`, which calls `String::from_utf8(key)` and
+        // unwraps, so it panics on our 32 random bytes of key.
+        let stat = storage.env.stat();
+        let live_pages = (stat.branch_pages as u64)
+            .saturating_add(stat.leaf_pages as u64)
+            .saturating_add(stat.overflow_pages as u64);
+        let live_bytes = live_pages.saturating_mul(u64::from(stat.page_size));
+        let file_bytes = storage.env.real_disk_size().expect("query store file size");
+        let reusable = file_bytes.saturating_sub(live_bytes);
+        assert!(
+            reusable > MAX_CHUNK_SIZE as u64,
+            "the store has to sit on more than one chunk of reusable space, or the \
+             two predicates are not yet being asked to differ \
+             (file_bytes={file_bytes}, live_bytes={live_bytes})"
+        );
+
+        // Neither call caches a refusal, so the order of the two does not
+        // decide either answer.
+        let pre_check_refuses = storage.check_capacity().is_err();
+        let verdict = storage.capacity_verdict();
+        assert_eq!(
+            pre_check_refuses,
+            verdict != CapacityVerdict::Writable,
+            "the dial pre-check and the verification gate disagree about whether \
+             this node can write: check_capacity refuses={pre_check_refuses}, \
+             verdict={verdict:?}. A verdict of Full under a pre-check that admits \
+             the write leaves a node that can store chunks refusing to look for \
+             them"
         );
     }
 }

--- a/src/storage/lmdb.rs
+++ b/src/storage/lmdb.rs
@@ -687,6 +687,31 @@ impl LmdbStorage {
         self.check_disk_space_cached()
     }
 
+    /// Capacity as a three-way verdict, distinguishing a full disk from a
+    /// query that failed.
+    ///
+    /// Shares the same TTL cache as [`Self::check_capacity`]: a passing result
+    /// is cached, a failing one is always rechecked, so freed space is noticed
+    /// promptly.
+    pub(crate) fn capacity_verdict(&self) -> CapacityVerdict {
+        {
+            let last = self.last_disk_ok.lock();
+            if let Some(t) = *last {
+                if t.elapsed().as_secs() < DISK_CHECK_INTERVAL_SECS {
+                    return CapacityVerdict::Writable;
+                }
+            }
+        }
+        let verdict = verdict_from_available_space(
+            fs2::available_space(&self.env_dir),
+            self.config.disk_reserve,
+        );
+        if verdict == CapacityVerdict::Writable {
+            *self.last_disk_ok.lock() = Some(Instant::now());
+        }
+        verdict
+    }
+
     /// Check available disk space, skipping the syscall if a recent check passed.
     ///
     /// Only caches *passing* results — a low-space condition is always
@@ -869,6 +894,43 @@ fn map_target_bytes(current_db_bytes: u64, available: u64, reserve: u64) -> u64 
     let growth_room = growth_room.min(WINDOWS_MAP_HEADROOM);
 
     current_db_bytes.saturating_add(growth_room)
+}
+
+/// Map the result of a space query onto a verdict.
+///
+/// Split out from [`LmdbStorage::capacity_verdict`] because the three-way
+/// mapping is the part worth proving, and proving it through the filesystem is
+/// not portable: asking for the free space of a directory that does not exist
+/// fails on Unix but succeeds on Windows, which resolves it to the volume.
+fn verdict_from_available_space(available: std::io::Result<u64>, reserve: u64) -> CapacityVerdict {
+    match available {
+        Ok(available) if available < reserve => CapacityVerdict::Full,
+        Ok(_) => CapacityVerdict::Writable,
+        Err(e) => {
+            warn!("Could not query available disk space: {e}");
+            CapacityVerdict::Unknown
+        }
+    }
+}
+
+/// What a capacity check concluded, when the caller needs to tell "this node is
+/// full" apart from "this node could not find out".
+///
+/// [`LmdbStorage::check_capacity`] collapses both into `Err`, which is right for
+/// a caller that only wants to know whether to attempt a write. A caller
+/// deciding *how long to stand down* needs the distinction: a full disk is a
+/// standing condition worth waiting minutes on, while a failed `statvfs` may
+/// have cleared by the next attempt and must not be treated as one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapacityVerdict {
+    /// Available space is at or above the configured reserve. That is what the
+    /// query establishes, and possibly from the TTL cache — not a promise the
+    /// next write succeeds.
+    Writable,
+    /// Available space is below the configured reserve.
+    Full,
+    /// The query itself failed, so nothing is known about available space.
+    Unknown,
 }
 
 /// Reject the write early if available disk space is below `reserve`.
@@ -1317,5 +1379,80 @@ mod tests {
             .await
             .expect("try_resize did not complete after the raw read released")
             .expect("try_resize");
+    }
+
+    /// The gate fires on `Full` and only on `Full`, so the verdict has to tell a
+    /// disk below its reserve from one above it, and has to notice when that
+    /// stops being true.
+    ///
+    /// The third call is the one that matters for recovery: the below-reserve
+    /// condition clears, and the verdict has to follow it rather than stay stuck
+    /// on its earlier answer. A node that remembered a refusal would stop
+    /// fetching for good.
+    ///
+    /// What this does not show: that a changed free-space reading is re-read from
+    /// the filesystem. The condition is cleared by dropping the reserve, which is
+    /// the same comparison approached from the other side.
+    #[tokio::test]
+    async fn capacity_verdict_follows_the_reserve_and_notices_recovery() {
+        let (writable, _temp) = create_test_storage().await;
+        assert_eq!(writable.capacity_verdict(), CapacityVerdict::Writable);
+
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        let config = LmdbStorageConfig {
+            root_dir: temp_dir.path().to_path_buf(),
+            // Far above any real free space, the same way the e2e builds a
+            // write-blocked node.
+            disk_reserve: u64::MAX / 2,
+            ..LmdbStorageConfig::test_default()
+        };
+        let mut full = LmdbStorage::new(config).await.expect("create storage");
+        assert_eq!(full.capacity_verdict(), CapacityVerdict::Full);
+
+        // Still short of space, so still `Full`. A `Full` result that populated
+        // the passing-result cache would answer `Writable` here.
+        assert_eq!(full.capacity_verdict(), CapacityVerdict::Full);
+
+        // Space is no longer short. Nothing cached a refusal, so the very next
+        // read has to see it.
+        full.config.disk_reserve = 0;
+        assert_eq!(
+            full.capacity_verdict(),
+            CapacityVerdict::Writable,
+            "a refusal must not be negatively cached: the next read has to see the \
+             below-reserve condition clear"
+        );
+    }
+
+    /// A space query that fails says nothing about available space, so it must
+    /// not read as a full disk. The gate stands a key down for five minutes on
+    /// `Full` alone, and a failed `statvfs` is not a condition worth standing
+    /// down for: it may be gone by the next cycle.
+    ///
+    /// The two `Ok` cases pin the boundary the reserve names: equal to the
+    /// reserve is writable, one byte under it is not.
+    ///
+    /// What this does not show: that the gate leaves `Unknown` alone. The gate
+    /// tests `== Full` on a separate line inside the verification cycle, which
+    /// needs a network to reach, so this covers the classification only.
+    #[test]
+    fn a_failed_space_query_reads_as_unknown_not_full() {
+        const RESERVE: u64 = 1024;
+
+        assert_eq!(
+            verdict_from_available_space(Err(std::io::Error::other("space query failed")), RESERVE),
+            CapacityVerdict::Unknown,
+            "a failed query must not be reported as a full disk"
+        );
+
+        assert_eq!(
+            verdict_from_available_space(Ok(RESERVE - 1), RESERVE),
+            CapacityVerdict::Full
+        );
+        assert_eq!(
+            verdict_from_available_space(Ok(RESERVE), RESERVE),
+            CapacityVerdict::Writable,
+            "at the reserve is not below it"
+        );
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -50,4 +50,5 @@ pub(crate) mod lmdb;
 pub use crate::ant_protocol::XorName;
 pub use handler::AntProtocol;
 pub(crate) use handler::ChunkRequestContext;
+pub(crate) use lmdb::CapacityVerdict;
 pub use lmdb::{LmdbStorage, LmdbStorageConfig, StorageStats};

--- a/tests/e2e/fetch_local_write_guard.rs
+++ b/tests/e2e/fetch_local_write_guard.rs
@@ -45,11 +45,13 @@
 use super::testnet::TestNetworkConfig;
 use super::verify_storage_gate::find_key_for_target;
 use super::TestHarness;
+use ant_node::client::XorName;
 use ant_node::replication::config::storage_admission_width;
 use ant_node::replication::{
     verification_requests_for_key_from_for_test, watch_verification_requests_for_test,
 };
-use ant_node::ReplicationConfig;
+use ant_node::{ReplicationConfig, ReplicationEngine};
+use saorsa_core::identity::PeerId;
 use serial_test::serial;
 use std::collections::HashMap;
 use std::time::Duration;
@@ -74,6 +76,33 @@ const CONTROL_INDEX: usize = 7;
 /// backoff rather than just "something deferred it". Every other requeue in this
 /// path waits `verification_request_timeout`, which is 15 s.
 const CAPACITY_BACKOFF_FLOOR: Duration = Duration::from_secs(60);
+
+/// Put `key` into `engine`'s pending-verification queue, tolerating a hint that
+/// arrived first.
+///
+/// Seeding a key on other nodes is what makes it advertisable, so a replica hint
+/// can land in the target's queue before this call runs. `add_pending_verify`
+/// then merges the hint into the entry already there and reports
+/// `AlreadyPresent` rather than `Admitted`, which is not a failure: every phase
+/// below needs the key to *be* pending verification, not this call to be what
+/// put it there. Asserting on the admission result alone made the phases lose a
+/// race that widens on a slow runner, and did so at the setup step rather than
+/// at anything the gate decides.
+///
+/// A key that is neither newly admitted nor already pending is still a hard
+/// stop. Left unchecked, the later assertions would read a missing queue entry
+/// as a gate decision.
+async fn ensure_pending_verify(engine: &ReplicationEngine, key: XorName, hinter: PeerId) {
+    if engine.enqueue_pending_verify_for_test(key, hinter).await {
+        return;
+    }
+    assert!(
+        engine.pending_verify_delay_for_test(&key).await.is_some(),
+        "key {} was refused admission to pending verification and is not already \
+         there, so the phase that follows has nothing to observe",
+        hex::encode(key)
+    );
+}
 
 /// A node whose available space is below its reserve must neither dial for a
 /// chunk it has already authorized nor ask its close group where to find one.
@@ -244,18 +273,8 @@ async fn write_blocked_node_neither_probes_nor_dials() {
         .await
         .expect("seed control paid list");
 
-    assert!(
-        target_engine
-            .enqueue_pending_verify_for_test(blocked_key, holder_peer)
-            .await,
-        "blocked key must be admitted to pending verification"
-    );
-    assert!(
-        control_engine
-            .enqueue_pending_verify_for_test(control_key, holder_peer)
-            .await,
-        "control key must be admitted to pending verification"
-    );
+    ensure_pending_verify(target_engine, blocked_key, holder_peer).await;
+    ensure_pending_verify(control_engine, control_key, holder_peer).await;
 
     let deadline = tokio::time::Instant::now() + OBSERVATION_WINDOW;
     let mut blocked_delay = None;
@@ -337,12 +356,7 @@ async fn write_blocked_node_neither_probes_nor_dials() {
             }
         }
     }
-    assert!(
-        target_engine
-            .enqueue_pending_verify_for_test(quorum_key, holder_peer)
-            .await,
-        "quorum key must be admitted to pending verification"
-    );
+    ensure_pending_verify(target_engine, quorum_key, holder_peer).await;
 
     let deadline = tokio::time::Instant::now() + OBSERVATION_WINDOW;
     let mut quorum_delay = None;

--- a/tests/e2e/fetch_local_write_guard.rs
+++ b/tests/e2e/fetch_local_write_guard.rs
@@ -12,7 +12,10 @@
 //! the refusal happens before any holder is contacted, and what the
 //! classification adds is that no *further* holder is contacted.)
 //!
-//! Both scenarios are observed through the holder's `chunks_retrieved` counter.
+//! The dial scenarios are observed through the holder's `chunks_retrieved`
+//! counter; the probe scenario is observed through a sender-side count of
+//! verification requests, since a request that was never sent leaves no trace on
+//! any receiver.
 //! Only `LmdbStorage::get` increments it — the replication fetch responder and
 //! the client GET handler; audits read through `get_raw` and leave it alone.
 //! It is not keyed by chunk or requester, so it is an "it served something"
@@ -43,6 +46,9 @@ use super::testnet::TestNetworkConfig;
 use super::verify_storage_gate::find_key_for_target;
 use super::TestHarness;
 use ant_node::replication::config::storage_admission_width;
+use ant_node::replication::{
+    verification_requests_for_key_from_for_test, watch_verification_requests_for_test,
+};
 use ant_node::ReplicationConfig;
 use serial_test::serial;
 use std::collections::HashMap;
@@ -62,11 +68,48 @@ const HOLDER_INDEX: usize = 6;
 const IMPOSSIBLE_DISK_RESERVE: u64 = u64::MAX / 2;
 const OBSERVATION_WINDOW: Duration = Duration::from_secs(15);
 const OBSERVATION_POLL: Duration = Duration::from_millis(200);
+/// Storage is untouched on this node, so it is the positive control.
+const CONTROL_INDEX: usize = 7;
+/// A delay no ordinary requeue reaches, so the check identifies the capacity
+/// backoff rather than just "something deferred it". Every other requeue in this
+/// path waits `verification_request_timeout`, which is 15 s.
+const CAPACITY_BACKOFF_FLOOR: Duration = Duration::from_secs(60);
 
-/// A node whose storage cannot accept a write must not dial for the chunk.
+/// A node whose available space is below its reserve must neither dial for a
+/// chunk it has already authorized nor ask its close group where to find one.
+///
+/// Three phases on one network, because they are facets of the same duty and a
+/// second 12-node testnet is real port pressure on a CI runner.
+///
+/// **Phase 1, the dial.** `execute_single_fetch` refuses before the dial, so no
+/// holder is conscripted. Observed through the holder's `chunks_retrieved`
+/// counter: only `LmdbStorage::get` moves it — the replication fetch responder
+/// and the client GET handler — while audits read through `get_raw` and leave it
+/// alone. It is not keyed by chunk or requester, so it is an "it served
+/// something" signal rather than an exact per-key one; on a freshly built
+/// testnet with no other traffic to the holder, a delta means it served this
+/// fetch.
+///
+/// **Phase 2, the probe.** Ending the dial does not end the source-discovery
+/// round in front of it. Before the capacity gate a write-blocked node still
+/// asked its close group about every key it owed, on every cycle the key came
+/// back on, for as long as it owed them — a cost that scales with the owed set
+/// rather than with anything the node can do about it.
+/// Both nodes are seeded through the local paid-list path, which is where a full
+/// node spends its life: authorization is already settled, so all that remains is
+/// finding a holder to download from.
+///
+/// In phase 2 the discriminator is the probe count, not the delay: it counts
+/// whether the close group was asked at all, per key, so unrelated background
+/// convergence — which a full node rightly still does — cannot disturb it.
+///
+/// In phase 3 the delay *is* the discriminator, and only because a refused fetch
+/// now requeues on the ordinary `verification_request_timeout`: held before
+/// promotion the key waits five minutes, promoted and then refused it waits
+/// fifteen seconds.
 #[tokio::test]
 #[serial]
-async fn write_blocked_node_does_not_dial() {
+async fn write_blocked_node_neither_probes_nor_dials() {
     let mut storage_disk_reserve_overrides = HashMap::new();
     storage_disk_reserve_overrides.insert(TARGET_INDEX, IMPOSSIBLE_DISK_RESERVE);
     let config = TestNetworkConfig {
@@ -93,6 +136,7 @@ async fn write_blocked_node_does_not_dial() {
         .expect("target protocol")
         .storage();
     let target_engine = target.replication_engine.as_ref().expect("target engine");
+    let target_peer = *target.p2p_node.as_ref().expect("target p2p").peer_id();
     let holder = harness.test_node(HOLDER_INDEX).expect("holder");
     let holder_peer = *holder.p2p_node.as_ref().expect("holder p2p").peer_id();
     let holder_storage = holder
@@ -149,6 +193,209 @@ async fn write_blocked_node_does_not_dial() {
     );
     assert!(
         !target_storage.exists(&key).unwrap_or(true),
+        "the target cannot have stored a chunk its storage refuses to write"
+    );
+
+    // ---- Phase 2: the source-discovery round in front of the dial ----------
+
+    let control = harness.test_node(CONTROL_INDEX).expect("control");
+    let control_storage = control
+        .ant_protocol
+        .as_ref()
+        .expect("control protocol")
+        .storage();
+    let control_engine = control.replication_engine.as_ref().expect("control engine");
+    let control_peer = *control.p2p_node.as_ref().expect("control p2p").peer_id();
+
+    let (blocked_content, blocked_key) =
+        find_key_for_target(&harness, TARGET_INDEX, width, true, "capblocked").await;
+    let (control_content, control_key) =
+        find_key_for_target(&harness, CONTROL_INDEX, width, true, "capcontrol").await;
+
+    // Both keys are answerable, so a node that stays quiet chose to.
+    holder_storage
+        .put(&blocked_key, &blocked_content)
+        .await
+        .expect("host the blocked key");
+    holder_storage
+        .put(&control_key, &control_content)
+        .await
+        .expect("host the control key");
+
+    // Count probes only for these two keys, so the convergence traffic a full
+    // node rightly still sends for unauthorized keys cannot disturb the result.
+    // Counted where they are sent, so a responder shedding a request cannot
+    // turn a probe that happened into a zero here.
+    watch_verification_requests_for_test(&[blocked_key, control_key]);
+
+    // Authorization settled locally on both nodes. That is the state a full
+    // node reaches for an owed key once its paid list has caught up, which is
+    // the case the gate exists for; keys still awaiting that, or stuck on an
+    // inconclusive quorum, keep running the ungated round. Once settled, the
+    // cycle skips the quorum round and goes straight to the presence probe.
+    target_engine
+        .paid_list()
+        .insert(&blocked_key)
+        .await
+        .expect("seed target paid list");
+    control_engine
+        .paid_list()
+        .insert(&control_key)
+        .await
+        .expect("seed control paid list");
+
+    assert!(
+        target_engine
+            .enqueue_pending_verify_for_test(blocked_key, holder_peer)
+            .await,
+        "blocked key must be admitted to pending verification"
+    );
+    assert!(
+        control_engine
+            .enqueue_pending_verify_for_test(control_key, holder_peer)
+            .await,
+        "control key must be admitted to pending verification"
+    );
+
+    let deadline = tokio::time::Instant::now() + OBSERVATION_WINDOW;
+    let mut blocked_delay = None;
+    let mut control_stored = false;
+    while tokio::time::Instant::now() < deadline {
+        let delay = target_engine
+            .pending_verify_delay_for_test(&blocked_key)
+            .await;
+        if delay.is_some_and(|d| d >= CAPACITY_BACKOFF_FLOOR) {
+            blocked_delay = delay;
+        }
+        control_stored = control_storage.exists(&control_key).unwrap_or(false);
+        if blocked_delay.is_some() && control_stored {
+            break;
+        }
+        tokio::time::sleep(OBSERVATION_POLL).await;
+    }
+
+    let blocked_probes = verification_requests_for_key_from_for_test(&target_peer, &blocked_key);
+    let control_probes = verification_requests_for_key_from_for_test(&control_peer, &control_key);
+    println!(
+        "CAPACITY-GATE-RESULT blocked_probes={blocked_probes} control_probes={control_probes} \
+         blocked_delay={blocked_delay:?} control_stored={control_stored}"
+    );
+
+    // The load-bearing assertion. Counted per key, so the convergence traffic a
+    // full node rightly still sends for keys it has not authorized cannot mask
+    // or manufacture this result.
+    assert_eq!(
+        blocked_probes, 0,
+        "the write-blocked node sent {blocked_probes} verification request(s) for a key \
+         its own capacity check will refuse. That probe is what scales with the owed \
+         set, and it is paid whether or not the dial behind it is stopped"
+    );
+    assert!(
+        control_probes > 0,
+        "the control asked nobody either, so the zero above is not evidence of \
+         anything — the cycle never reached the probe on either node"
+    );
+    assert!(
+        control_stored,
+        "the control never acquired its key, so the run says nothing about the gate"
+    );
+    assert!(
+        blocked_delay.is_some_and(|d| d >= CAPACITY_BACKOFF_FLOOR),
+        "the blocked key must be held on the capacity backoff, not merely skipped \
+         for one cycle: a skip without a deferral is re-selected on the next poll"
+    );
+    assert!(
+        !target_storage.exists(&blocked_key).unwrap_or(true),
+        "the target cannot have stored a chunk its storage refuses to write"
+    );
+
+    // ---- Phase 3: the second gate, on promotion after the quorum round -----
+    //
+    // The first gate covers keys the node has already authorized. A key it has
+    // not is authorized by a network quorum round instead, and that round is
+    // deliberately left alone — it is how `PaidForList` converges. What must
+    // still be stopped is the promotion that follows it.
+    //
+    // The delay is what separates the two outcomes here, and only because a
+    // refused fetch now requeues on the ordinary schedule: gated before
+    // promotion the key waits `CAPACITY_BLOCKED_RETRY`, whereas promoted and
+    // refused at the dial it waits `verification_request_timeout`. Those are
+    // 5 minutes against 15 seconds.
+    let (quorum_content, quorum_key) =
+        find_key_for_target(&harness, TARGET_INDEX, width, true, "capquorum").await;
+
+    // Host it widely enough that the round can actually reach quorum
+    // (`QUORUM_THRESHOLD` is 4 of a 7-wide close group), and deliberately do
+    // not touch the target's paid list, so the key takes the network branch.
+    for idx in 0..harness.node_count() {
+        if idx == TARGET_INDEX {
+            continue;
+        }
+        if let Some(node) = harness.test_node(idx) {
+            if let Some(protocol) = node.ant_protocol.as_ref() {
+                let _ = protocol.storage().put(&quorum_key, &quorum_content).await;
+            }
+        }
+    }
+    assert!(
+        target_engine
+            .enqueue_pending_verify_for_test(quorum_key, holder_peer)
+            .await,
+        "quorum key must be admitted to pending verification"
+    );
+
+    let deadline = tokio::time::Instant::now() + OBSERVATION_WINDOW;
+    let mut quorum_delay = None;
+    while tokio::time::Instant::now() < deadline {
+        let delay = target_engine
+            .pending_verify_delay_for_test(&quorum_key)
+            .await;
+        if delay.is_some_and(|d| d >= CAPACITY_BACKOFF_FLOOR) {
+            quorum_delay = delay;
+            break;
+        }
+        tokio::time::sleep(OBSERVATION_POLL).await;
+    }
+    // The gate has to sit *after* authorization, not in front of it. A delay on
+    // its own cannot tell those apart: a gate moved ahead of the quorum round
+    // would hold the key for the same five minutes while never learning it was
+    // paid for, which is the failure mode that strands keys, keeps bootstrap
+    // drain pending and leaves audits disabled. The paid list is the record of
+    // the round having completed, so assert on it directly.
+    let quorum_authorized = target_engine
+        .paid_list()
+        .contains(&quorum_key)
+        .unwrap_or(false);
+    println!(
+        "CAPACITY-GATE-PROMOTION-RESULT quorum_delay={quorum_delay:?} \
+         quorum_authorized={quorum_authorized}"
+    );
+    assert!(
+        quorum_authorized,
+        "the key was held without being authorized first: the quorum round did not \
+         reach the target's paid list, so the gate is in front of authorization \
+         rather than behind it (key {})",
+        hex::encode(quorum_key)
+    );
+
+    // One caveat on what a pass here proves. Without the promotion gate,
+    // `promote_pending_to_fetch` can also fail because the fetch queue is at
+    // capacity, which leaves the key ready and — since Step 4 has by then
+    // inserted it into `PaidForList` — the *first* gate would defer it five
+    // minutes on the next cycle. On a fresh 12-node harness the queue is
+    // nowhere near its 131,072 bound, and the gate-2-only mutation run
+    // confirms the assertion does fail when the gate is removed, so that path
+    // is not what is being observed. It is recorded because the assertion is
+    // not intrinsically exclusive to the second gate.
+    assert!(
+        quorum_delay.is_some(),
+        "the network-verified key was not held at the promotion gate. Either it was \
+         promoted and refused at the dial — which requeues on the 15 s schedule, not \
+         the capacity backoff — or the round never resolved (key {})",
+        hex::encode(quorum_key)
+    );
+    assert!(
+        !target_storage.exists(&quorum_key).unwrap_or(true),
         "the target cannot have stored a chunk its storage refuses to write"
     );
 


### PR DESCRIPTION
## Linear issue

V2-1009 — https://linear.app/autonominetwork/issue/V2-1009/ant-node-gate-the-replication-verification-cycle-on-local-write

Follow-up to V2-963 (#202), which added the capacity pre-check to the fetch path,
and to the testnet run recorded on
[V2-987](https://linear.app/autonominetwork/issue/V2-987/testnet-run-replication-fetch-guard-with-artificially-full-nodes-v2),
which measured the cost this closes. That run's failing criterion is not a
regression from #202: it measured a trend with no baseline arm, and the local A/B
that does have both arms shows the guard slightly *below* main on the same lane.

## Risk tier

- [ ] T0 — docs / tooling / CI / pure UX-output. Repo CI only.
- [ ] T1 — client-only, no network-facing behavior change. CI + prod compat smoke.
- [x] T2 — node/client logic with behavioral surface, no protocol/format/economics change. Dev testnet + ADR.
- [ ] T3 — protocol / storage format / payments / routing. T2 evidence + adversarial testing.

Node-side replication behaviour: once a node's available space is below its
reserve, keys it has *already authorized* stop running the source-discovery round
and stop being promoted for fetch. Unauthorized keys still run their quorum round,
paid-list convergence and the terminal checks still run, and a failed space query
or other write error is not gated. No protocol, format, or economics change.

## Compatibility

- Wire: none. The gate decides whether this node *sends* a `VerificationRequest` it
  was about to send anyway. No message, field, or protocol id changes, and no
  peer-side heuristic consumes the absence of unsolicited verification requests.
- Storage: none. `ReplicationConfig` is neither serialised nor persisted; persisted
  TOML is `NodeConfig`. No schema, key, or on-disk format change.
- API: none in a default build, and checked three times. The backoff is a `pub(crate)` constant,
  deliberately **not** a `ReplicationConfig` field — that struct is publicly
  re-exported and is not `#[non_exhaustive]`, so adding a field would break
  downstream exhaustive construction. An earlier revision added one and it was
  removed. A later review then caught that the constant and the new
  `in_flight_verification_age` accessor were still `pub` inside public modules,
  which is additive rather than breaking but is still public surface; both are
  now `pub(crate)`. The new public items — the two engine test hooks, the probe watch and its query —
  are all `#[cfg(any(test, feature = "test-utils"))]`, so they are additive under
  `test-utils` and absent from a default build. Four items, not one.

## Semver impact

- [ ] breaking
- [ ] feature
- [x] fix

## Test evidence

**Simplicity.** The production change is one capacity read per cycle, two gates
that call the existing `defer_pending`, and a three-way verdict so a failed space
query is not mistaken for a full disk. The verdict's mapping sits in its own free
function so it can be proved without depending on how a given platform answers a
space query for an unusual path.
`scheduling.rs` carries no production change; the only edit there is one test.
An earlier revision also clamped the deferral to
half the entry's remaining life, protected the deferred key from fairness
eviction, and carried the verdict through `FetchResult`; all three were cut on
review, for the reasons recorded in ADR-0011.

**Unit (`cargo test --lib`, 934 passed / 0 failed)** — the existing
`apply_fetch_result` cases still hold with `LocalWriteFailed` back to its
upstream shape, plus five new tests. Each is mutation-checked, and each states
in its own rustdoc what it does *not* show.

- `capacity_verdict_follows_the_reserve_and_notices_recovery` — the verdict
  tracks the reserve in both directions. The third assertion is the one that
  matters operationally: once space is freed the very next read has to see it,
  because a node stuck on a remembered refusal would stop fetching for good. What
  it proves precisely is that `Full` is not negatively cached: the condition is
  cleared by dropping the reserve, which is the same comparison from the other
  side, not by freeing actual space. Killed by inverting the
  comparison, by caching the refusal in the passing-result slot, and by memoising
  it separately.
- `a_failed_space_query_reads_as_unknown_not_full` — a failed `statvfs` must be
  classified as `Unknown` rather than as a full disk, plus the reserve boundary
  itself. Killed by folding the error arm into `Full`, by inverting the
  comparison, and by slipping the boundary to `<=`. This is the round-7 finding,
  pinned at the classification. That the gate then leaves `Unknown` alone is a
  separate line inside the cycle and stays inspection-only.

  The three-way mapping moved into a small free function, `verdict_from_available_space`,
  for this. The first version of the test forced a real query failure by pointing
  the storage at a directory that does not exist; that is not portable, and CI
  proved it — the test passed on macOS and Linux and failed on Windows, which
  resolves a missing subdirectory to its volume and answers successfully. Injecting
  the query result is both simpler and provable everywhere.
- `capacity_deferral_does_not_extend_entry_lifetime` — deferral moves the next
  look, not the entry's birth, so a blocked key still ages out on schedule. This
  is why no eviction protection is carried: protecting deferred keys would
  preserve, against a bounded queue, the one duty a full node cannot discharge.
  Killed both by exempting deferred keys from eviction and by refreshing
  `created_at` on deferral.
- `capacity_blocked_retry_is_an_order_above_the_request_timeout_and_below_the_entry_lifetime`
  — the constant has to be an order above the retry it replaces, or the repeat
  cost stays the same order, and below `PENDING_VERIFY_MAX_AGE`, or every
  deferral silently becomes an eviction. Killed by collapsing the constant back
  to 15 s.
- `capacity_verdict_refuses_exactly_when_check_capacity_does` — the verdict this
  gate reads and the pre-check the dial reads have to refuse on the same
  condition. A verdict stricter than the pre-check is the harmful direction: a
  node the pre-check would let write stops looking for keys it could have
  stored. Built on a store that has deleted more than one chunk's worth of pages
  rather than on a bare full disk, because that is the state the two are about
  to part company over. Killed by applying #210's predicate to the pre-check:
  the other 933 tests still pass and only this one fails.

**Ordering against #210.** #210 (`fix/capacity-check-lmdb-reuse`) rewrites the
same pre-check this gate reads, making it two-part — below the reserve *and* out
of reusable pages inside the store — because LMDB returns a deleted record's
pages to its own free list and never to the filesystem. The two changes edit
neighbouring code in `src/storage/lmdb.rs`, so they conflict textually whichever
lands first, but the conflict that matters is not textual. With #210's predicate
in and this verdict left as it stands, a heavily pruned node reads as `Full`
here while its own dial pre-check admits the write, so it stands its keys down
for five minutes at a time instead of looking for chunks it could store. That is
under-replication, and it is the risk raised against #202 and this change
together. The test above fails in exactly that state, so whichever merges second
has to carry the second half of the predicate into the verdict rather than
resolve the conflict by hand and move on.

**What the unit tests do not do**, since it is the obvious question to ask of
them: none executes either gate. The gates live inside `run_verification_cycle`,
which needs storage, a p2p node and queues, so the e2e below is what proves them,
per gate, by mutation. The unit tests pin the pieces the gates are built from —
the verdict, the policy constant, and the deferral's interaction with eviction.
Each says so in its own rustdoc.

One thing stays unpinned by any test: which of `capacity_deferred_probe` and
`capacity_deferred_promote` a given gate increments. Reaching it means returning
cycle statistics out of a 400-line async function, which is a larger change than
the label is worth — a swap would mislabel one diagnostic line on the dev testnet,
not misbehave on the network. It is called out here rather than papered over.

**E2E (`cargo test --test e2e --features test-utils -- --test-threads=1`)** — no
new test and no new testnet. The probe assertions are folded into #202's existing
write-blocked test in `tests/e2e/fetch_local_write_guard.rs`, renamed
`write_blocked_node_neither_probes_nor_dials` to say what it now covers. All
three phases run on the one 12-node network that test already built, because a
second one is real port pressure on a CI runner.

- Phase 1 (unchanged, from #202): the holder serves `0` chunks, so no dial.
- Phase 2: `blocked_probes=0` against `control_probes=7`, with the control also
  completing its acquisition (`control_stored=true`) so a cycle that never
  reached the probe cannot read as a pass.
- Phase 3: the promotion gate on the network-authorization branch, which was
  inspection-only until this revision. The chunk is hosted widely enough to clear
  the four-of-seven quorum threshold and deliberately left out of the target's
  paid list, so the key takes that branch; it is then held at `quorum_delay=299.9s`
  rather than promoted, with `quorum_authorized=true`.

  That second value is what pins the gate *behind* authorization rather than in
  front of it. A delay on its own cannot tell those apart, which a review caught:
  a gate moved ahead of the quorum round holds the key for the same five minutes
  while never learning it was paid for, and that is the failure mode that strands
  keys, keeps bootstrap drain pending and leaves audits disabled. Moving the gate
  ahead of the round reproduces it exactly — `quorum_delay=299.9s` still, but
  `quorum_authorized=false` — and the assertion fails. Gate 1's ordering behind
  the terminal checks remains inspection-only; building a node that both holds a
  key and refuses writes is not constructible here, as the module header records.

**Each gate is pinned independently.** Disabling the promotion gate alone leaves
phase 2 passing (`blocked_probes=0`) and fails phase 3 with `quorum_delay=None` —
the key was promoted, refused at the dial, and requeued on the 15 s schedule.
Disabling both fails phase 2 first with `blocked_probes=7`. Neither gate can be
removed without a test catching it. Cutting the capacity-specific `FetchResult`
backoff is what made phase 3 observable at all, since a refused fetch now requeues
on a visibly different schedule from a gated one.

Probes are counted **per key**, not per peer. A write-blocked node legitimately
keeps sending verification requests for keys it has not yet authorized — that is
`PaidForList` convergence, which this change deliberately leaves alone — so a
per-peer count would have asserted something untrue and been flaky against
background traffic.

Phase 2 asserts both the zero probe count and the long delay; the probe count is
what discriminates the gate, the delay only confirms the key was held rather than
dropped. An earlier revision asserted on the delay *alone* and was vacuous — with
the gates removed the key was promoted, refused at the dial, and requeued on the
same long backoff, so the delay read ~299.8 s either way. The mutation run showed
that, not the code review.

Phase 3 can assert on the delay as its discriminator only because the
capacity-specific `FetchResult` backoff was cut: a refused fetch now requeues on
the ordinary 15 s schedule, so 5 minutes versus 15 seconds separates "held before
promotion" from "promoted, then refused".

**What this does not do**, which earlier drafts of this PR and of ADR-0011 both
claimed it did: it does not silence a full node. A key the node has not yet authorized still runs
its quorum round, because that is how `PaidForList` converges, and its close group
still pays a presence lookup for it. What goes away is the *repeating* cost on
keys it has already authorized and cannot store — the loop that scaled with the
owed set. Traffic falls to a convergence floor, not to zero.

A key deferred inside the last five minutes of its entry's life expires without a
further look and returns on the next neighbour-sync hint. That is the trade for
not carrying a clamp whose tail looks can themselves become ungated quorum
rounds, working against the point of the change.

**Open gate: the T2 dev testnet run.** The tier's evidence bar is "Dev testnet +
ADR". The ADR is in this PR; the run is not, and I cannot run one. The natural
shape is a repeat of the V2-987 plan with this change in, because that plan
already builds the condition under test — 25% of the fleet artificially
storage-full — and it would settle the criterion that failed there rather than
leaving it as a judgement call.

Stated as the two-sided criterion asked for in review, so whoever runs it does
not have to reconstruct what a pass looks like:

- **While full.** The full cohort's per-hour delta of
  `verification_request_tx_bytes` settles instead of climbing 1.06 → 1.77 →
  2.53 GB across the window. The counter is cumulative, so the criterion is its
  growth rate, not its value. The floor is not zero: a key the node has not yet
  authorized still runs its quorum round, which is how `PaidForList` converges,
  so what should disappear is the repeating cost on keys it has already
  authorized.
- **After capacity returns.** Freed nodes resume acquisition inside the plan's
  60-minute recovery allowance, with no key silently dropped. A deferred key is
  scheduled for its next look `CAPACITY_BLOCKED_RETRY` (5 minutes) ahead — the
  requested delay rather than a bound, since cycle polling and a backlog can
  push it later — against a `PENDING_VERIFY_MAX_AGE` of 30 minutes. Nothing
  caches the refusal: the verdict re-reads capacity every cycle and only passing
  results are cached. Both halves are pinned by unit tests; measuring the
  recovery on a fleet is what the run adds.
- **Unchanged either way.** `key_absent` audit rates and download success.

Treating that run as a merge gate is the reason this PR is marked ready for
review rather than ready to merge. The other gate raised in review — rebasing
onto current `main` so the branch resolves `h2 0.4.16` rather than `0.4.15` — is
closed: the branch sits on `661e68a`, which carries #209, and Security Audit is
green along with the other fourteen checks.

**A second flake, in this PR's own test, fixed rather than tolerated.** Phases 2
and 3 asserted that their explicit `enqueue_pending_verify_for_test` call was
what *admitted* the key. Seeding the chunk on other nodes is what makes it
advertisable, so a replica hint can reach the target's queue first, and
`add_pending_verify` then merges the hint into the entry already there and
reports `AlreadyPresent`. Phase 3 lost that race once on a Windows runner —
seeding eleven nodes is what widens the window — and it failed at the setup step
rather than at anything a gate decides, with phases 1 and 2 passing in the same
run (`served_by_holder=0`, `blocked_probes=0` against `control_probes=7`). The
phases now require the key to *be* pending verification, newly admitted or
already there, and still stop hard if it is neither, so a missing queue entry
cannot be read as a gate decision.

**Known harness flake, not from this change.** The e2e suite intermittently fails
at testnet *construction* with `Failed to create dual-stack network nodes: Failed
to create transport` — a socket bind, before any replication code runs. It has hit
all three CI platforms and six distinct tests, always at setup and never on an
assertion, including on 13 August on an unrelated branch that passed on its next
run. It also reproduced locally after many back-to-back suite runs, and both
affected tests passed immediately on isolated rerun, so it is not CI-specific;
port exhaustion under repeated testnet construction is the plausible cause rather
than a proven one. If a test job is red, check for that signature before reading
it as a defect.

## New dependency

none

## ADR

New: [**ADR-0011** — capacity-gated source discovery in the replication verification
cycle](https://github.com/WithAutonomi/ant-node/blob/fix/capacity-aware-verification-cycle/docs/adr/ADR-0011-capacity-gated-source-discovery.md),
`Status: Proposed`. It records the decision, the option that was implemented first
and rejected in review (gating on hint provenance), the clamp, and the trade-offs.

Related but not restating this decision: ADR-0003 decides how *other* nodes treat a
full peer; this decides what the full peer itself stops doing. ADR-0005 owns the
verification/fetch pipeline being changed.

## Mitigation / rollback

Revert the commit. The change is two branches in `run_verification_cycle`, both
behind a capacity verdict that is `Full` only on a node whose available space is
below its configured reserve, so a node that can write never reaches the changed
paths. What else the diff adds is inert by construction: a retry constant, a
storage verdict that reuses the existing capacity check and its cache, per-gate
counters on an existing log line, and test-only probe recording. `scheduling.rs`
has no production change.

