### PR TITLE
chore(deps): bump h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,9 +2818,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Linear issue

- https://linear.app/autonominetwork/issue/V2-1023

## Risk tier

- [ ] T0 — docs / tooling / CI / pure UX-output. Repo CI only.
- [x] T1 — client-only, no network-facing behavior change. CI + prod compat smoke.
- [ ] T2 — node/client logic with behavioral surface, no protocol/format/economics change. Dev testnet + ADR.
- [ ] T3 — protocol / storage format / payments / routing. T2 evidence + adversarial testing.

Proposed rather than asserted. Nothing here alters node behaviour, the wire protocol, stored formats, economics or the upgrade mechanism, which is what T1 asks, and the tier list has no row for "transitive dependency of the node binary". The one argument for T2 is that `h2` ships inside the node, so its frame handling is technically node-resident behaviour; against that, no path in this build reaches it except UPnP, and the patch only adds a limit that was missing. If a reviewer prefers T2, I have no objection.

## Compatibility

- Wire: none. The node's own protocol is QUIC, and `h2` is HTTP/2 inside a dependency.
- Storage: none.
- API: none. No manifest and no source file is touched; this is the lockfile only.

## Semver impact

- [ ] breaking
- [ ] feature
- [x] fix

## Test evidence

Run on this branch, a single commit on top of `main` at `99d1136`.

- `cargo audit`: no vulnerabilities. Before this change it reported RUSTSEC-2026-0258; after it, only the eight warnings already allowed on `main`, unchanged.
- `cargo metadata --locked`: accepted, and cargo does not want to rewrite the lockfile.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo doc --all-features --no-deps` with `RUSTDOCFLAGS="-D warnings"`: clean.
- `cargo test --lib --features test-utils`: 929 passed, 0 failed.
- `cargo test --lib --no-default-features`: 929 passed, 0 failed.
- `cargo test --test e2e --features test-utils -- --test-threads=1`: 96 passed, 0 failed, 3 ignored. The three ignored are the pre-existing `live_testnet` cases awaiting a rewrite after the saorsa-core 0.16 DHT API change; they are ignored on `main` too.
- `cargo test --test poc_commitment_audit_attacks --features test-utils`: 19 passed, 0 failed.
- `cargo test --test poc_audit_handler_live --features test-utils`: 16 passed, 0 failed.
- `cargo test --test poc_bootstrap_stall --features test-utils`: 3 passed, 0 failed.
- `cargo build --release --no-default-features`: clean.

On the lockfile edit itself:

- The new checksum is the real one: hashing the cached `h2-0.4.16.crate` gives `a9f37a95…`, and the crates.io sparse index reports the same checksum for a non-yanked 0.4.16.
- The published manifests for 0.4.15 and 0.4.16 differ only in the version field. Same dependencies, same features, same edition, same MSRV (1.63), so the lockfile's dependency list for the entry is still correct.
- Three cargo versions (1.88, 1.94, 1.95) accept the lock under `--locked`, and `cargo update -p h2 --precise 0.4.16 --dry-run` reports nothing to change on each. The lock is stable, not merely parseable.
- `cargo tree --target x86_64-pc-windows-msvc` resolves on all three, keeping the same three `windows-sys` versions `main` already has.

## New dependency

None. This is a version bump of an existing transitive dependency, `h2` 0.4.15 to 0.4.16. No entry is added or removed.

## ADR

n/a — Tier 1.

## Mitigation / rollback

Revert the commit. It touches nothing but `Cargo.lock`, so there is no migration and no stored-data or wire implication either way.

---

## What this is

`cargo audit` fails on **RUSTSEC-2026-0258**, "h2 unbounded empty DATA frames", against `h2` 0.4.15. The advisory published on 2026-08-17 and prescribes 0.4.16 or later, which is what this takes.

`h2` accepts and queues empty DATA frames without any limit. A stream that is not actively drained therefore grows memory without bound, or panics when the length overflows. The advisory rates it low severity and files it under denial of service.

## How far it actually reaches

Nothing in this repository depends on `h2` directly. It arrives through `hyper`:

```
h2 → hyper 1.10.1 → hyper-rustls / hyper-util → reqwest 0.13.4 → ant-node
                                                              → saorsa-transport → saorsa-core
                                                              → alloy-transport-http → alloy → evmlib
                  → igd-next 0.17.1 → saorsa-transport
```

That tree overstates the exposure, so, precisely:

- `reqwest` is built here without its `http2` feature (`json` and `rustls` only, default features off). Its HTTP/2 support sits behind `#[cfg(feature = "http2")]`, so the release-feed polling in `src/upgrade` and the EVM RPC calls through `alloy` negotiate HTTP/1.1 and never drive `h2`.
- The only crate that turns on `hyper`'s `http2` feature is `igd-next`, which saorsa-transport pulls in for UPnP port mapping. That client talks to whatever answers as the IGD gateway on the local network.

So the live surface is a node whose UPnP client is fed empty DATA frames by something on the LAN posing as the gateway. Small, and behind an attacker already on your network, but real, and it costs two lines to close.

## Why it is its own PR

`main` pins the vulnerable version, so this reds the Security Audit check on `main` and on every open PR the moment their CI re-runs. No feature branch caused it and none should carry the fix, since that would put an unrelated dependency change inside that branch's review. Landing it here fixes the check for everyone at once, and open branches pick it up on their next rebase.

## Why the diff is two lines and not ten

`cargo update -p h2` bumps `h2` **and** reshuffles which dependents point at `windows-sys` 0.52.0 against 0.61.2: eight further lines across `mio`, `socket2`, `rustix`, `tempfile` and `rustls-native-certs`. That is churn in the QUIC and filesystem stacks, on the Windows target, that an advisory bump has no business carrying. The `h2` entry is therefore edited on its own, and the checks above are there to show the result is a lockfile cargo itself agrees with.

## Residual risk

0.4.16 carries more than the DATA-frame limit: flow-control release, trailer wakeups, stream-reset handling, push accounting, header and trailer validation, write-zero handling, HPACK work and reduced lock contention. The one behaviour that tightens rather than fixes is the rejection of connection-specific trailer fields, which HTTP/2 requires anyway. Nothing here calls `h2` directly, so the regression risk lands on `igd-next`'s UPnP calls, which fail soft already.

`RUSTSEC-2026-0253` on `lru` 0.16.4 is still an allowed warning after this change, as it was before. Clearing it needs a manifest-level `lru` upgrade, which is a different PR.
