### PR TITLE
feat: restrict the beta upgrade channel to -beta pre-releases

### DIFF
--- a/.claude/commands/prepare-for-auto-upgrade-test.md
+++ b/.claude/commands/prepare-for-auto-upgrade-test.md
@@ -1,0 +1,123 @@
+# Prepare for Auto Upgrade Test
+
+@Cargo.toml
+@src/config.rs
+@src/upgrade/monitor.rs
+@src/node.rs
+@.github/workflows/release.yml
+
+I want you to help me prepare for a test of the automatic-upgrades process.
+
+## Overview
+
+The process has 4 phases:
+
+* Derive test parameters from the current version
+* Clear previous test artifacts
+* Prepare the current branch for an auto-upgrade test
+* Create a fake beta release branch and trigger the release
+
+The fake release uses a `-beta.N` suffix, not `-rc.N`. The beta upgrade channel accepts a version
+only when its pre-release component is empty or its first identifier is exactly `beta`; release
+candidates are deliberately rejected on every channel, so an `-rc.1` fake release would never be
+picked up by anything.
+
+# Phase 1: Derive Test Parameters
+
+We need to derive all test parameters from the current `Cargo.toml` version.
+
+Follow these steps:
+- Read the current version from `Cargo.toml` (the `version` field under `[package]`).
+- Create a `BETA_VERSION` parameter by adding 10 to the current PATCH component and appending a
+  `-beta.1` suffix. For example, if the current version is `0.3.2`, the beta version should be
+  `0.3.12-beta.1`.
+- Create a `TAG_NAME` parameter by prepending `v` to the `BETA_VERSION`. For example:
+  `v0.3.12-beta.1`.
+- Create a `BRANCH_NAME` parameter by taking the version with the bumped patch (without the
+  `-beta.1` suffix) and prepending `beta-`. For example: `beta-0.3.12`.
+
+Print the values you have obtained for these parameters and prompt me to verify them before
+proceeding to the next phase.
+
+# Phase 2: Clear Previous Test Artifacts
+
+It's possible there was a previous test run that has not been cleaned up. We need to remove any
+artifacts from any previous test.
+
+Follow these steps for the current `BRANCH_NAME` / `TAG_NAME`:
+- If a `BRANCH_NAME` branch exists locally, delete it.
+- If a `BRANCH_NAME` branch exists on the `upstream` remote, delete it.
+- If a `TAG_NAME` tag exists locally, delete it.
+- If a `TAG_NAME` tag exists on the `upstream` remote, delete it.
+- If a GitHub release exists for `TAG_NAME` on the upstream repository (`WithAutonomi/ant-node`),
+  delete it using `gh release delete TAG_NAME --repo WithAutonomi/ant-node --yes`.
+
+Earlier runs of this command used release-candidate names, so also clean up the legacy equivalents:
+- The `rc-<bumped version>` branch, locally and on `upstream` (e.g. `rc-0.3.12`).
+- The `v<bumped version>-rc.1` tag, locally and on `upstream` (e.g. `v0.3.12-rc.1`).
+- The GitHub release for that rc tag, if one exists.
+
+For each step, check if the artifact exists before attempting deletion. Report what was cleaned up.
+
+# Phase 3: Preparing the Current Branch
+
+For the test, the current branch needs a temporary commit that compresses the upgrade timing so
+that test nodes detect and apply the fake beta release quickly.
+
+Note that we do **not** change the default upgrade channel. Cohort nodes opt into beta explicitly
+at launch with `--upgrade-channel beta` (or `ANT_UPGRADE_CHANNEL=beta`), exactly as a real
+community beta node would, so the test exercises the real opt-in path.
+
+The timing parameters are not runtime-configurable, so they have to be compiled in. This means the
+tested binary is a modified build — a known and accepted limitation of a mechanism test.
+
+Follow these steps:
+
+* Compress the upgrade check interval from 1 hour to 20 minutes. The interval is currently held in
+  hours as a `u64`, so it cannot express 20 minutes as a fraction. Convert the field to minutes:
+  - Rename the `check_interval_hours` field in `UpgradeConfig` (`src/config.rs`) to
+    `check_interval_minutes`, keeping the `u64` type.
+  - Change `default_check_interval()` to return `20`.
+  - In `UpgradeMonitor::new`, compute the interval as `check_interval_minutes * 60` seconds instead
+    of `check_interval_hours * 3600`.
+  - Update the serde field name and every other reference to `check_interval_hours` in the
+    codebase, including tests.
+
+* Change the staged rollout window from 24 hours to 2 hours for the test. Update
+  `default_staged_rollout_hours()` in `src/config.rs` to return `2`. This keeps the test duration
+  practical (100 nodes over 2 hours ≈ 1 restart/minute) while still validating even distribution.
+
+* Create a chore commit with these changes. The commit message should indicate that these are
+  temporary timing changes for auto-upgrade testing and will be removed after the test. Let me
+  review the commit before proceeding.
+
+* Push the change to the `origin` remote (the user's fork). Force pushing is fine if necessary.
+
+# Phase 4: Create Fake Beta Release Branch
+
+Now we need to create a fake beta release branch that will trigger a GitHub release when the tag is
+pushed.
+
+Follow these steps:
+
+* Create a new branch from the current one called `BRANCH_NAME`.
+* Update the `version` field in `Cargo.toml` to the value of `BETA_VERSION`.
+* Put this change in a commit with the title `chore(release): fake beta release BETA_VERSION` and in
+  the body, indicate that it's a fake beta release for testing automatic upgrades.
+
+Allow me to review the commit, and once I approve:
+
+* Push the branch to the `upstream` remote.
+* Push the tag `TAG_NAME` pointing at the HEAD of this branch to the `upstream` remote. This will
+  trigger the release workflow which builds, signs, and publishes the release as a pre-release on
+  GitHub.
+
+After pushing, print a reminder:
+- The release workflow will take several minutes to complete.
+- Once complete, the fake beta release will appear as a pre-release at
+  `https://github.com/WithAutonomi/ant-node/releases`. It will not be marked "Latest".
+- Test nodes must be running with `--upgrade-channel beta` (or `ANT_UPGRADE_CHANNEL=beta`) and the
+  compressed-timing build from Phase 3; they will detect and upgrade to this version within
+  ~20 minutes. Nodes left on the default stable channel will correctly ignore it.
+- After testing, remember to clean up: revert the temporary commit on the current branch, and
+  delete the beta branch/tag/release from upstream.

--- a/.claude/commands/prepare-for-musl-swap-test.md
+++ b/.claude/commands/prepare-for-musl-swap-test.md
@@ -1,0 +1,263 @@
+# Prepare for Musl Swap Auto-Upgrade Test
+
+@Cargo.toml
+@src/config.rs
+@src/upgrade/monitor.rs
+@src/upgrade/apply.rs
+@src/node.rs
+@.github/workflows/release.yml
+
+I want you to help me prepare for a test of the automatic-upgrades process where a beta release
+switches the Linux build from glibc to musl. The initial testnet runs glibc binaries (today's
+production shape); the beta release publishes musl-static binaries under the same asset filenames
+so the existing substring matcher picks them up.
+
+The fake release uses a `-beta.N` suffix, not `-rc.N`. The beta upgrade channel accepts a version
+only when its pre-release component is empty or its first identifier is exactly `beta`; release
+candidates are deliberately rejected on every channel, so an `-rc.1` fake release would never be
+picked up by anything.
+
+## Branch model
+
+There is a shared **feature base** and three branches built from it. Be careful not to conflate
+them.
+
+**Feature base.** The branch containing the upgrade-subsystem changes that are actually under test
+— currently `grumbach/fix/a1-upgrade-cache-resign-verify` (per-cache-hit ML-DSA re-verification,
+FIFO/pipe rejection, cache-first apply ordering). Both the test branch and the musl swap branch
+**must** be based on this, so the initial-cohort binary and the beta binary share identical
+upgrade-apply code. If they don't, the running (initial) binary may short-circuit before reaching
+the code path the test is trying to exercise — e.g. an old version-check-first ordering never
+consults the cache, so sibling nodes never hit the re-verification path. Ask me which branch is
+the current feature base; it changes per test.
+
+1. **Test branch** (e.g. `chore/musl-swap-upgrade-test`). Cut from the **feature base**. The only
+   change on top is a temporary commit that shortens the upgrade check interval and staged rollout
+   window so initial nodes detect and apply the beta release quickly. It does **not** change the
+   default upgrade channel — cohort nodes opt into beta explicitly at launch (see Phase 3).
+   **The test branch does NOT contain the musl swap or mimalloc** — the whole point of the test is
+   that the initial cohort runs the current production shape (glibc) and upgrades to a musl beta
+   release. Discarded after the test.
+
+2. **Musl swap branch** (e.g. `feat/musl-linux-builds`). The feature base **plus** the *real*
+   product change being tested: flipping the release workflow's two Linux matrix entries from
+   `gnu` to `musl`, plus the `mimalloc` global allocator. Intended to land on `main` eventually as
+   a normal PR. **Not** thrown away after the test.
+
+3. **Fake beta branch** (`BRANCH_NAME` from Phase 1). Cut from the musl swap branch. The only
+   thing it adds is the version bump to `BETA_VERSION`. Discarded after the test along with the tag
+   and pre-release.
+
+Tag the fake beta branch and you get a pre-release that contains musl-built Linux binaries. The
+test branch's (glibc) initial nodes, started on the beta channel, detect that release and upgrade
+to it. Because both branches share the feature base, the only intended differences between the
+initial and upgraded binaries are: timing (test branch) and musl + mimalloc (beta release).
+
+## Overview
+
+The process has 6 phases:
+
+* Derive test parameters from the current version
+* Clear previous test artifacts
+* Prepare the test branch (timing commit — glibc initial nodes)
+* Prepare the musl swap branch (release workflow gnu → musl + mimalloc)
+* Create the fake beta branch (musl swap branch + version bump)
+* Publish to upstream and verify
+
+# Phase 1: Derive Test Parameters
+
+We need to derive all test parameters from the current `Cargo.toml` version.
+
+Follow these steps:
+- Read the current version from `Cargo.toml` (the `version` field under `[package]`).
+- Create a `BETA_VERSION` parameter by adding 10 to the current PATCH component and appending a
+  `-beta.1` suffix. For example, if the current version is `0.3.2`, the beta version should be
+  `0.3.12-beta.1`.
+- Create a `TAG_NAME` parameter by prepending `v` to the `BETA_VERSION`. For example:
+  `v0.3.12-beta.1`.
+- Create a `BRANCH_NAME` parameter by taking the version with the bumped patch (without the
+  `-beta.1` suffix) and prepending `beta-`. For example: `beta-0.3.12`. This is the *fake beta*
+  branch.
+
+Ask me for:
+- the **feature base** branch (the upgrade-subsystem branch under test, e.g.
+  `grumbach/fix/a1-upgrade-cache-resign-verify`) — run `git fetch` on its remote so it's current;
+- the **test branch** name;
+- the **musl swap branch** name.
+
+None of these are derived from the version. The feature base and musl swap branch may already
+exist from a previous session; in that case I'll point you at them.
+
+Print the values you have obtained for these parameters and prompt me to verify them before
+proceeding to the next phase.
+
+# Phase 2: Clear Previous Test Artifacts
+
+It's possible there was a previous test run that has not been cleaned up. We need to remove any
+artifacts from any previous test.
+
+The musl swap branch is a real branch that may persist across test runs — do **not** delete it in
+this phase. Only the fake beta branch and its tag/release are throwaway.
+
+Follow these steps:
+- If a `BRANCH_NAME` branch exists locally, delete it.
+- If a `BRANCH_NAME` branch exists on the `upstream` remote, delete it.
+- If a `TAG_NAME` tag exists locally, delete it.
+- If a `TAG_NAME` tag exists on the `upstream` remote, delete it.
+- If a GitHub release exists for `TAG_NAME` on the upstream repository (`WithAutonomi/ant-node`),
+  delete it using `gh release delete TAG_NAME --repo WithAutonomi/ant-node --yes`.
+
+Earlier runs of this command used release-candidate names, so also clean up the legacy equivalents:
+- The `rc-<bumped version>` branch, locally and on `upstream` (e.g. `rc-0.3.12`).
+- The `v<bumped version>-rc.1` tag, locally and on `upstream` (e.g. `v0.3.12-rc.1`).
+- The GitHub release for that rc tag, if one exists.
+
+For each step, check if the artifact exists before attempting deletion. Report what was cleaned up.
+
+# Phase 3: Prepare the Test Branch (glibc initial nodes)
+
+The test branch is what the initial testnet nodes are built from. They MUST stay glibc — the whole
+point of the test is to verify that glibc nodes correctly download and execute the musl beta
+binary. So the test branch only modifies upgrade timing; **it does not touch
+`.github/workflows/release.yml` or add mimalloc** — those belong only on the musl swap branch.
+
+We do **not** change the default upgrade channel. Cohort nodes opt into beta explicitly at launch
+with `--upgrade-channel beta` (or `ANT_UPGRADE_CHANNEL=beta`), exactly as a real community beta
+node would. The timing parameters are not runtime-configurable, so those still have to be compiled
+in — a known and accepted limitation of a mechanism test.
+
+Switch to the test branch I named in Phase 1.
+
+- If the branch already exists (locally or on `origin`) and already has the timing commit sitting
+  directly on top of the **feature base**, skip the modification steps and proceed to the push
+  step. If it still carries an older commit that moved the `#[default]` upgrade channel to `Beta`,
+  drop that part — the channel is now selected per node at launch.
+- If the branch does not exist anywhere, create it from the **feature base** (the upgrade-subsystem
+  branch named in Phase 1, e.g. `grumbach/fix/a1-upgrade-cache-resign-verify`). **Not from
+  `upstream/main` and not from the musl swap branch.** The test branch must carry the same
+  upgrade-apply code as the beta build (so the path under test is reachable on the running binary)
+  while staying glibc (so the test exercises a real glibc → musl swap). If the feature base is just
+  `upstream/main` for a given run (no separate upgrade changes under test), cutting from
+  `upstream/main` is correct — confirm with me.
+
+Then apply these changes:
+
+* Compress the upgrade check interval from 1 hour to 20 minutes. The interval is held in hours as
+  a `u64`, so it cannot express 20 minutes as a fraction — convert the field to minutes:
+  - Change the `check_interval_hours` field in `UpgradeConfig` (`src/config.rs`) to
+    `check_interval_minutes` (type `u64`).
+  - Update `default_check_interval()` to return `20` (minutes).
+  - Update `UpgradeMonitor::new` (in `src/upgrade/monitor.rs`) to calculate
+    `check_interval_minutes * 60` instead of `check_interval_hours * 3600`.
+  - Update the serde field name and any references to `check_interval_hours` throughout the
+    codebase.
+
+* Change the staged rollout window from 24 hours to 2 hours. Update
+  `default_staged_rollout_hours()` in `src/config.rs` to return `2`.
+
+* Create a single chore commit with these changes. The commit message should indicate that these
+  are temporary timing changes for an auto-upgrade musl swap test and will be reverted after the
+  test. Let me review the commit before proceeding.
+
+* Push the change to the `origin` remote (the user's fork). Force pushing is fine if necessary.
+
+# Phase 4: Prepare the Musl Swap Branch (release workflow gnu → musl)
+
+This branch holds the *real* product change — flipping the release workflow's Linux matrix from
+`gnu` to `musl` and adding `mimalloc` as the global allocator. It will be opened as a normal PR
+after the test passes; it is not throwaway. The fake beta branch (Phase 5) is cut from this
+branch.
+
+Switch to the musl swap branch I named in Phase 1.
+
+- If the branch already exists (locally or on `origin`) and already contains the workflow change
+  and the mimalloc commit on top of the **feature base**, skip the modification and commit steps
+  and proceed straight to the push step (which is a no-op if `origin` is already up to date).
+- If the branch does not exist anywhere, create it from the **feature base** (the same branch the
+  test branch is cut from) — **not from `upstream/main`** when a separate feature base is in play.
+  The musl swap branch and the test branch must share the same upgrade-apply code.
+
+If creating from scratch, apply two commits:
+
+1. Modify `.github/workflows/release.yml` to build musl instead of glibc on Linux. In the build
+   matrix:
+   - Change the `x86_64-unknown-linux-gnu` row's target to `x86_64-unknown-linux-musl` and add
+     `cross: true`.
+   - Change the `aarch64-unknown-linux-gnu` row's target to `aarch64-unknown-linux-musl` (it
+     already has `cross: true`).
+   - **Do not change `friendly_name`, `binary`, or `archive`** — asset filenames must remain
+     `ant-node-cli-linux-{arm64,x64}.tar.gz` so the existing substring matcher on running nodes
+     still finds them. The contents change; the names do not.
+
+2. Add `mimalloc = "0.1"` to `[dependencies]` in `Cargo.toml`. Add `#[global_allocator] static
+   GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;` to `src/bin/ant-node/main.rs` and
+   `src/bin/ant-devnet/main.rs`.
+
+Two separate commits with clear messages (these will eventually be on the PR). Let me review
+before pushing.
+
+Push the musl swap branch to `origin`.
+
+# Phase 5: Create the Fake Beta Branch (version bump only)
+
+Cut `BRANCH_NAME` from the **musl swap branch** (Phase 4), **not from the test branch**. The beta
+build must not carry the timing tweak — that change only belongs on initial nodes. This branch's
+tag triggers the release. It is thrown away after the test.
+
+Follow these steps:
+
+* Switch to the musl swap branch from Phase 4 and confirm you're on it.
+* Create a new branch `BRANCH_NAME` from it.
+* Update the `version` field in `Cargo.toml` to the value of `BETA_VERSION`.
+* Commit with the title `chore(release): fake beta release BETA_VERSION` and a body noting it's a
+  fake beta release for testing the glibc → musl auto-upgrade swap.
+
+Allow me to review the commit, and once I approve, proceed to Phase 6.
+
+# Phase 6: Publish to Upstream and Verify
+
+Now publish to upstream and run the verification.
+
+Follow these steps:
+
+* Push the `BRANCH_NAME` branch to `upstream`.
+* Push the `TAG_NAME` tag to `upstream`. This triggers the release workflow on
+  `WithAutonomi/ant-node` and produces the real test pre-release.
+
+After pushing, print a reminder of the test plan:
+
+**Rollback safety check (do before deploying any cohort):**
+- Read `src/upgrade/apply.rs` and identify whether failed-upgrade rollback is implemented (e.g.
+  does it keep the previous binary and restore it on spawn failure?). If rollback is absent, keep
+  the cohort small enough to recover manually if a node fails to restart post-swap.
+
+**Single-host smoke (run first):**
+- On one glibc Ubuntu host, deploy a node from the test branch (glibc binary), started with
+  `--upgrade-channel beta` (or `ANT_UPGRADE_CHANNEL=beta`). Confirm the channel is actually set
+  before waiting — a node left on the default stable channel will correctly ignore the beta release
+  and the wait will look like a failure.
+- Wait for the upgrade interval (~20 min) and confirm the node picks up the beta release, swaps to
+  the musl binary, restarts, and resumes serving.
+- Verify the swapped binary is musl-static:
+  ```sh
+  readelf -l <node-data-dir>/ant-node | grep INTERP || echo "static musl"
+  ```
+  Glibc shows `/lib/ld-linux-{aarch64,x86-64}.so.{1,2}` after `INTERP`; musl-static shows nothing
+  and the `echo` fires.
+- Confirm `ant node status` shows the new version, `stderr.log` is empty, and the live log shows
+  DHT bootstrap re-completing and peers reconnecting.
+
+**Full glibc testnet (run after smoke passes):**
+- Deploy a testnet via the `saorsa-testnet-registry` MCP using nodes built from the test branch —
+  all nodes glibc, all started on the beta channel.
+- Wait for the upgrade interval. Nodes should upgrade themselves over the 2-hour staged-rollout
+  window.
+- Verify a sample of nodes with the `readelf` check above.
+
+**Cleanup after the test:**
+- Revert the Phase 3 commit on the test branch and force-push to `origin`.
+- Delete `BRANCH_NAME` locally and from `upstream`.
+- Delete `TAG_NAME` locally and from `upstream`.
+- Delete the pre-release on `WithAutonomi/ant-node`
+  (`gh release delete TAG_NAME --repo WithAutonomi/ant-node --yes`).
+- **Do not delete the musl swap branch** — open it as a PR if the test passed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -432,8 +432,7 @@ jobs:
 
             ### Auto-Upgrade
 
-            Running nodes automatically detect and upgrade to this version
-            within a 24-hour staged rollout window.
+            ${{ needs.validate.outputs.is_prerelease == 'true' && 'This is a pre-release, so it is not installed by nodes on the default `stable` channel. Only `-beta.N` releases are installed automatically, and only by nodes started with `--upgrade-channel beta` (or `ANT_UPGRADE_CHANNEL=beta`). Release candidates (`-rc.N`) are not installed automatically on any channel.' || 'Running nodes automatically detect and upgrade to this version within a 24-hour staged rollout window.' }}
           files: |
             release/ant-node-cli-*.tar.gz
             release/ant-node-cli-*.zip
@@ -441,5 +440,9 @@ jobs:
             release/SHA256SUMS.txt
           draft: false
           prerelease: ${{ needs.validate.outputs.is_prerelease }}
+          # Never promote a pre-release (-beta.N, -rc.N, -alpha.N) to "Latest".
+          # GitHub already refuses to mark a prerelease as latest, but setting this
+          # explicitly keeps the guarantee independent of action defaults.
+          make_latest: ${{ needs.validate.outputs.is_prerelease != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -224,6 +224,9 @@ proptest-regressions/
 .cargo/
 
 # Claude/AI assistant files
-.claude/
+# Ignore everything under .claude/ (plans, local state) except the shared
+# slash-commands, which are version-controlled so the team runs the same ones.
+.claude/*
+!.claude/commands/
 .cache/
 /devnet-manifest.json

--- a/docs/adr/ADR-0010-beta-upgrade-channel-semantics.md
+++ b/docs/adr/ADR-0010-beta-upgrade-channel-semantics.md
@@ -1,0 +1,114 @@
+# ADR-0010: Restrict the beta upgrade channel to `-beta.*` pre-releases
+
+- **Status:** Proposed
+- **Date:** 2026-08-18
+- **Decision owners:** @jacderida
+- **Reviewers:** @dirvine
+- **Supersedes:** none
+- **Superseded by:** none
+- **Related:** Linear V2-1010, V2-1011, V2-1012; `src/upgrade/monitor.rs`
+
+## Context
+
+Nodes auto-upgrade by polling the GitHub releases list for `WithAutonomi/ant-node` and selecting the
+highest-versioned release that matches their configured channel and carries both a platform binary
+and its `.sig`. GitHub's own `prerelease` / `latest` flags are ignored; selection is driven purely by
+semver on the tag.
+
+Two channels exist: `stable` (the default) and `beta`, chosen per node with `--upgrade-channel` or
+`ANT_UPGRADE_CHANNEL`. Their filters were:
+
+- `Stable` — accept a version only if it has no pre-release component.
+- `Beta` — accept everything.
+
+The weekly release train publishes `vX.Y.Z-rc.N` as a GitHub prerelease on the Tuesday cut, *before*
+the release gates have returned a verdict. "Beta accepts everything" therefore had two consequences
+that only become visible once a beta channel has real users:
+
+1. **The upgrade mechanism bypassed the release gates.** Every beta node would install the rc the
+   moment it was published, which is the precise window in which the build is not yet known to be
+   good. The gate process cannot be a control if the fleet installs the artefact before it runs.
+2. **Beta soaks could not hold.** Semver orders pre-release identifiers lexically, so
+   `0.17.0-beta.1 < 0.17.0-rc.1 < 0.17.0`. A node deliberately soaking `0.17.0-beta.1` would see the
+   *next* cut's `-rc.1` as an upgrade and abandon the soak build for un-gated code.
+
+The fix had to land before the first `v*-beta.N` tag was ever published, so that any node opting into
+beta has correct semantics from its first poll. There is no way to retrofit semantics onto nodes that
+have already shipped with the permissive rule.
+
+## Decision Drivers
+
+- The release gate must be the only thing that promotes code to the fleet; no channel may route
+  around it.
+- A soak is only meaningful if the build under soak is not silently replaced.
+- The rule is applied in two code paths and must not be able to drift between them.
+- Whatever is chosen becomes the compatibility contract for community beta nodes on day one.
+
+## Considered Options
+
+1. **Keep `Beta => true`.** No work. Retains both problems above; not viable once beta has users.
+2. **Beta accepts finals plus pre-releases whose first identifier is exactly `beta`.** Everything
+   else, `rc.*` included, is rejected on both channels.
+3. **Add a third `rc` channel** so release candidates have a home and beta excludes them.
+
+## Decision
+
+We will adopt option 2. A version is eligible for a channel iff:
+
+- its pre-release component is empty (a final release) — eligible on **both** channels; or
+- its first dot-separated pre-release identifier is exactly `beta` (`0.17.0-beta.1`, `0.17.0-beta`)
+  — eligible on **beta only**.
+
+Every other pre-release suffix — `rc.*`, `alpha.*`, and anything added later — is rejected on every
+channel. Matching is on the exact first identifier rather than a prefix, so `betax.1` does not
+qualify.
+
+The rule is defined once, as a free function in `src/upgrade/monitor.rs`, and used by both the
+selection path (`select_upgrade_from_releases`, which is what `check_for_updates` actually calls) and
+the public `UpgradeMonitor::version_matches_channel`.
+
+Option 3 is deliberately deferred rather than rejected: nothing here prevents adding an `rc` channel
+later, and the exact-identifier rule means doing so is an additive change.
+
+## Consequences
+
+### Positive
+
+- A release candidate cannot reach any node through the upgrade mechanism, so publishing the Tuesday
+  cut no longer races the gate verdict.
+- A beta node holds its soak build until a higher `-beta.N` or a final release appears.
+- The rule exists in one place, so the selection path and the predicate cannot diverge.
+- The `stable` channel is unchanged, so the production fleet is unaffected.
+
+### Negative / Trade-offs
+
+- **No channel installs release candidates any more.** Internal rc soaking, if wanted, must be done
+  by deploying the binary directly or by introducing the `rc` channel from option 3. This is a real
+  capability reduction and is the main thing a reviewer should weigh.
+- Any future pre-release suffix is rejected by default. That is the safe direction, but it means a
+  new suffix requires a deliberate code change rather than working implicitly.
+
+### Neutral / Operational
+
+- A node already running an rc under the old rule stays there until a higher eligible version is
+  published; nothing forces it off.
+- Asset naming, signature verification, and staged rollout are untouched.
+- The releases page keeps its `prerelease` flag on beta tags, and the release workflow now sets
+  `make_latest` explicitly so a pre-release can never be promoted to "Latest".
+
+## Validation
+
+- Unit tests in `src/upgrade/monitor.rs` cover: stable rejecting `-beta.N` and `-rc.N`; beta
+  accepting `-beta.N` and finals while rejecting `-rc.N`, `-alpha.N` and `-betax.N`; selection over a
+  mixed list (`0.16.0`, `0.17.0-beta.1`, `0.17.0-rc.1`) resolving to `0.16.0` on stable and
+  `0.17.0-beta.1` on beta; and the ship-and-promote-same-day case hopping from `0.16.0-beta.1`
+  straight to `0.17.0-beta.1`.
+- End-to-end validation is tracked separately as V2-1012: a dev testnet where the cohort pulls a fake
+  `-beta.N` release and demonstrably ignores a real rc published in the same window.
+- Review trigger: revisit this ADR if a new pre-release suffix is introduced, if internal rc soaking
+  becomes a requirement (option 3), or if channel selection stops being semver-on-tag.
+
+## Notes for AI-assisted work
+
+AI tools may help draft this ADR, but **must not mark it Accepted without human review**. Accepted
+ADRs are immutable: create a new superseding ADR rather than editing an Accepted ADR.

--- a/src/upgrade/monitor.rs
+++ b/src/upgrade/monitor.rs
@@ -175,7 +175,11 @@ impl UpgradeMonitor {
 
     /// Check if version matches the configured channel.
     ///
-    /// See [`version_matches_channel`] for the rule.
+    /// - Stable: only final releases, i.e. no pre-release component at all.
+    /// - Beta: final releases, plus pre-releases whose first identifier is exactly `beta`
+    ///   (`0.17.0-beta.1`, `0.17.0-beta`).
+    ///
+    /// Every other pre-release suffix, `-rc.*` included, is rejected on both channels.
     #[must_use]
     pub fn version_matches_channel(&self, version: &Version) -> bool {
         version_matches_channel(version, self.channel)

--- a/src/upgrade/monitor.rs
+++ b/src/upgrade/monitor.rs
@@ -175,14 +175,10 @@ impl UpgradeMonitor {
 
     /// Check if version matches the configured channel.
     ///
-    /// - Stable channel: Only accepts versions without pre-release suffixes
-    /// - Beta channel: Accepts all versions (stable and pre-release)
+    /// See [`version_matches_channel`] for the rule.
     #[must_use]
     pub fn version_matches_channel(&self, version: &Version) -> bool {
-        match self.channel {
-            UpgradeChannel::Stable => version.pre.is_empty(),
-            UpgradeChannel::Beta => true, // Beta accepts all
-        }
+        version_matches_channel(version, self.channel)
     }
 
     /// Check GitHub for available updates.
@@ -440,10 +436,31 @@ impl UpgradeMonitor {
     }
 }
 
+/// Check whether a version is eligible for the given upgrade channel.
+///
+/// - Stable: only final releases, i.e. no pre-release component at all.
+/// - Beta: final releases, plus pre-releases whose first identifier is exactly `beta`
+///   (`0.17.0-beta.1`, `0.17.0-beta`).
+///
+/// Every other pre-release suffix is rejected on both channels. In particular `-rc.*`
+/// is not a beta candidate: release candidates are published before the release gates
+/// have given a verdict, and semver ranks `-rc` above `-beta`, so accepting them would
+/// pull beta nodes off their soak build and onto un-gated code.
+#[must_use]
+fn version_matches_channel(version: &Version, channel: UpgradeChannel) -> bool {
+    if version.pre.is_empty() {
+        return true;
+    }
+
+    match channel {
+        UpgradeChannel::Stable => false,
+        UpgradeChannel::Beta => version.pre.as_str().split('.').next() == Some("beta"),
+    }
+}
+
 /// Select the most appropriate upgrade from a list of releases.
 ///
-/// For stable channel, pre-releases are ignored.
-/// For beta channel, pre-releases are eligible.
+/// Only versions eligible for the channel are considered; see [`version_matches_channel`].
 ///
 /// Returns the newest version that matches the channel and has platform assets.
 fn select_upgrade_from_releases(
@@ -462,7 +479,7 @@ fn select_upgrade_from_releases(
             continue;
         }
 
-        if channel == UpgradeChannel::Stable && !version.pre.is_empty() {
+        if !version_matches_channel(&version, channel) {
             continue;
         }
 
@@ -657,6 +674,19 @@ mod tests {
         assert!(monitor.version_matches_channel(&stable_version));
     }
 
+    /// Test 5b: Stable rejects release candidates too
+    #[test]
+    fn test_stable_channel_filters_rc() {
+        let monitor = UpgradeMonitor::new(
+            "WithAutonomi/ant-node".to_string(),
+            UpgradeChannel::Stable,
+            24,
+        );
+
+        assert!(!monitor.version_matches_channel(&Version::parse("1.0.0-rc.1").unwrap()));
+        assert!(monitor.version_matches_channel(&Version::parse("1.0.0").unwrap()));
+    }
+
     /// Test 6: Channel filtering - beta includes beta
     #[test]
     fn test_beta_channel_accepts_beta() {
@@ -668,6 +698,25 @@ mod tests {
 
         let beta_version = Version::parse("1.0.0-beta.1").unwrap();
         assert!(monitor.version_matches_channel(&beta_version));
+
+        let stable_version = Version::parse("1.0.0").unwrap();
+        assert!(monitor.version_matches_channel(&stable_version));
+    }
+
+    /// Test 6b: Beta rejects release candidates and any other pre-release suffix
+    #[test]
+    fn test_beta_channel_rejects_rc() {
+        let monitor = UpgradeMonitor::new(
+            "WithAutonomi/ant-node".to_string(),
+            UpgradeChannel::Beta,
+            24,
+        );
+
+        assert!(!monitor.version_matches_channel(&Version::parse("1.0.0-rc.1").unwrap()));
+        assert!(!monitor.version_matches_channel(&Version::parse("1.0.0-alpha.1").unwrap()));
+        // Only an exact `beta` identifier qualifies, not a prefix match.
+        assert!(!monitor.version_matches_channel(&Version::parse("1.0.0-betax.1").unwrap()));
+        assert!(monitor.version_matches_channel(&Version::parse("1.0.0-beta").unwrap()));
     }
 
     /// Test 7: Parse GitHub release response
@@ -1068,5 +1117,65 @@ mod tests {
             select_upgrade_from_releases(&releases, &current, UpgradeChannel::Beta).unwrap();
         assert_eq!(upgrade.version, Version::parse("1.2.0-beta.1").unwrap());
         assert!(upgrade.download_url.contains("beta"));
+    }
+
+    /// Build a release fixture carrying the platform binary and its signature, so that
+    /// `select_upgrade_from_releases` does not skip it for missing assets.
+    fn release_with_assets(tag: &str) -> GitHubRelease {
+        let arch = std::env::consts::ARCH;
+        let os = std::env::consts::OS;
+        #[cfg(windows)]
+        let bin_name = format!("ant-node-{arch}-{os}.exe");
+        #[cfg(not(windows))]
+        let bin_name = format!("ant-node-{arch}-{os}");
+
+        GitHubRelease {
+            tag_name: tag.to_string(),
+            name: tag.to_string(),
+            body: format!("notes for {tag}"),
+            prerelease: tag.contains('-'),
+            assets: vec![
+                Asset {
+                    name: bin_name.clone(),
+                    browser_download_url: format!("https://example.com/{tag}"),
+                },
+                Asset {
+                    name: format!("{bin_name}.sig"),
+                    browser_download_url: format!("https://example.com/{tag}.sig"),
+                },
+            ],
+        }
+    }
+
+    /// Mixed release list: stable takes the final, beta takes the beta, neither takes the rc.
+    #[test]
+    fn test_select_upgrade_never_picks_rc() {
+        let current = Version::parse("0.15.0").unwrap();
+        let releases = vec![
+            release_with_assets("v0.16.0"),
+            release_with_assets("v0.17.0-beta.1"),
+            release_with_assets("v0.17.0-rc.1"),
+        ];
+
+        let stable =
+            select_upgrade_from_releases(&releases, &current, UpgradeChannel::Stable).unwrap();
+        assert_eq!(stable.version, Version::parse("0.16.0").unwrap());
+
+        let beta = select_upgrade_from_releases(&releases, &current, UpgradeChannel::Beta).unwrap();
+        assert_eq!(beta.version, Version::parse("0.17.0-beta.1").unwrap());
+    }
+
+    /// Ship-and-promote on the same day: a node soaking `0.16.0-beta.1` sees both the promoted
+    /// `0.16.0` and the next cut `0.17.0-beta.1`, and hops straight to the new beta.
+    #[test]
+    fn test_select_upgrade_beta_ship_and_promote_same_day() {
+        let current = Version::parse("0.16.0-beta.1").unwrap();
+        let releases = vec![
+            release_with_assets("v0.16.0"),
+            release_with_assets("v0.17.0-beta.1"),
+        ];
+
+        let beta = select_upgrade_from_releases(&releases, &current, UpgradeChannel::Beta).unwrap();
+        assert_eq!(beta.version, Version::parse("0.17.0-beta.1").unwrap());
     }
 }


### PR DESCRIPTION
## Linear issue

V2-1010 and V2-1011 — https://linear.app/autonominetwork/issue/V2-1010/ant-node-restrict-the-beta-upgrade-channel-to-beta-pre-releases

## Risk tier

- [ ] T0 — docs / tooling / CI / pure UX-output. Repo CI only.
- [ ] T1 — client-only, no network-facing behavior change. CI + prod compat smoke.
- [x] T2 — node/client logic with behavioral surface, no protocol/format/economics change. Dev testnet + ADR.
- [ ] T3 — protocol / storage format / payments / routing. T2 evidence + adversarial testing.

Tier proposed as T2 because it changes the upgrade mechanism — which builds a node will install.
No protocol, storage or economics surface is touched.

## Compatibility

- Wire: none.
- Storage: none.
- API: no signature changes. `UpgradeMonitor::version_matches_channel` is still `pub` with the same
  signature, but on the `Beta` channel it now returns `false` for pre-releases whose first identifier
  is not exactly `beta` (previously it returned `true` for every version). `UpgradeConfig` and the
  `--upgrade-channel` / `ANT_UPGRADE_CHANNEL` surface are unchanged.

## Semver impact

- [ ] breaking
- [x] feature
- [ ] fix

## Test evidence

**Dev testnet — DEV-01, 2026-08-18: PASS.** Full results on
[V2-1012](https://linear.app/autonominetwork/issue/V2-1012/testnet-run-beta-channel-isolation-fake-beta-pulled-real-rc-ignored).

107 services (100 WAN nodes across 20 DO VMs in lon1/nyc1, plus 6 bootstraps and genesis), built
from this branch, running `--upgrade-channel beta` explicitly rather than a patched default.
Fake prerelease `v0.17.11-beta.1` published 14:20:30Z; start version `0.17.1`.

| Check | Result |
|---|---|
| Services that detected and scheduled the upgrade | 107 / 107 |
| VMs with binary at `0.17.11-beta.1` | 27 / 27 |
| Services running after upgrade | 107 / 107 |
| Processes executing the current binary inode | 107 / 107 |
| ERROR/WARN on `ant_node::upgrade*` | 0 |
| Services left pending | 0 |

Applies spread evenly across the compressed 2h staged window (15:25:02Z–17:23:44Z; per-15-min
buckets 4 / 14 / 12 / 14 / 13 / 9 / 18 / 17 / 6). Co-located services sharing
`/usr/local/bin/ant-node` handled the shared binary correctly — first writer replaces it, the rest
log `Binary already upgraded ... skipping replacement`; no contention or partial writes.

Network health held throughout: **956/956 uploads and 1130/1130 downloads succeeded**, zero
failures, with 356 operations landing inside the rollout window while the fleet was version-mixed.
Chunk stores stayed intact across the restart.

This run also exercises the release-workflow half of the change: `v0.17.11-beta.1` was built,
signed and published as a prerelease by the workflow *as modified in this PR*, and every node then
selected, downloaded and signature-verified it. That confirms end-to-end that a `v*-beta.N` tag
triggers the workflow, is flagged a prerelease, and ships a complete artifact set whose names and
`.sig` pairing satisfy `select_upgrade_from_releases`.

Scope note: this run evidences beta uptake and network health. Rejection of `-rc.*` is covered by
the unit tests below rather than by the run.

**Unit — `cargo test --lib upgrade::monitor`: 25 passed, 0 failed.** Four cases added:

| Case | Expectation |
|---|---|
| `test_stable_channel_filters_rc` | stable rejects `-rc.N` |
| `test_beta_channel_rejects_rc` | beta rejects `-rc.1`, `-alpha.1`, `-betax.1`; accepts bare `-beta` |
| `test_select_upgrade_never_picks_rc` | over `0.16.0` / `0.17.0-beta.1` / `0.17.0-rc.1`: stable → `0.16.0`, beta → `0.17.0-beta.1` |
| `test_select_upgrade_beta_ship_and_promote_same_day` | from `0.16.0-beta.1`, with `0.16.0` and `0.17.0-beta.1` both published, beta → `0.17.0-beta.1` |

Existing coverage for stable-rejects-beta and beta-accepts-beta was kept and extended.

**CI — green.** Clippy, Format, Documentation, Builds and Tests on all three platforms, ADR
validation, `linear-link` and `pr-template` all pass. Security Audit fails on RUSTSEC-2026-0258,
which also fails on `main` at the base commit `3cda0dd`; this PR changes no dependencies.

## New dependency

none

## ADR

https://github.com/jacderida/ant-node/blob/feat/beta-release-channel/docs/adr/ADR-0010-beta-upgrade-channel-semantics.md

(ADR-0010, Status: Proposed — acceptance is a human decision.)

## Mitigation / rollback

Revert `cb40bca` to restore `Beta => true`; the other commits are workflow, docs and tooling and are
independently revertible. Blast radius is limited to nodes explicitly opted into the beta channel —
the `stable` default is untouched, so the production fleet behaves identically before and after.

---

## Summary

- **Beta channel semantics (V2-1010).** The beta channel accepted every pre-release, so beta nodes
  would install `vX.Y.Z-rc.N` as soon as the Tuesday cut published it — before the release gates
  returned a verdict — and because semver ranks `-rc` above `-beta`, a node soaking a beta build
  would abandon it for the next cut's rc. Beta now accepts a version only when its pre-release
  component is empty or its first identifier is exactly `beta`. The rule previously existed in two
  places that could drift; it is now one free function used by both.

- **Release workflow (V2-1011).** Audited against `v*-beta.N` and found already correct — the `v*`
  glob matches, the version regex accepts it, `beta` was already in the prerelease test, and
  crates.io publish is skipped for any prerelease. Two implicit things made explicit: `make_latest`
  is now passed rather than relying on GitHub's implicit rule, and the release body's auto-upgrade
  claim is conditional, since only beta nodes install `-beta.N` and nothing installs `-rc.N`.

- **Test-prep commands (V2-1011).** Both `prepare-for-*-test` commands built a fake `-rc.1` release
  and flipped the compiled-in default channel to Beta — a combination this change makes inert. They
  now drive a `-beta.1` release with nodes opting in via `--upgrade-channel beta`, which is what a
  real community beta node does. These files were previously untracked; `.gitignore` is narrowed to
  `.claude/*` with an exception for `.claude/commands/` so they are reviewable.

