### PR TITLE
chore(release): promote rc-2026.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.18.0"
+version = "0.18.1-rc.1"
 dependencies = [
  "alloy",
  "ant-protocol",
@@ -862,9 +862,8 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "2.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e081248778491b063a97754d4ea6a5227bb03740f8de1b546bbb4b16e60c4c99"
+version = "2.3.5-rc.1"
+source = "git+https://github.com/WithAutonomi/ant-protocol?branch=rc-2026.9.1#a0c94dcf4b8949218823cdbbf7fd17a00ec772a8"
 dependencies = [
  "blake3",
  "bytes",
@@ -4885,9 +4884,8 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b3c5cb6c2eaeab9645a0224735651d4fb034d9f4a8882d9c283de70b4905249"
+version = "0.27.3-rc.1"
+source = "git+https://github.com/WithAutonomi/saorsa-core?branch=rc-2026.9.1#395847c7ea4d224bef15b33ec173838c5d2cfbaf"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4958,9 +4956,8 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.36.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba15b6b5dcee750fe741edd08a0719f43274f9ceee2b9c0f595225a72dd021b"
+version = "0.36.3-rc.1"
+source = "git+https://github.com/WithAutonomi/saorsa-transport?branch=rc-2026.9.1#e1e0ef316438187e7e40adf9956ea1a34951e1df"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.18.1-rc.1"
+version = "0.18.1"
 dependencies = [
  "alloy",
  "ant-protocol",
@@ -862,8 +862,9 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "2.3.5-rc.1"
-source = "git+https://github.com/WithAutonomi/ant-protocol?branch=rc-2026.9.1#a0c94dcf4b8949218823cdbbf7fd17a00ec772a8"
+version = "2.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd13dd1f51e3e9b3e871673b7d52a65054c9431b0656f4fa9589098126c3dafd"
 dependencies = [
  "blake3",
  "bytes",
@@ -4884,8 +4885,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.27.3-rc.1"
-source = "git+https://github.com/WithAutonomi/saorsa-core?branch=rc-2026.9.1#395847c7ea4d224bef15b33ec173838c5d2cfbaf"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5929d77d38c0ffb422393a2420f9d2f9ecd92deaa9859b3bfbbe58bada68e40a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4956,8 +4958,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.36.3-rc.1"
-source = "git+https://github.com/WithAutonomi/saorsa-transport?branch=rc-2026.9.1#e1e0ef316438187e7e40adf9956ea1a34951e1df"
+version = "0.36.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd4be74fa8b82e0321b338bbfbc084c66170614245660b85bb8b041ea808bc4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.18.1-rc.1"
+version = "0.18.1"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"
@@ -39,10 +39,10 @@ mimalloc = "0.1"
 # Until then, the git pin tracks the matching saorsa-core lineage
 # (the rc-2026.4.2 branch) so Cargo can unify the wire types here
 # with ant-protocol's re-exports.
-ant-protocol = { git = "https://github.com/WithAutonomi/ant-protocol", branch = "rc-2026.9.1" }
+ant-protocol = "2.3.5"
 
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
-saorsa-core = { git = "https://github.com/WithAutonomi/saorsa-core", branch = "rc-2026.9.1" }
+saorsa-core = "0.27.3"
 saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-node"
-version = "0.18.0"
+version = "0.18.1-rc.1"
 edition = "2021"
 authors = ["David Irvine <david.irvine@maidsafe.net>"]
 description = "Pure quantum-proof network node for the Autonomi decentralized network"
@@ -39,10 +39,10 @@ mimalloc = "0.1"
 # Until then, the git pin tracks the matching saorsa-core lineage
 # (the rc-2026.4.2 branch) so Cargo can unify the wire types here
 # with ant-protocol's re-exports.
-ant-protocol = "2.3.4"
+ant-protocol = { git = "https://github.com/WithAutonomi/ant-protocol", branch = "rc-2026.9.1" }
 
 # Core (provides EVERYTHING: networking, DHT, security, trust, storage)
-saorsa-core = "0.27.2"
+saorsa-core = { git = "https://github.com/WithAutonomi/saorsa-core", branch = "rc-2026.9.1" }
 saorsa-pqc = "0.5"
 
 # Payment verification - autonomi network lookup + EVM payment


### PR DESCRIPTION
Promotes `rc-2026.9.1` to release version(s): 0.18.1.

- strips `-rc.*` from `[package].version`
- rewrites internal git+branch deps to crates.io version pins
- regenerates `Cargo.lock`

Once merged, the release tag will be pushed to fire the publish workflow.